### PR TITLE
ScaledObjects CRD for kedacore/keda-olm-operator (HW2)

### DIFF
--- a/operators/kedacore_keda-olm-operator/jsonDepth.py
+++ b/operators/kedacore_keda-olm-operator/jsonDepth.py
@@ -25,18 +25,14 @@ def depth(x):
     return 0
 
 if __name__ == "__main__":
+    # Helpful source: https://www.geeksforgeeks.org/read-json-file-using-python/
     f = open('scaledobjectscrd.json')
  
     # returns JSON object as 
     # a dictionary
     data = json.load(f)
-    
-    # Iterating through the json
-    # list
     print("Depth of entire CRD:", depth(data))
     print("Breadth of entire CRD:", breadth(data))
-    # print(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"])
-    # print("Depth of openAPIV3Schema: ", depth(data["spec"]["versions"]))
     print("Depth of openAPIV3Schema: ", depth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]))
     print("Breadth of openAPIV3Schema: ", breadth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]))
     print("Depth of horizontalPodAutoscalerConfig: ", depth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"]["advanced"]["properties"]["horizontalPodAutoscalerConfig"]))

--- a/operators/kedacore_keda-olm-operator/jsonDepth.py
+++ b/operators/kedacore_keda-olm-operator/jsonDepth.py
@@ -1,0 +1,50 @@
+import json
+
+def breadth(x):
+    queue = [x]
+    curr_breadth = 0
+    while len(queue) > 0:
+        curr = queue.pop()
+        if type(curr) is dict and curr:
+            for key in curr:
+                queue.append(curr[key])
+        if type(curr) is list:
+            for item in curr:
+                queue.append(item)
+        else:
+            curr_breadth += 1
+    return curr_breadth
+
+def depth(x):
+    # Code from https://stackoverflow.com/questions/30928331/how-to-find-the-maximum-depth-of-a-python-dictionary-or-json-object
+    # Seems very similar to depth first search, but we are finding the maximum depth here
+    if type(x) is dict and x:
+        return 1 + max(depth(x[a]) for a in x)
+    if type(x) is list and x:
+        return 1 + max(depth(a) for a in x)
+    return 0
+
+if __name__ == "__main__":
+    f = open('scaledobjectscrd.json')
+ 
+    # returns JSON object as 
+    # a dictionary
+    data = json.load(f)
+    
+    # Iterating through the json
+    # list
+    print("Depth of entire CRD:", depth(data))
+    print("Breadth of entire CRD:", breadth(data))
+    # print(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"])
+    # print("Depth of openAPIV3Schema: ", depth(data["spec"]["versions"]))
+    print("Depth of openAPIV3Schema: ", depth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]))
+    print("Breadth of openAPIV3Schema: ", breadth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]))
+    print("Depth of horizontalPodAutoscalerConfig: ", depth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"]["advanced"]["properties"]["horizontalPodAutoscalerConfig"]))
+    print("Breadth of horizontalPodAutoscalerConfig: ", breadth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"]["advanced"]["properties"]["horizontalPodAutoscalerConfig"]))
+    print("Depth of restoreToOriginalReplicaCount: ", depth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"]["advanced"]["properties"]["restoreToOriginalReplicaCount"]))
+    print("Breadth of restoreToOriginalReplicaCount: ", breadth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"]["advanced"]["properties"]["restoreToOriginalReplicaCount"]))
+    print("Depth of scalingModifiers: ", depth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"]["advanced"]["properties"]["scalingModifiers"]))
+    print("Breadth of scalingModifiers: ", breadth(data["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"]["advanced"]["properties"]["scalingModifiers"]))
+
+    # Closing file
+    f.close()

--- a/operators/kedacore_keda-olm-operator/scaledobjectscrd.json
+++ b/operators/kedacore_keda-olm-operator/scaledobjectscrd.json
@@ -1,0 +1,520 @@
+{
+    "apiVersion": "apiextensions.k8s.io/v1",
+    "kind": "CustomResourceDefinition",
+    "metadata": {
+        "annotations": {
+            "controller-gen.kubebuilder.io/version": "v0.13.0",
+            "operatorframework.io/installed-alongside-344b0b4e6e81a922": "operators/keda.v2.12.1"
+        },
+        "creationTimestamp": "2024-02-05T06:07:44Z",
+        "generation": 1,
+        "labels": {
+            "app.kubernetes.io/part-of": "keda-operator",
+            "app.kubernetes.io/version": "2.12.1",
+            "olm.managed": "true",
+            "operators.coreos.com/keda.operators": ""
+        },
+        "name": "scaledobjects.keda.sh",
+        "resourceVersion": "3217300",
+        "uid": "f6d53cc1-1d66-43c4-ae9b-4d5f86597886"
+    },
+    "spec": {
+        "conversion": {
+            "strategy": "None"
+        },
+        "group": "keda.sh",
+        "names": {
+            "kind": "ScaledObject",
+            "listKind": "ScaledObjectList",
+            "plural": "scaledobjects",
+            "shortNames": [
+                "so"
+            ],
+            "singular": "scaledobject"
+        },
+        "scope": "Namespaced",
+        "versions": [
+            {
+                "additionalPrinterColumns": [
+                    {
+                        "jsonPath": ".status.scaleTargetKind",
+                        "name": "ScaleTargetKind",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".spec.scaleTargetRef.name",
+                        "name": "ScaleTargetName",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".spec.minReplicaCount",
+                        "name": "Min",
+                        "type": "integer"
+                    },
+                    {
+                        "jsonPath": ".spec.maxReplicaCount",
+                        "name": "Max",
+                        "type": "integer"
+                    },
+                    {
+                        "jsonPath": ".spec.triggers[*].type",
+                        "name": "Triggers",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".spec.triggers[*].authenticationRef.name",
+                        "name": "Authentication",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".status.conditions[?(@.type==\"Ready\")].status",
+                        "name": "Ready",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".status.conditions[?(@.type==\"Active\")].status",
+                        "name": "Active",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".status.conditions[?(@.type==\"Fallback\")].status",
+                        "name": "Fallback",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".status.conditions[?(@.type==\"Paused\")].status",
+                        "name": "Paused",
+                        "type": "string"
+                    },
+                    {
+                        "jsonPath": ".metadata.creationTimestamp",
+                        "name": "Age",
+                        "type": "date"
+                    }
+                ],
+                "name": "v1alpha1",
+                "schema": {
+                    "openAPIV3Schema": {
+                        "description": "ScaledObject is a specification for a ScaledObject resource",
+                        "properties": {
+                            "apiVersion": {
+                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                "type": "string"
+                            },
+                            "kind": {
+                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                            },
+                            "metadata": {
+                                "type": "object"
+                            },
+                            "spec": {
+                                "description": "ScaledObjectSpec is the spec for a ScaledObject resource",
+                                "properties": {
+                                    "advanced": {
+                                        "description": "AdvancedConfig specifies advance scaling options",
+                                        "properties": {
+                                            "horizontalPodAutoscalerConfig": {
+                                                "description": "HorizontalPodAutoscalerConfig specifies horizontal scale config",
+                                                "properties": {
+                                                    "behavior": {
+                                                        "description": "HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).",
+                                                        "properties": {
+                                                            "scaleDown": {
+                                                                "description": "scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).",
+                                                                "properties": {
+                                                                    "policies": {
+                                                                        "description": "policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
+                                                                        "items": {
+                                                                            "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                                                                            "properties": {
+                                                                                "periodSeconds": {
+                                                                                    "description": "periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                                                                    "format": "int32",
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "type": {
+                                                                                    "description": "type is used to specify the scaling policy.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "value contains the amount of change which is permitted by the policy. It must be greater than zero",
+                                                                                    "format": "int32",
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "periodSeconds",
+                                                                                "type",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array",
+                                                                        "x-kubernetes-list-type": "atomic"
+                                                                    },
+                                                                    "selectPolicy": {
+                                                                        "description": "selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "stabilizationWindowSeconds": {
+                                                                        "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                                                                        "format": "int32",
+                                                                        "maximum": 3600,
+                                                                        "minimum": 0,
+                                                                        "type": "integer"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            },
+                                                            "scaleUp": {
+                                                                "description": "scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of: * increase no more than 4 pods per 60 seconds * double the number of pods per 60 seconds No stabilization is used.",
+                                                                "properties": {
+                                                                    "policies": {
+                                                                        "description": "policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
+                                                                        "items": {
+                                                                            "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                                                                            "properties": {
+                                                                                "periodSeconds": {
+                                                                                    "description": "periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                                                                    "format": "int32",
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "type": {
+                                                                                    "description": "type is used to specify the scaling policy.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "value contains the amount of change which is permitted by the policy. It must be greater than zero",
+                                                                                    "format": "int32",
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "periodSeconds",
+                                                                                "type",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array",
+                                                                        "x-kubernetes-list-type": "atomic"
+                                                                    },
+                                                                    "selectPolicy": {
+                                                                        "description": "selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "stabilizationWindowSeconds": {
+                                                                        "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                                                                        "format": "int32",
+                                                                        "maximum": 3600,
+                                                                        "minimum": 0,
+                                                                        "type": "integer"
+                                                                    }
+                                                                },
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "restoreToOriginalReplicaCount": {
+                                                "type": "boolean"
+                                            },
+                                            "scalingModifiers": {
+                                                "description": "ScalingModifiers describes advanced scaling logic options like formula",
+                                                "properties": {
+                                                    "activationTarget": {
+                                                        "type": "string"
+                                                    },
+                                                    "formula": {
+                                                        "type": "string"
+                                                    },
+                                                    "metricType": {
+                                                        "description": "MetricTargetType specifies the type of metric being targeted, and should be either \"Value\", \"AverageValue\", or \"Utilization\"",
+                                                        "type": "string"
+                                                    },
+                                                    "target": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    },
+                                    "cooldownPeriod": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "fallback": {
+                                        "description": "Fallback is the spec for fallback options",
+                                        "properties": {
+                                            "failureThreshold": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                            },
+                                            "replicas": {
+                                                "format": "int32",
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "failureThreshold",
+                                            "replicas"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "idleReplicaCount": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "maxReplicaCount": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "minReplicaCount": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "pollingInterval": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "scaleTargetRef": {
+                                        "description": "ScaleTarget holds the reference to the scale target Object",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "type": "string"
+                                            },
+                                            "envSourceContainerName": {
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "triggers": {
+                                        "items": {
+                                            "description": "ScaleTriggers reference the scaler that will be used",
+                                            "properties": {
+                                                "authenticationRef": {
+                                                    "description": "AuthenticationRef points to the TriggerAuthentication or ClusterTriggerAuthentication object that is used to authenticate the scaler with the environment",
+                                                    "properties": {
+                                                        "kind": {
+                                                            "description": "Kind of the resource being referred to. Defaults to TriggerAuthentication.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ],
+                                                    "type": "object"
+                                                },
+                                                "metadata": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "metricType": {
+                                                    "description": "MetricTargetType specifies the type of metric being targeted, and should be either \"Value\", \"AverageValue\", or \"Utilization\"",
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "useCachedMetrics": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "metadata",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "scaleTargetRef",
+                                    "triggers"
+                                ],
+                                "type": "object"
+                            },
+                            "status": {
+                                "description": "ScaledObjectStatus is the status for a ScaledObject resource",
+                                "properties": {
+                                    "compositeScalerName": {
+                                        "type": "string"
+                                    },
+                                    "conditions": {
+                                        "description": "Conditions an array representation to store multiple Conditions",
+                                        "items": {
+                                            "description": "Condition to store the condition state",
+                                            "properties": {
+                                                "message": {
+                                                    "description": "A human readable message indicating details about the transition.",
+                                                    "type": "string"
+                                                },
+                                                "reason": {
+                                                    "description": "The reason for the condition's last transition.",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "Status of the condition, one of True, False, Unknown.",
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "description": "Type of condition",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "status",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "externalMetricNames": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "health": {
+                                        "additionalProperties": {
+                                            "description": "HealthStatus is the status for a ScaledObject's health",
+                                            "properties": {
+                                                "numberOfFailures": {
+                                                    "format": "int32",
+                                                    "type": "integer"
+                                                },
+                                                "status": {
+                                                    "description": "HealthStatusType is an indication of whether the health status is happy or failing",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "object"
+                                    },
+                                    "hpaName": {
+                                        "type": "string"
+                                    },
+                                    "lastActiveTime": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "originalReplicaCount": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "pausedReplicaCount": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                    },
+                                    "resourceMetricNames": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "scaleTargetGVKR": {
+                                        "description": "GroupVersionKindResource provides unified structure for schema.GroupVersionKind and Resource",
+                                        "properties": {
+                                            "group": {
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "type": "string"
+                                            },
+                                            "resource": {
+                                                "type": "string"
+                                            },
+                                            "version": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "group",
+                                            "kind",
+                                            "resource",
+                                            "version"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "scaleTargetKind": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        },
+                        "required": [
+                            "spec"
+                        ],
+                        "type": "object"
+                    }
+                },
+                "served": true,
+                "storage": true,
+                "subresources": {
+                    "status": {}
+                }
+            }
+        ]
+    },
+    "status": {
+        "acceptedNames": {
+            "kind": "ScaledObject",
+            "listKind": "ScaledObjectList",
+            "plural": "scaledobjects",
+            "shortNames": [
+                "so"
+            ],
+            "singular": "scaledobject"
+        },
+        "conditions": [
+            {
+                "lastTransitionTime": "2024-02-05T06:07:44Z",
+                "message": "no conflicts found",
+                "reason": "NoConflicts",
+                "status": "True",
+                "type": "NamesAccepted"
+            },
+            {
+                "lastTransitionTime": "2024-02-05T06:07:44Z",
+                "message": "the initial names have been accepted",
+                "reason": "InitialNamesAccepted",
+                "status": "True",
+                "type": "Established"
+            }
+        ],
+        "storedVersions": [
+            "v1alpha1"
+        ]
+    }
+}

--- a/operators/kedacore_keda-olm-operator/scaledobjectscrd.yaml
+++ b/operators/kedacore_keda-olm-operator/scaledobjectscrd.yaml
@@ -1,0 +1,428 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  creationTimestamp: "2024-02-05T06:07:44Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/part-of: keda-operator
+    app.kubernetes.io/version: 2.12.0
+  name: scaledobjects.keda.sh
+  resourceVersion: "1125009"
+  uid: f6d53cc1-1d66-43c4-ae9b-4d5f86597886
+spec:
+  conversion:
+    strategy: None
+  group: keda.sh
+  names:
+    kind: ScaledObject
+    listKind: ScaledObjectList
+    plural: scaledobjects
+    shortNames:
+    - so
+    singular: scaledobject
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.scaleTargetKind
+      name: ScaleTargetKind
+      type: string
+    - jsonPath: .spec.scaleTargetRef.name
+      name: ScaleTargetName
+      type: string
+    - jsonPath: .spec.minReplicaCount
+      name: Min
+      type: integer
+    - jsonPath: .spec.maxReplicaCount
+      name: Max
+      type: integer
+    - jsonPath: .spec.triggers[*].type
+      name: Triggers
+      type: string
+    - jsonPath: .spec.triggers[*].authenticationRef.name
+      name: Authentication
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Active")].status
+      name: Active
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Fallback")].status
+      name: Fallback
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScaledObject is a specification for a ScaledObject resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScaledObjectSpec is the spec for a ScaledObject resource
+            properties:
+              advanced:
+                description: AdvancedConfig specifies advance scaling options
+                properties:
+                  horizontalPodAutoscalerConfig:
+                    description: HorizontalPodAutoscalerConfig specifies horizontal
+                      scale config
+                    properties:
+                      behavior:
+                        description: HorizontalPodAutoscalerBehavior configures the
+                          scaling behavior of the target in both Up and Down directions
+                          (scaleUp and scaleDown fields respectively).
+                        properties:
+                          scaleDown:
+                            description: scaleDown is scaling policy for scaling Down.
+                              If not set, the default value is to allow to scale down
+                              to minReplicas pods, with a 300 second stabilization
+                              window (i.e., the highest recommendation for the last
+                              300sec is used).
+                            properties:
+                              policies:
+                                description: policies is a list of potential scaling
+                                  polices which can be used during scaling. At least
+                                  one policy must be specified, otherwise the HPAScalingRules
+                                  will be discarded as invalid
+                                items:
+                                  description: HPAScalingPolicy is a single policy
+                                    which must hold true for a specified past interval.
+                                  properties:
+                                    periodSeconds:
+                                      description: periodSeconds specifies the window
+                                        of time for which the policy should hold true.
+                                        PeriodSeconds must be greater than zero and
+                                        less than or equal to 1800 (30 min).
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      description: type is used to specify the scaling
+                                        policy.
+                                      type: string
+                                    value:
+                                      description: value contains the amount of change
+                                        which is permitted by the policy. It must
+                                        be greater than zero
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                description: selectPolicy is used to specify which
+                                  policy should be used. If not set, the default value
+                                  Max is used.
+                                type: string
+                              stabilizationWindowSeconds:
+                                description: 'stabilizationWindowSeconds is the number
+                                  of seconds for which past recommendations should
+                                  be considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than
+                                  or equal to zero and less than or equal to 3600
+                                  (one hour). If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window
+                                  is 300 seconds long).'
+                                format: int32
+                                maximum: 3600
+                                minimum: 0
+                                type: integer
+                            type: object
+                          scaleUp:
+                            description: 'scaleUp is scaling policy for scaling Up.
+                              If not set, the default value is the higher of: * increase
+                              no more than 4 pods per 60 seconds * double the number
+                              of pods per 60 seconds No stabilization is used.'
+                            properties:
+                              policies:
+                                description: policies is a list of potential scaling
+                                  polices which can be used during scaling. At least
+                                  one policy must be specified, otherwise the HPAScalingRules
+                                  will be discarded as invalid
+                                items:
+                                  description: HPAScalingPolicy is a single policy
+                                    which must hold true for a specified past interval.
+                                  properties:
+                                    periodSeconds:
+                                      description: periodSeconds specifies the window
+                                        of time for which the policy should hold true.
+                                        PeriodSeconds must be greater than zero and
+                                        less than or equal to 1800 (30 min).
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      description: type is used to specify the scaling
+                                        policy.
+                                      type: string
+                                    value:
+                                      description: value contains the amount of change
+                                        which is permitted by the policy. It must
+                                        be greater than zero
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                description: selectPolicy is used to specify which
+                                  policy should be used. If not set, the default value
+                                  Max is used.
+                                type: string
+                              stabilizationWindowSeconds:
+                                description: 'stabilizationWindowSeconds is the number
+                                  of seconds for which past recommendations should
+                                  be considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than
+                                  or equal to zero and less than or equal to 3600
+                                  (one hour). If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window
+                                  is 300 seconds long).'
+                                format: int32
+                                maximum: 3600
+                                minimum: 0
+                                type: integer
+                            type: object
+                        type: object
+                      name:
+                        type: string
+                    type: object
+                  restoreToOriginalReplicaCount:
+                    type: boolean
+                  scalingModifiers:
+                    description: ScalingModifiers describes advanced scaling logic
+                      options like formula
+                    properties:
+                      activationTarget:
+                        type: string
+                      formula:
+                        type: string
+                      metricType:
+                        description: MetricTargetType specifies the type of metric
+                          being targeted, and should be either "Value", "AverageValue",
+                          or "Utilization"
+                        type: string
+                      target:
+                        type: string
+                    type: object
+                type: object
+              cooldownPeriod:
+                format: int32
+                type: integer
+              fallback:
+                description: Fallback is the spec for fallback options
+                properties:
+                  failureThreshold:
+                    format: int32
+                    type: integer
+                  replicas:
+                    format: int32
+                    type: integer
+                required:
+                - failureThreshold
+                - replicas
+                type: object
+              idleReplicaCount:
+                format: int32
+                type: integer
+              maxReplicaCount:
+                format: int32
+                type: integer
+              minReplicaCount:
+                format: int32
+                type: integer
+              pollingInterval:
+                format: int32
+                type: integer
+              scaleTargetRef:
+                description: ScaleTarget holds the reference to the scale target Object
+                properties:
+                  apiVersion:
+                    type: string
+                  envSourceContainerName:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              triggers:
+                items:
+                  description: ScaleTriggers reference the scaler that will be used
+                  properties:
+                    authenticationRef:
+                      description: AuthenticationRef points to the TriggerAuthentication
+                        or ClusterTriggerAuthentication object that is used to authenticate
+                        the scaler with the environment
+                      properties:
+                        kind:
+                          description: Kind of the resource being referred to. Defaults
+                            to TriggerAuthentication.
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    metricType:
+                      description: MetricTargetType specifies the type of metric being
+                        targeted, and should be either "Value", "AverageValue", or
+                        "Utilization"
+                      type: string
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    useCachedMetrics:
+                      type: boolean
+                  required:
+                  - metadata
+                  - type
+                  type: object
+                type: array
+            required:
+            - scaleTargetRef
+            - triggers
+            type: object
+          status:
+            description: ScaledObjectStatus is the status for a ScaledObject resource
+            properties:
+              compositeScalerName:
+                type: string
+              conditions:
+                description: Conditions an array representation to store multiple
+                  Conditions
+                items:
+                  description: Condition to store the condition state
+                  properties:
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalMetricNames:
+                items:
+                  type: string
+                type: array
+              health:
+                additionalProperties:
+                  description: HealthStatus is the status for a ScaledObject's health
+                  properties:
+                    numberOfFailures:
+                      format: int32
+                      type: integer
+                    status:
+                      description: HealthStatusType is an indication of whether the
+                        health status is happy or failing
+                      type: string
+                  type: object
+                type: object
+              hpaName:
+                type: string
+              lastActiveTime:
+                format: date-time
+                type: string
+              originalReplicaCount:
+                format: int32
+                type: integer
+              pausedReplicaCount:
+                format: int32
+                type: integer
+              resourceMetricNames:
+                items:
+                  type: string
+                type: array
+              scaleTargetGVKR:
+                description: GroupVersionKindResource provides unified structure for
+                  schema.GroupVersionKind and Resource
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  resource:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - group
+                - kind
+                - resource
+                - version
+                type: object
+              scaleTargetKind:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ScaledObject
+    listKind: ScaledObjectList
+    plural: scaledobjects
+    shortNames:
+    - so
+    singular: scaledobject
+  conditions:
+  - lastTransitionTime: "2024-02-05T06:07:44Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2024-02-05T06:07:44Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1alpha1

--- a/operators/kedacore_keda-olm-operator/yugm2_system_state.json
+++ b/operators/kedacore_keda-olm-operator/yugm2_system_state.json
@@ -1,0 +1,17028 @@
+{
+    "cluster_role_binding": {
+        "cluster-admin": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "cluster-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "166",
+                "self_link": null,
+                "uid": "d9c16a78-7e34-45cb-8217-969457570055"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:masters",
+                    "namespace": null
+                }
+            ]
+        },
+        "keda-hpa-controller-external-metrics": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-hpa-controller-external-metrics\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-hpa-controller-external-metrics\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"keda-external-metrics-reader\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"horizontal-pod-autoscaler\",\"namespace\":\"kube-system\"}]}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-hpa-controller-external-metrics",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    }
+                ],
+                "name": "keda-hpa-controller-external-metrics",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122645",
+                "self_link": null,
+                "uid": "c77c2a93-c56c-4de4-833e-fbdb44c5250d"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "keda-external-metrics-reader"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "horizontal-pod-autoscaler",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "keda-olm-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:44+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/part-of": "keda-olm-operator",
+                    "app.kubernetes.io/version": "main"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:44+00:00"
+                    }
+                ],
+                "name": "keda-olm-operator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122395",
+                "self_link": null,
+                "uid": "e35b7714-6cc9-4094-a68c-48b71e4c578b"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "keda-olm-operator"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "keda-olm-operator",
+                    "namespace": "keda"
+                }
+            ]
+        },
+        "keda-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"keda-operator\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"keda-operator\",\"namespace\":\"keda\"}]}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:54+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:56+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122628",
+                "self_link": null,
+                "uid": "684cad66-4b57-4c93-89a8-8aaae37e7414"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "keda-operator"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "keda-operator",
+                    "namespace": "keda"
+                }
+            ]
+        },
+        "keda-system-auth-delegator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-system-auth-delegator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-system-auth-delegator\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"system:auth-delegator\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"keda-operator\",\"namespace\":\"keda\"}]}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-system-auth-delegator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    }
+                ],
+                "name": "keda-system-auth-delegator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122647",
+                "self_link": null,
+                "uid": "0920f245-51cc-417b-a759-ed0c9f859f25"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:auth-delegator"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "keda-operator",
+                    "namespace": "keda"
+                }
+            ]
+        },
+        "keda.v2.12.0-77dddd4fdc": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:45:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "keda.v2.12.0",
+                    "olm.owner.kind": "ClusterServiceVersion",
+                    "olm.owner.namespace": "operators",
+                    "olm.permissions.hash": "3QxFxBAwuQW4RsSSynoJjAeZt61RsRIIzRoXyY",
+                    "operators.coreos.com/keda.operators": ""
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {},
+                                    "f:olm.permissions.hash": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "catalog",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:45:04+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:operators.coreos.com/keda.operators": {}
+                                }
+                            }
+                        },
+                        "manager": "Go-http-client",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:45:11+00:00"
+                    }
+                ],
+                "name": "keda.v2.12.0-77dddd4fdc",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1722",
+                "self_link": null,
+                "uid": "e98f1d81-b9dc-4721-9fe8-5dc134b2cf04"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "keda.v2.12.0-77dddd4fdc"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "keda-olm-operator",
+                    "namespace": "operators"
+                }
+            ]
+        },
+        "kindnet": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:53+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:53+00:00"
+                    }
+                ],
+                "name": "kindnet",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "295",
+                "self_link": null,
+                "uid": "95d132d4-9095-437e-a853-a14f73c51837"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kindnet"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kindnet",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "kubeadm:get-nodes": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "kubeadm:get-nodes",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "256",
+                "self_link": null,
+                "uid": "e3944820-89de-44d1-991f-39c17f614df1"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kubeadm:get-nodes"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:kubelet-bootstrap": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "kubeadm:kubelet-bootstrap",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "258",
+                "self_link": null,
+                "uid": "829671e3-9ae5-4db7-9e39-3736e95f4a1f"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-bootstrapper"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-autoapprove-bootstrap": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-autoapprove-bootstrap",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "259",
+                "self_link": null,
+                "uid": "31b16763-b573-459a-8629-bc461810a993"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:certificates.k8s.io:certificatesigningrequests:nodeclient"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-autoapprove-certificate-rotation": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-autoapprove-certificate-rotation",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "260",
+                "self_link": null,
+                "uid": "c135dea1-9dc3-4bd6-801d-ed85bd3f3318"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:nodes",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-proxier": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "276",
+                "self_link": null,
+                "uid": "18469f28-fe71-491a-8f6a-48244b95d07a"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-proxier"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kube-proxy",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "local-path-provisioner-bind": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-bind\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"local-path-provisioner-role\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"local-path-provisioner-service-account\",\"namespace\":\"local-path-storage\"}]}\n"
+                },
+                "creation_timestamp": "2024-01-31T19:37:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:55+00:00"
+                    }
+                ],
+                "name": "local-path-provisioner-bind",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "307",
+                "self_link": null,
+                "uid": "379b7b35-cff7-4c03-ad69-8190f4f70fc4"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "local-path-provisioner-role"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "local-path-provisioner-service-account",
+                    "namespace": "local-path-storage"
+                }
+            ]
+        },
+        "olm-operator-binding-olm": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:06+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:06+00:00"
+                    }
+                ],
+                "name": "olm-operator-binding-olm",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1001",
+                "self_link": null,
+                "uid": "05de9d5a-ab64-4391-9301-4d21eb64ac96"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:operator-lifecycle-manager"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "olm-operator-serviceaccount",
+                    "namespace": "olm"
+                }
+            ]
+        },
+        "packageserver-service-system:auth-delegator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:25+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "packageserver",
+                    "olm.owner.kind": "ClusterServiceVersion",
+                    "olm.owner.namespace": "olm"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:25+00:00"
+                    }
+                ],
+                "name": "packageserver-service-system:auth-delegator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1105",
+                "self_link": null,
+                "uid": "c3abdfbc-33c7-4267-af83-d745593b5f53"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:auth-delegator"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "olm-operator-serviceaccount",
+                    "namespace": "olm"
+                }
+            ]
+        },
+        "system:basic-user": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:basic-user",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "169",
+                "self_link": null,
+                "uid": "a142fc65-d675-4080-a308-4a98f1d1f1a5"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:basic-user"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:controller:attachdetach-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:attachdetach-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "178",
+                "self_link": null,
+                "uid": "4024daac-12e4-42ba-8cd6-e1232803c809"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:attachdetach-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "attachdetach-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:certificate-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:certificate-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "205",
+                "self_link": null,
+                "uid": "d5d99479-05a8-4395-8368-52959f24f7b7"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:certificate-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "certificate-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:clusterrole-aggregation-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:clusterrole-aggregation-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "179",
+                "self_link": null,
+                "uid": "d1054682-24fd-4f43-a25a-422e3b3a6ee9"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:clusterrole-aggregation-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "clusterrole-aggregation-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:cronjob-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:cronjob-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "180",
+                "self_link": null,
+                "uid": "1204360d-269b-44fe-85e3-681d68d1a56a"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:cronjob-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "cronjob-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:daemon-set-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:daemon-set-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "182",
+                "self_link": null,
+                "uid": "a6406cb2-dc07-467b-95fb-11930be38318"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:daemon-set-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "daemon-set-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:deployment-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:deployment-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "183",
+                "self_link": null,
+                "uid": "aa93e50e-5d6b-44b7-8853-497d6790efad"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:deployment-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "deployment-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:disruption-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:disruption-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "184",
+                "self_link": null,
+                "uid": "0d5870c6-c5d0-4c8e-8618-9ebd9b189547"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:disruption-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "disruption-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpoint-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:endpoint-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "185",
+                "self_link": null,
+                "uid": "7f2758f3-dbd4-42b5-ab05-95c2458af0b9"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpoint-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpoint-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpointslice-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslice-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "186",
+                "self_link": null,
+                "uid": "8be60933-c235-4e25-aa97-8bd333442dfd"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpointslice-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpointslice-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpointslicemirroring-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslicemirroring-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "187",
+                "self_link": null,
+                "uid": "f6e78e8f-03e5-4980-933d-2ddccd92e0e5"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpointslicemirroring-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpointslicemirroring-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ephemeral-volume-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:ephemeral-volume-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "189",
+                "self_link": null,
+                "uid": "378729be-e0dc-4d42-b2f8-cd5575371fd7"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ephemeral-volume-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ephemeral-volume-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:expand-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:expand-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "188",
+                "self_link": null,
+                "uid": "50acd231-7359-4070-9372-c363dd2116e6"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:expand-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "expand-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:generic-garbage-collector": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:generic-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "190",
+                "self_link": null,
+                "uid": "57f1b080-318f-4c44-b048-619f1ccb0385"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:generic-garbage-collector"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "generic-garbage-collector",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:horizontal-pod-autoscaler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:horizontal-pod-autoscaler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "191",
+                "self_link": null,
+                "uid": "5921ae0d-ce87-42e6-bf77-10a45f1c6295"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:horizontal-pod-autoscaler"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "horizontal-pod-autoscaler",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:job-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:job-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "192",
+                "self_link": null,
+                "uid": "9fcad1dc-b3bd-4308-ae18-20e5eff42625"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:job-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "job-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:namespace-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:namespace-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "193",
+                "self_link": null,
+                "uid": "59477699-581e-462f-916c-b56252a1310d"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:namespace-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "namespace-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:node-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:node-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "194",
+                "self_link": null,
+                "uid": "0ed42ccf-94e5-4d93-a4ea-535263fde0fe"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:node-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "node-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:persistent-volume-binder": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:persistent-volume-binder",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "195",
+                "self_link": null,
+                "uid": "3edccabb-29c3-457d-9b8a-cb041e27f27c"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:persistent-volume-binder"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "persistent-volume-binder",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pod-garbage-collector": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:pod-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "196",
+                "self_link": null,
+                "uid": "869a0372-3d4e-47fc-bdde-5065a61485c8"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pod-garbage-collector"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pod-garbage-collector",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pv-protection-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:pv-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "207",
+                "self_link": null,
+                "uid": "881b1c65-90d4-46ea-b167-18aaeea90c07"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pv-protection-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pv-protection-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pvc-protection-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:pvc-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "206",
+                "self_link": null,
+                "uid": "a1850dc5-1e07-4908-b9ee-2b3bd1a80ce6"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pvc-protection-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pvc-protection-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:replicaset-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:replicaset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "197",
+                "self_link": null,
+                "uid": "f27451b4-6ef4-44b8-b6d3-2f76110c1383"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:replicaset-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "replicaset-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:replication-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:replication-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "198",
+                "self_link": null,
+                "uid": "b37447db-b6b6-440d-8940-2db9e7236bac"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:replication-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "replication-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:resourcequota-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:resourcequota-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "199",
+                "self_link": null,
+                "uid": "44b01bff-c940-4f61-88f9-ae3e7c4596c8"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:resourcequota-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "resourcequota-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:root-ca-cert-publisher": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:root-ca-cert-publisher",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "209",
+                "self_link": null,
+                "uid": "7dd05a65-adb1-48c9-a086-8a1671d564cd"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:root-ca-cert-publisher"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "root-ca-cert-publisher",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:route-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:route-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "200",
+                "self_link": null,
+                "uid": "9939d68c-24fd-4f33-87e4-049e2fa74448"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:route-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "route-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:service-account-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:service-account-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "201",
+                "self_link": null,
+                "uid": "e7e71fb3-87cb-43a0-9dd4-50870b9226b0"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:service-account-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "service-account-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:service-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:service-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "202",
+                "self_link": null,
+                "uid": "40857413-869d-4b5f-8ee0-4ad96d990a97"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:service-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "service-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:statefulset-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:statefulset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "203",
+                "self_link": null,
+                "uid": "7655c4e8-909f-4a02-90b7-b778dea91ad0"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:statefulset-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "statefulset-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ttl-after-finished-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-after-finished-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "208",
+                "self_link": null,
+                "uid": "c4ca806b-fcfd-4152-a0af-9f94d915621d"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ttl-after-finished-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ttl-after-finished-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ttl-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "204",
+                "self_link": null,
+                "uid": "a7707b37-5793-44f9-9901-43e23f800ca1"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ttl-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ttl-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:coredns": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "system:coredns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "266",
+                "self_link": null,
+                "uid": "c0f9e1f7-f774-485b-b93b-166003362375"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:coredns"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "coredns",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:discovery": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "168",
+                "self_link": null,
+                "uid": "bd627096-2e5f-4cd1-b30f-b03a7ed54c92"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:discovery"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:kube-controller-manager": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:kube-controller-manager",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "172",
+                "self_link": null,
+                "uid": "9ac2edb3-90fb-44fe-b5cd-59fd4e6d1351"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-controller-manager"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-controller-manager",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:kube-dns": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:kube-dns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "173",
+                "self_link": null,
+                "uid": "ecb78bc1-7698-46f1-a4fd-3bb4bc734aee"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-dns"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kube-dns",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:kube-scheduler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:kube-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "174",
+                "self_link": null,
+                "uid": "27dcb20e-4f0f-4a21-ba38-1496dd100757"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-scheduler"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-scheduler",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:monitoring": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:monitoring",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "167",
+                "self_link": null,
+                "uid": "02482bf2-3c45-49ab-ba63-dac550c28815"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:monitoring"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:monitoring",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:node": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:node",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "176",
+                "self_link": null,
+                "uid": "cb8adfbd-9415-4366-8dea-e7775ef25ac8"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node"
+            },
+            "subjects": null
+        },
+        "system:node-proxier": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "171",
+                "self_link": null,
+                "uid": "14cb3b47-3441-4b02-83f4-3d2ef63b1f41"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-proxier"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-proxy",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:public-info-viewer": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:public-info-viewer",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "170",
+                "self_link": null,
+                "uid": "cb182b14-03b8-473b-8aaa-456f1d51077d"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:public-info-viewer"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                },
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:unauthenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:service-account-issuer-discovery": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:service-account-issuer-discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "177",
+                "self_link": null,
+                "uid": "f45484d1-ee16-4fed-a182-9c2ca27e41a1"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:service-account-issuer-discovery"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:serviceaccounts",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:volume-scheduler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:volume-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "175",
+                "self_link": null,
+                "uid": "88e44e49-9dda-4d2e-a947-d219331b083c"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:volume-scheduler"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-scheduler",
+                    "namespace": null
+                }
+            ]
+        }
+    },
+    "cluster_role": {
+        "admin": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:48+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122531",
+                "self_link": null,
+                "uid": "6ffc192a-b6f1-4179-a620-dad8fa8f6fb2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subscriptions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterserviceversions",
+                        "catalogsources",
+                        "installplans",
+                        "subscriptions"
+                    ],
+                    "verbs": [
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterserviceversions",
+                        "catalogsources",
+                        "installplans",
+                        "subscriptions",
+                        "operatorgroups"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests",
+                        "packagemanifests/icon"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "clustertriggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kedacontrollers.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledjobs.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledobjects.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "triggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "aggregate-olm-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:06+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:06+00:00"
+                    }
+                ],
+                "name": "aggregate-olm-edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1014",
+                "self_link": null,
+                "uid": "9fbebca2-bfe0-49ee-93e3-31a9b53053a3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subscriptions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterserviceversions",
+                        "catalogsources",
+                        "installplans",
+                        "subscriptions"
+                    ],
+                    "verbs": [
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "aggregate-olm-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:06+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:06+00:00"
+                    }
+                ],
+                "name": "aggregate-olm-view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1022",
+                "self_link": null,
+                "uid": "feff40ca-7353-4a35-b4ed-648b00e42bda"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterserviceversions",
+                        "catalogsources",
+                        "installplans",
+                        "subscriptions",
+                        "operatorgroups"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests",
+                        "packagemanifests/icon"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "cluster-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "cluster-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "55",
+                "self_link": null,
+                "uid": "68c1a05a-73d1-40d9-808f-f9ec9f600b85"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "*"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "clustertriggerauthentications.keda.sh-v1alpha1-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"1b28fea7-210a-4bc6-a19a-01cad657ac12\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "clustertriggerauthentications.keda.sh-v1alpha1-admin",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "clustertriggerauthentications.keda.sh",
+                        "uid": "1b28fea7-210a-4bc6-a19a-01cad657ac12"
+                    }
+                ],
+                "resource_version": "1122437",
+                "self_link": null,
+                "uid": "3d8dfed7-8033-487b-ac9a-782995cb8731"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "clustertriggerauthentications.keda.sh-v1alpha1-crdview": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"1b28fea7-210a-4bc6-a19a-01cad657ac12\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "clustertriggerauthentications.keda.sh-v1alpha1-crdview",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "clustertriggerauthentications.keda.sh",
+                        "uid": "1b28fea7-210a-4bc6-a19a-01cad657ac12"
+                    }
+                ],
+                "resource_version": "1122444",
+                "self_link": null,
+                "uid": "e472050d-2bf0-4354-83bd-84529600d667"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "clustertriggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "clustertriggerauthentications.keda.sh-v1alpha1-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-edit": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-edit": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"1b28fea7-210a-4bc6-a19a-01cad657ac12\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "clustertriggerauthentications.keda.sh-v1alpha1-edit",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "clustertriggerauthentications.keda.sh",
+                        "uid": "1b28fea7-210a-4bc6-a19a-01cad657ac12"
+                    }
+                ],
+                "resource_version": "1122438",
+                "self_link": null,
+                "uid": "d7e14f39-ea4f-4967-81bc-86114850e0e3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "clustertriggerauthentications.keda.sh-v1alpha1-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"1b28fea7-210a-4bc6-a19a-01cad657ac12\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "clustertriggerauthentications.keda.sh-v1alpha1-view",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "clustertriggerauthentications.keda.sh",
+                        "uid": "1b28fea7-210a-4bc6-a19a-01cad657ac12"
+                    }
+                ],
+                "resource_version": "1122441",
+                "self_link": null,
+                "uid": "8477aaed-379f-4901-86f3-9c86920cff7e"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "edit": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:48+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122530",
+                "self_link": null,
+                "uid": "6858ccef-7791-4e17-82ea-8b6ace3e7d46"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subscriptions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterserviceversions",
+                        "catalogsources",
+                        "installplans",
+                        "subscriptions"
+                    ],
+                    "verbs": [
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterserviceversions",
+                        "catalogsources",
+                        "installplans",
+                        "subscriptions",
+                        "operatorgroups"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests",
+                        "packagemanifests/icon"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "clustertriggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kedacontrollers.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledjobs.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledobjects.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "triggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "keda-external-metrics-reader": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-external-metrics-reader\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-external-metrics-reader\"},\"rules\":[{\"apiGroups\":[\"external.metrics.k8s.io\"],\"resources\":[\"*\"],\"verbs\":[\"*\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-external-metrics-reader",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    }
+                ],
+                "name": "keda-external-metrics-reader",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122640",
+                "self_link": null,
+                "uid": "25693a84-9f18-47f3-974b-ea59d66a680b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "external.metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "keda-olm-operator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:44+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-olm-operator",
+                    "app.kubernetes.io/version": "main"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:44+00:00"
+                    }
+                ],
+                "name": "keda-olm-operator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122394",
+                "self_link": null,
+                "uid": "1b95d607-baa2-4b1d-9f21-215d64adb583"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "events",
+                        "namespaces",
+                        "persistentvolumeclaims",
+                        "pods",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "admissionregistration.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "validatingwebhookconfigurations"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiregistration.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "apiservices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "replicasets",
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "keda-olm-operator"
+                    ],
+                    "resources": [
+                        "deployments/finalizers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers",
+                        "kedacontrollers/finalizers",
+                        "kedacontrollers/status"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "monitoring.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "podmonitors",
+                        "servicemonitors"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings",
+                        "clusterroles",
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "route.openshift.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "routes"
+                    ],
+                    "verbs": [
+                        "*",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "keda-operator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\"},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"configmaps\",\"configmaps/status\",\"events\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"\"],\"resources\":[\"external\",\"pods\",\"secrets\",\"services\"],\"verbs\":[\"get\",\"list\",\"watch\"]},{\"apiGroups\":[\"\"],\"resources\":[\"serviceaccounts\"],\"verbs\":[\"list\",\"watch\"]},{\"apiGroups\":[\"*\"],\"resources\":[\"*\"],\"verbs\":[\"get\"]},{\"apiGroups\":[\"*\"],\"resources\":[\"*/scale\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"admissionregistration.k8s.io\"],\"resources\":[\"validatingwebhookconfigurations\"],\"verbs\":[\"get\",\"list\",\"patch\",\"update\",\"watch\"]},{\"apiGroups\":[\"apiregistration.k8s.io\"],\"resources\":[\"apiservices\"],\"verbs\":[\"get\",\"list\",\"patch\",\"update\",\"watch\"]},{\"apiGroups\":[\"apps\"],\"resources\":[\"deployments\",\"statefulsets\"],\"verbs\":[\"list\",\"watch\"]},{\"apiGroups\":[\"autoscaling\"],\"resources\":[\"horizontalpodautoscalers\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"batch\"],\"resources\":[\"jobs\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"coordination.k8s.io\"],\"resources\":[\"leases\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"keda.sh\"],\"resources\":[\"clustertriggerauthentications\",\"clustertriggerauthentications/status\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"keda.sh\"],\"resources\":[\"scaledjobs\",\"scaledjobs/finalizers\",\"scaledjobs/status\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"keda.sh\"],\"resources\":[\"scaledobjects\",\"scaledobjects/finalizers\",\"scaledobjects/status\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"keda.sh\"],\"resources\":[\"triggerauthentications\",\"triggerauthentications/status\"],\"verbs\":[\"*\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:54+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:56+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122626",
+                "self_link": null,
+                "uid": "36ac1fc2-fec2-45c9-93f9-491d3f28e953"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "configmaps/status",
+                        "events"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "external",
+                        "pods",
+                        "secrets",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*/scale"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "admissionregistration.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "validatingwebhookconfigurations"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiregistration.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "apiservices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments",
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications",
+                        "clustertriggerauthentications/status"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs",
+                        "scaledjobs/finalizers",
+                        "scaledjobs/status"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects",
+                        "scaledobjects/finalizers",
+                        "scaledobjects/status"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications",
+                        "triggerauthentications/status"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "keda.v2.12.0-77dddd4fdc": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:45:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "keda.v2.12.0",
+                    "olm.owner.kind": "ClusterServiceVersion",
+                    "olm.owner.namespace": "operators",
+                    "olm.permissions.hash": "7axPlFkHJljArOqlVlUojVYBDxDy9Q9h02YdJU",
+                    "operators.coreos.com/keda.operators": ""
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {},
+                                    "f:olm.permissions.hash": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "catalog",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:45:04+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:operators.coreos.com/keda.operators": {}
+                                }
+                            }
+                        },
+                        "manager": "Go-http-client",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:45:11+00:00"
+                    }
+                ],
+                "name": "keda.v2.12.0-77dddd4fdc",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1719",
+                "self_link": null,
+                "uid": "41390ac9-e440-459e-95a1-7d3aca33b994"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "events",
+                        "namespaces",
+                        "persistentvolumeclaims",
+                        "pods",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "admissionregistration.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "validatingwebhookconfigurations"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiregistration.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "apiservices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "replicasets",
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "keda-olm-operator"
+                    ],
+                    "resources": [
+                        "deployments/finalizers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers",
+                        "kedacontrollers/finalizers",
+                        "kedacontrollers/status"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "monitoring.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "podmonitors",
+                        "servicemonitors"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings",
+                        "clusterroles",
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "route.openshift.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "routes"
+                    ],
+                    "verbs": [
+                        "*",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "kedacontrollers.keda.sh-v1alpha1-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"682c17bb-fb3d-43bd-9e11-eb2b87cc344f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "kedacontrollers.keda.sh-v1alpha1-admin",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "kedacontrollers.keda.sh",
+                        "uid": "682c17bb-fb3d-43bd-9e11-eb2b87cc344f"
+                    }
+                ],
+                "resource_version": "1122447",
+                "self_link": null,
+                "uid": "31b0c8ff-ac79-426b-92da-19618dfe09aa"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "kedacontrollers.keda.sh-v1alpha1-crdview": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"682c17bb-fb3d-43bd-9e11-eb2b87cc344f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "kedacontrollers.keda.sh-v1alpha1-crdview",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "kedacontrollers.keda.sh",
+                        "uid": "682c17bb-fb3d-43bd-9e11-eb2b87cc344f"
+                    }
+                ],
+                "resource_version": "1122459",
+                "self_link": null,
+                "uid": "fdf5893b-444e-435f-9227-ff48c435add6"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kedacontrollers.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kedacontrollers.keda.sh-v1alpha1-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-edit": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-edit": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"682c17bb-fb3d-43bd-9e11-eb2b87cc344f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "kedacontrollers.keda.sh-v1alpha1-edit",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "kedacontrollers.keda.sh",
+                        "uid": "682c17bb-fb3d-43bd-9e11-eb2b87cc344f"
+                    }
+                ],
+                "resource_version": "1122452",
+                "self_link": null,
+                "uid": "8b61d32e-c3dd-43ea-babd-02a9503e7312"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "kedacontrollers.keda.sh-v1alpha1-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"682c17bb-fb3d-43bd-9e11-eb2b87cc344f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "kedacontrollers.keda.sh-v1alpha1-view",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "kedacontrollers.keda.sh",
+                        "uid": "682c17bb-fb3d-43bd-9e11-eb2b87cc344f"
+                    }
+                ],
+                "resource_version": "1122456",
+                "self_link": null,
+                "uid": "62847461-c23b-4a00-be93-13da7da115ab"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kindnet": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:53+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:53+00:00"
+                    }
+                ],
+                "name": "kindnet",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "293",
+                "self_link": null,
+                "uid": "0025c7ef-a324-406c-a315-abde2a845a8c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kindnet"
+                    ],
+                    "resources": [
+                        "podsecuritypolicies"
+                    ],
+                    "verbs": [
+                        "use"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kubeadm:get-nodes": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "kubeadm:get-nodes",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "255",
+                "self_link": null,
+                "uid": "e9a3e437-a805-4a32-8ae4-a4a4923d3db8"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "local-path-provisioner-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-role\"},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"nodes\",\"persistentvolumeclaims\",\"configmaps\"],\"verbs\":[\"get\",\"list\",\"watch\"]},{\"apiGroups\":[\"\"],\"resources\":[\"endpoints\",\"persistentvolumes\",\"pods\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"\"],\"resources\":[\"events\"],\"verbs\":[\"create\",\"patch\"]},{\"apiGroups\":[\"storage.k8s.io\"],\"resources\":[\"storageclasses\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
+                },
+                "creation_timestamp": "2024-01-31T19:37:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:55+00:00"
+                    }
+                ],
+                "name": "local-path-provisioner-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "306",
+                "self_link": null,
+                "uid": "55afc557-099a-4cc2-ad96-73c321453dd5"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "persistentvolumeclaims",
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "persistentvolumes",
+                        "pods"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "olm.og.global-operators.admin-5UD4U2IfBGbw51Qy2Jaefk1uawvkj2OJILlc3w": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-admin": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-admin": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-admin": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-admin": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-admin": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:25+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "global-operators",
+                    "olm.owner.kind": "OperatorGroup",
+                    "olm.owner.namespace": "operators"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {}
+                                }
+                            }
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    }
+                ],
+                "name": "olm.og.global-operators.admin-5UD4U2IfBGbw51Qy2Jaefk1uawvkj2OJILlc3w",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122632",
+                "self_link": null,
+                "uid": "638a1bdd-0f9a-4e41-8b57-744dc0a1d820"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "olm.og.global-operators.edit-9ZbzBIwu1SlHO7KbWinNtOfyGaVjTWIYhNkNP": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-edit": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-edit": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-edit": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-edit": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-edit": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:25+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "global-operators",
+                    "olm.owner.kind": "OperatorGroup",
+                    "olm.owner.namespace": "operators"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {}
+                                }
+                            }
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    }
+                ],
+                "name": "olm.og.global-operators.edit-9ZbzBIwu1SlHO7KbWinNtOfyGaVjTWIYhNkNP",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122637",
+                "self_link": null,
+                "uid": "b5205270-653e-43fb-9581-da9e55c6599f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "olm.og.global-operators.view-6lzJtrbG08ne4wrZHGxP3h1MBUjq5e7nOF4gax": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-view": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-2ca3e4711947c970-view": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-view": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-view": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-view": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:25+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "global-operators",
+                    "olm.owner.kind": "OperatorGroup",
+                    "olm.owner.namespace": "operators"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {}
+                                }
+                            }
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    }
+                ],
+                "name": "olm.og.global-operators.view-6lzJtrbG08ne4wrZHGxP3h1MBUjq5e7nOF4gax",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122642",
+                "self_link": null,
+                "uid": "21a5e277-aa70-4def-b1f0-0b95937ea20d"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "clustertriggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kedacontrollers.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledjobs.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledobjects.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "triggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "olm.og.olm-operators.admin-4ZLCGAP5QcGCG77n5nsv27O9w2VWNfAzuGGQ43": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-admin": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:25+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "olm-operators",
+                    "olm.owner.kind": "OperatorGroup",
+                    "olm.owner.namespace": "olm"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:31+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {}
+                                }
+                            }
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:25+00:00"
+                    }
+                ],
+                "name": "olm.og.olm-operators.admin-4ZLCGAP5QcGCG77n5nsv27O9w2VWNfAzuGGQ43",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1216",
+                "self_link": null,
+                "uid": "ddf13083-9fc1-4fec-b9a0-14543052a1ad"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "olm.og.olm-operators.edit-736WBdqykyrqf8gmqVOBugEoWcoEpAgFF2BdSD": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-edit": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:25+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "olm-operators",
+                    "olm.owner.kind": "OperatorGroup",
+                    "olm.owner.namespace": "olm"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:31+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {}
+                                }
+                            }
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:25+00:00"
+                    }
+                ],
+                "name": "olm.og.olm-operators.edit-736WBdqykyrqf8gmqVOBugEoWcoEpAgFF2BdSD",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1219",
+                "self_link": null,
+                "uid": "167a5a97-cd65-4e32-9a49-f7ab217c77a4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "olm.og.olm-operators.view-1Xspg12ELROt61EB7hNkNQZYeAx3gOCYxpwBSz": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-view": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:25+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.owner": "olm-operators",
+                    "olm.owner.kind": "OperatorGroup",
+                    "olm.owner.namespace": "olm"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:31+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.owner": {},
+                                    "f:olm.owner.kind": {},
+                                    "f:olm.owner.namespace": {}
+                                }
+                            }
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:25+00:00"
+                    }
+                ],
+                "name": "olm.og.olm-operators.view-1Xspg12ELROt61EB7hNkNQZYeAx3gOCYxpwBSz",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1221",
+                "self_link": null,
+                "uid": "b7932a52-7618-4705-982a-7ce5ce577215"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "packagemanifests-v1-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:31+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"e8b85097-f7ef-442c-9cc8-355e9caf7e08\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:31+00:00"
+                    }
+                ],
+                "name": "packagemanifests-v1-admin",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiregistration.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "APIService",
+                        "name": "v1.packages.operators.coreos.com",
+                        "uid": "e8b85097-f7ef-442c-9cc8-355e9caf7e08"
+                    }
+                ],
+                "resource_version": "1214",
+                "self_link": null,
+                "uid": "92dd88c7-7158-4799-967f-db1f6f5f9216"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "packagemanifests-v1-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:31+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-edit": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-edit": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"e8b85097-f7ef-442c-9cc8-355e9caf7e08\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:31+00:00"
+                    }
+                ],
+                "name": "packagemanifests-v1-edit",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiregistration.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "APIService",
+                        "name": "v1.packages.operators.coreos.com",
+                        "uid": "e8b85097-f7ef-442c-9cc8-355e9caf7e08"
+                    }
+                ],
+                "resource_version": "1215",
+                "self_link": null,
+                "uid": "c44021f8-6b98-4fd7-9b74-b286114867fb"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "packagemanifests-v1-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:31+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-4bca9f23e412d79d-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"e8b85097-f7ef-442c-9cc8-355e9caf7e08\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:31+00:00"
+                    }
+                ],
+                "name": "packagemanifests-v1-view",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiregistration.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "APIService",
+                        "name": "v1.packages.operators.coreos.com",
+                        "uid": "e8b85097-f7ef-442c-9cc8-355e9caf7e08"
+                    }
+                ],
+                "resource_version": "1218",
+                "self_link": null,
+                "uid": "73f6e4ed-faed-433a-a242-8b0817cd161a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "scaledjobs.keda.sh-v1alpha1-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-cebc826c59f4838-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"ad2fbeb3-9f60-4e6a-8463-c137cf79d59e\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "scaledjobs.keda.sh-v1alpha1-admin",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledjobs.keda.sh",
+                        "uid": "ad2fbeb3-9f60-4e6a-8463-c137cf79d59e"
+                    }
+                ],
+                "resource_version": "1122464",
+                "self_link": null,
+                "uid": "3ecbe482-23b2-4a71-b212-c74c76e0f2ef"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "scaledjobs.keda.sh-v1alpha1-crdview": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-cebc826c59f4838-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"ad2fbeb3-9f60-4e6a-8463-c137cf79d59e\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "scaledjobs.keda.sh-v1alpha1-crdview",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledjobs.keda.sh",
+                        "uid": "ad2fbeb3-9f60-4e6a-8463-c137cf79d59e"
+                    }
+                ],
+                "resource_version": "1122478",
+                "self_link": null,
+                "uid": "a6a62d94-6797-46c3-92c5-860b17456a12"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledjobs.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "scaledjobs.keda.sh-v1alpha1-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-edit": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-cebc826c59f4838-edit": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"ad2fbeb3-9f60-4e6a-8463-c137cf79d59e\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:46+00:00"
+                    }
+                ],
+                "name": "scaledjobs.keda.sh-v1alpha1-edit",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledjobs.keda.sh",
+                        "uid": "ad2fbeb3-9f60-4e6a-8463-c137cf79d59e"
+                    }
+                ],
+                "resource_version": "1122470",
+                "self_link": null,
+                "uid": "dc9232c6-4925-47b5-9d1e-49f3612b2277"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "scaledjobs.keda.sh-v1alpha1-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-cebc826c59f4838-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"ad2fbeb3-9f60-4e6a-8463-c137cf79d59e\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "scaledjobs.keda.sh-v1alpha1-view",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledjobs.keda.sh",
+                        "uid": "ad2fbeb3-9f60-4e6a-8463-c137cf79d59e"
+                    }
+                ],
+                "resource_version": "1122473",
+                "self_link": null,
+                "uid": "0f8096de-9b0f-4435-aac9-6b60bfbc99cb"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "scaledobjects.keda.sh-v1alpha1-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"f6d53cc1-1d66-43c4-ae9b-4d5f86597886\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "scaledobjects.keda.sh-v1alpha1-admin",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledobjects.keda.sh",
+                        "uid": "f6d53cc1-1d66-43c4-ae9b-4d5f86597886"
+                    }
+                ],
+                "resource_version": "1122483",
+                "self_link": null,
+                "uid": "f33bb035-eb43-493f-bb32-8187fe75e85c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "scaledobjects.keda.sh-v1alpha1-crdview": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"f6d53cc1-1d66-43c4-ae9b-4d5f86597886\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "scaledobjects.keda.sh-v1alpha1-crdview",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledobjects.keda.sh",
+                        "uid": "f6d53cc1-1d66-43c4-ae9b-4d5f86597886"
+                    }
+                ],
+                "resource_version": "1122495",
+                "self_link": null,
+                "uid": "6eb73065-b428-4553-b7f9-9883fad8f8d3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledobjects.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "scaledobjects.keda.sh-v1alpha1-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-edit": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-edit": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"f6d53cc1-1d66-43c4-ae9b-4d5f86597886\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "scaledobjects.keda.sh-v1alpha1-edit",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledobjects.keda.sh",
+                        "uid": "f6d53cc1-1d66-43c4-ae9b-4d5f86597886"
+                    }
+                ],
+                "resource_version": "1122486",
+                "self_link": null,
+                "uid": "aaefc05b-4556-4cac-9338-8e5362c66db2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "scaledobjects.keda.sh-v1alpha1-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"f6d53cc1-1d66-43c4-ae9b-4d5f86597886\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "scaledobjects.keda.sh-v1alpha1-view",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "scaledobjects.keda.sh",
+                        "uid": "f6d53cc1-1d66-43c4-ae9b-4d5f86597886"
+                    }
+                ],
+                "resource_version": "1122490",
+                "self_link": null,
+                "uid": "2b9cf038-ca51-4fc4-a8a3-9784e39200b1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "87",
+                "self_link": null,
+                "uid": "45cbec43-2f83-4237-be60-cc5838842392"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "89",
+                "self_link": null,
+                "uid": "a96c2907-ba95-43ec-bb88-c9a723d6d8cb"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "91",
+                "self_link": null,
+                "uid": "addb4210-6468-47f9-a3a9-d204c9ef97a5"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:auth-delegator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:auth-delegator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "103",
+                "self_link": null,
+                "uid": "a47b6e74-c2bb-4c7b-8041-4fead9d5eac5"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:basic-user": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:basic-user",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "68",
+                "self_link": null,
+                "uid": "e0816bd3-13bd-45dc-becf-02bea9155fb3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "selfsubjectaccessreviews",
+                        "selfsubjectrulesreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "selfsubjectreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:certificatesigningrequests:nodeclient": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "115",
+                "self_link": null,
+                "uid": "540ae2d0-ffb0-4a36-8c8f-c01f3d9f06c7"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/nodeclient"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "118",
+                "self_link": null,
+                "uid": "1a7e1c74-0517-4e7c-8d9f-65aa70226465"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/selfnodeclient"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kube-apiserver-client-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kube-apiserver-client-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "127",
+                "self_link": null,
+                "uid": "3e626574-2931-4f4b-a8d3-283a482d54ae"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kube-apiserver-client-kubelet-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kube-apiserver-client-kubelet-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "129",
+                "self_link": null,
+                "uid": "99405744-48bd-4e12-84ab-384b3f770631"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client-kubelet"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kubelet-serving-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kubelet-serving-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "124",
+                "self_link": null,
+                "uid": "4bf9c660-4ad9-4d63-9ea5-4d524b802257"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kubelet-serving"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:legacy-unknown-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:legacy-unknown-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "122",
+                "self_link": null,
+                "uid": "ef642faa-8bfc-4391-b582-741f2c5395ef"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/legacy-unknown"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:controller:attachdetach-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:attachdetach-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "133",
+                "self_link": null,
+                "uid": "c3f3731f-ca35-4d57-a5cd-df4b40e5c1cb"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumeattachments"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:certificate-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:certificate-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "161",
+                "self_link": null,
+                "uid": "66539f15-9905-4748-95b2-9e1158d9763c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/approval",
+                        "certificatesigningrequests/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client-kubelet"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client",
+                        "kubernetes.io/kube-apiserver-client-kubelet",
+                        "kubernetes.io/kubelet-serving",
+                        "kubernetes.io/legacy-unknown"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "sign"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:clusterrole-aggregation-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:clusterrole-aggregation-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "134",
+                "self_link": null,
+                "uid": "24a66533-7edf-4b89-bcb3-b440c71509f1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterroles"
+                    ],
+                    "verbs": [
+                        "escalate",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:cronjob-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:cronjob-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "135",
+                "self_link": null,
+                "uid": "e6838b5e-86ba-4d0a-bd4d-690183ca61a1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:daemon-set-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:daemon-set-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "136",
+                "self_link": null,
+                "uid": "c57d9616-afba-4dd6-ac62-a724c0cdd322"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/binding"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:deployment-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:deployment-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "138",
+                "self_link": null,
+                "uid": "96c0f712-61f2-4cd0-9e8e-427b1392368e"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:disruption-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:disruption-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "139",
+                "self_link": null,
+                "uid": "252e04d5-836d-450b-8cd1-0a4712886f8d"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*/scale"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpoint-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:endpoint-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "140",
+                "self_link": null,
+                "uid": "0dc76a56-524c-466d-b84c-c77162a6afe1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints/restricted"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpointslice-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslice-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "141",
+                "self_link": null,
+                "uid": "37708475-af2f-416c-a31f-f139e5125eed"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "pods",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpointslicemirroring-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslicemirroring-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "142",
+                "self_link": null,
+                "uid": "24b797d2-d5e9-4b94-a7fe-40e50a4206d9"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ephemeral-volume-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:ephemeral-volume-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "144",
+                "self_link": null,
+                "uid": "72a25c60-9f52-465b-afe9-856d8f42ac34"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:expand-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:expand-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "143",
+                "self_link": null,
+                "uid": "76aae2c6-42d0-49d4-83d5-a876374f0dc9"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:generic-garbage-collector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:generic-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "145",
+                "self_link": null,
+                "uid": "0da77165-3fa9-4e2b-8d9e-f97e933ca93a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:horizontal-pod-autoscaler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:horizontal-pod-autoscaler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "146",
+                "self_link": null,
+                "uid": "53fecce8-c8fe-493e-8fb1-9b596211650d"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "custom.metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "external.metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:job-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:job-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "147",
+                "self_link": null,
+                "uid": "5c881b7a-b13e-44bc-b310-5afe54f8fe45"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:namespace-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:namespace-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "148",
+                "self_link": null,
+                "uid": "f558e30d-46e6-4450-a64f-630490949487"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces/finalize",
+                        "namespaces/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "system:controller:node-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:controller:node-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "149",
+                "self_link": null,
+                "uid": "1b1172b4-1c2e-4087-bc92-1a7fbc20a6f4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustercidrs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:controller:operator-lifecycle-manager": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:42:06+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:42:06+00:00"
+                    }
+                ],
+                "name": "system:controller:operator-lifecycle-manager",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1000",
+                "self_link": null,
+                "uid": "6e66e04b-0836-4c9a-8e27-b1975cce35ef"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "watch",
+                        "list",
+                        "get",
+                        "create",
+                        "update",
+                        "patch",
+                        "delete",
+                        "deletecollection",
+                        "escalate",
+                        "bind"
+                    ]
+                },
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "*"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "system:controller:persistent-volume-binder": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:persistent-volume-binder",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "150",
+                "self_link": null,
+                "uid": "a5eba0ad-9116-4b34-a2ef-bf7d6ee699a4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pod-garbage-collector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:pod-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "151",
+                "self_link": null,
+                "uid": "236e2b04-c8cf-40cd-9e5f-44f067108ac6"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pv-protection-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:pv-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "163",
+                "self_link": null,
+                "uid": "bc073eef-35af-4c41-82e7-ea8c977886b1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pvc-protection-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:pvc-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "162",
+                "self_link": null,
+                "uid": "a85a68b4-aeaf-4a02-8be0-aa5e6808eb3c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:replicaset-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:replicaset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "152",
+                "self_link": null,
+                "uid": "3428e826-c67c-4b5c-a31d-754ef8b694b3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:replication-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:replication-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "153",
+                "self_link": null,
+                "uid": "a78a3bb0-4deb-4b8b-a1ff-ce35c77cbe64"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:resourcequota-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:resourcequota-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "154",
+                "self_link": null,
+                "uid": "cc823e12-8b01-46ea-8f80-1a4c335bfbe4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:root-ca-cert-publisher": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:root-ca-cert-publisher",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "165",
+                "self_link": null,
+                "uid": "490d8a7a-9189-4c8d-a70f-1a28518dc011"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:route-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:route-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "155",
+                "self_link": null,
+                "uid": "215da287-cb3f-4ebb-a9bb-eb791b10d902"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:service-account-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:service-account-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "156",
+                "self_link": null,
+                "uid": "06b584f3-7693-4750-8bde-359b2e9b0692"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:service-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:service-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "157",
+                "self_link": null,
+                "uid": "5721665d-710b-49df-930e-65151f39f3c2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:statefulset-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:statefulset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "158",
+                "self_link": null,
+                "uid": "3e94cc11-14a4-4d1a-8a1f-df4f415b0e70"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ttl-after-finished-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-after-finished-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "164",
+                "self_link": null,
+                "uid": "21a81c37-2f34-4b84-a4e4-4cf8ef64edfa"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ttl-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:48+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "160",
+                "self_link": null,
+                "uid": "a1e741ac-8816-4202-906b-20a8aa3d7f95"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:coredns": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:51+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:51+00:00"
+                    }
+                ],
+                "name": "system:coredns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "265",
+                "self_link": null,
+                "uid": "50339c70-ce28-4d31-98b3-325515c67a4c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services",
+                        "pods",
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:discovery": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "59",
+                "self_link": null,
+                "uid": "db411e43-b6d8-4da6-bd33-5f4ad3f356b5"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/api",
+                        "/api/*",
+                        "/apis",
+                        "/apis/*",
+                        "/healthz",
+                        "/livez",
+                        "/openapi",
+                        "/openapi/*",
+                        "/readyz",
+                        "/version",
+                        "/version/"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:heapster": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:heapster",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "93",
+                "self_link": null,
+                "uid": "8e4a2885-47b7-4e52-b018-9495717f9ae5"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events",
+                        "namespaces",
+                        "nodes",
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-aggregator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:kube-aggregator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "105",
+                "self_link": null,
+                "uid": "73a07f98-42f1-4ad4-aad2-58447d24870b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-controller-manager": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:kube-controller-manager",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "107",
+                "self_link": null,
+                "uid": "785b82fd-fb03-476b-b37f-f8abe672d26f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-controller-manager"
+                    ],
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-controller-manager"
+                    ],
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "namespaces",
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:kube-dns": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:kube-dns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "110",
+                "self_link": null,
+                "uid": "82d924db-5891-4f67-b012-e54da5f0c1d8"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-scheduler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:kube-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "132",
+                "self_link": null,
+                "uid": "ee45b957-5206-481a-abf3-f1c3b389d103"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-scheduler"
+                    ],
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-scheduler"
+                    ],
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "pods/binding"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csistoragecapacities"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kubelet-api-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:kubelet-api-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "99",
+                "self_link": null,
+                "uid": "2e18f08f-9c24-4719-9d8d-c3fc9822c3fd"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "proxy"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/log",
+                        "nodes/metrics",
+                        "nodes/proxy",
+                        "nodes/stats"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "system:monitoring": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:monitoring",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "65",
+                "self_link": null,
+                "uid": "99633d45-f3ec-4619-9cb0-969f080be8f9"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/healthz",
+                        "/healthz/*",
+                        "/livez",
+                        "/livez/*",
+                        "/metrics",
+                        "/metrics/slis",
+                        "/readyz",
+                        "/readyz/*"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:node": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:node",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "95",
+                "self_link": null,
+                "uid": "1f2cf4c7-e38e-48b9-a852-4a437c417dd8"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews",
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumeattachments"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "node.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "runtimeclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:node-bootstrapper": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:node-bootstrapper",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "101",
+                "self_link": null,
+                "uid": "99634248-6285-48b3-8e6b-a32da44e75f2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:node-problem-detector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:node-problem-detector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "97",
+                "self_link": null,
+                "uid": "24d60988-89c1-4471-926b-42e5853f88da"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:node-proxier": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "131",
+                "self_link": null,
+                "uid": "504ee9cf-38e3-4395-97f3-f5d8391d83d4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:persistent-volume-provisioner": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:persistent-volume-provisioner",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "112",
+                "self_link": null,
+                "uid": "bdc342e2-9d0c-45f1-aa33-4e7d5b4d859f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:public-info-viewer": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "system:public-info-viewer",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "73",
+                "self_link": null,
+                "uid": "9821a1f6-f974-4f1a-b96e-ce1ac28abf55"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/healthz",
+                        "/livez",
+                        "/readyz",
+                        "/version",
+                        "/version/"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:service-account-issuer-discovery": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:service-account-issuer-discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "130",
+                "self_link": null,
+                "uid": "5dcb574e-105d-4941-a1d2-fdc549bc7be0"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/.well-known/openid-configuration",
+                        "/openid/v1/jwks"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:volume-scheduler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:47+00:00"
+                    }
+                ],
+                "name": "system:volume-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "120",
+                "self_link": null,
+                "uid": "c74cddf1-80dc-4695-b16c-698d71640aa8"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "triggerauthentications.keda.sh-v1alpha1-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-admin": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-d5c32173553a738b-admin": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"9c2f2cef-0e99-4259-9064-a5c8c12a270f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "triggerauthentications.keda.sh-v1alpha1-admin",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "triggerauthentications.keda.sh",
+                        "uid": "9c2f2cef-0e99-4259-9064-a5c8c12a270f"
+                    }
+                ],
+                "resource_version": "1122499",
+                "self_link": null,
+                "uid": "da25f5e4-88dd-4fa1-ba55-3f99b83f85de"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "triggerauthentications.keda.sh-v1alpha1-crdview": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-d5c32173553a738b-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"9c2f2cef-0e99-4259-9064-a5c8c12a270f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "triggerauthentications.keda.sh-v1alpha1-crdview",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "triggerauthentications.keda.sh",
+                        "uid": "9c2f2cef-0e99-4259-9064-a5c8c12a270f"
+                    }
+                ],
+                "resource_version": "1122514",
+                "self_link": null,
+                "uid": "23aa74e5-8ef7-451e-bf02-090f933ac9d2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "triggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "triggerauthentications.keda.sh-v1alpha1-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-edit": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-d5c32173553a738b-edit": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"9c2f2cef-0e99-4259-9064-a5c8c12a270f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "triggerauthentications.keda.sh-v1alpha1-edit",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "triggerauthentications.keda.sh",
+                        "uid": "9c2f2cef-0e99-4259-9064-a5c8c12a270f"
+                    }
+                ],
+                "resource_version": "1122505",
+                "self_link": null,
+                "uid": "916d0d55-7fea-4561-9f7f-dd740b374b7a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        "triggerauthentications.keda.sh-v1alpha1-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:47+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "olm.managed": "true",
+                    "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-view": "true",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:olm.managed": {},
+                                    "f:olm.opgroup.permissions/aggregate-to-d5c32173553a738b-view": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"9c2f2cef-0e99-4259-9064-a5c8c12a270f\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "olm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:47+00:00"
+                    }
+                ],
+                "name": "triggerauthentications.keda.sh-v1alpha1-view",
+                "namespace": null,
+                "owner_references": [
+                    {
+                        "api_version": "apiextensions.k8s.io/v1",
+                        "block_owner_deletion": false,
+                        "controller": false,
+                        "kind": "customresourcedefinition",
+                        "name": "triggerauthentications.keda.sh",
+                        "uid": "9c2f2cef-0e99-4259-9064-a5c8c12a270f"
+                    }
+                ],
+                "resource_version": "1122510",
+                "self_link": null,
+                "uid": "7afe53b2-1851-4922-a908-f7396919862c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "view": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:46+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:48+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:46+00:00"
+                    }
+                ],
+                "name": "view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1122522",
+                "self_link": null,
+                "uid": "2a10dbfc-f0a2-4af7-bbf2-f010e77f29a5"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterserviceversions",
+                        "catalogsources",
+                        "installplans",
+                        "subscriptions",
+                        "operatorgroups"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests",
+                        "packagemanifests/icon"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "clustertriggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kedacontrollers.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "kedacontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "packages.operators.coreos.com"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "packagemanifests"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledjobs.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledobjects.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "triggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        }
+    },
+    "config_map": {
+        "kube-root-ca.crt": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "ca.crt": "-----BEGIN CERTIFICATE-----\nMIIC/jCCAeagAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl\ncm5ldGVzMB4XDTI0MDEzMTE5MzcxOVoXDTM0MDEyODE5MzcxOVowFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM4S\nLbVlnaQRdh6hgxVij9/OVenrw0IUSWucOHFp0PEA2kYDfHuYv+0SdyFVUUcA7Jmt\ndQjbFXLQa6OZEDa4su5OQroPYZ7Ow55NuJKL11HbgWU5CQluJI6ZZKWczrWgYVX9\nmSI5buTDU+AZCV4jLM91YYhMvupdNSiGZMXghmzUAL67hktT8S1k0nniG4fn6I2x\nMnXkHt8DmNv2DcHIkYc2JxlMslQeqDU2LYKVZpvPekhf3ennEmyC5L7WOrWP1se1\nSc+ABpXeLZ1eDavGfba/ZpVb6uAmm9201v/nHZ/qsrvkSbY2rlyb7CY9YhkjsVFU\n9EDHEXKI6vgzKCqEBkcCAwEAAaNZMFcwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB\n/wQFMAMBAf8wHQYDVR0OBBYEFGpXZ9mmWRvYxDCvYydc9/1dnO9yMBUGA1UdEQQO\nMAyCCmt1YmVybmV0ZXMwDQYJKoZIhvcNAQELBQADggEBAK/MIWVOTN4Z6Tdf4JP7\nc6agSjKjaOEdTSMsQ2NQqOR3k8Fl4vCCuYbAE5dz/VQLDHULc5vviDG17/nuZj8R\nooL3A13cX0Y0Zz1cyoErLmvClr7nO3FdNF2NSU1DTSD3jqdtYj/DrhkcYeo0a4b8\nqbLWi8LLgRHXLjEBAFl7xr4WfDpcFGvglO5M9YR3DTrqjWVca+AJjqthNV8+HVhd\n2vPhWsHGK5li+CsmMDNKYFT7TFq/CMBe5RgnPuACWZedMc6xJlAofWJlJRrseffG\nS4z7Ubxt1gsvZ3TogLIM0K4KMde1Aw8iSPPU7bO3+LpWPZVuzYIY1xhi3uebtP3F\nNOE=\n-----END CERTIFICATE-----\n"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubernetes.io/description": "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. No other usage is guaranteed across distributions of Kubernetes clusters."
+                },
+                "creation_timestamp": "2024-01-31T19:38:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:ca.crt": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubernetes.io/description": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:38:03+00:00"
+                    }
+                ],
+                "name": "kube-root-ca.crt",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "356",
+                "self_link": null,
+                "uid": "1f637276-98b3-49ce-9323-417d593736c7"
+            }
+        }
+    },
+    "cron_job": {},
+    "daemon_set": {},
+    "deployment": {},
+    "endpoint": {
+        "kubernetes": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "endpointslice.kubernetes.io/skip-mirror": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:endpointslice.kubernetes.io/skip-mirror": {}
+                                }
+                            },
+                            "f:subsets": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "kubernetes",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "227",
+                "self_link": null,
+                "uid": "223b3ad0-88fe-449e-b60c-0f013a138945"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": null,
+                            "ip": "172.18.0.5",
+                            "node_name": null,
+                            "target_ref": null
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": [
+                        {
+                            "app_protocol": null,
+                            "name": "https",
+                            "port": 6443,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "ingress": {},
+    "job": {},
+    "network_policy": {},
+    "persistent_volume_claim": {},
+    "persistent_volume": {},
+    "pod": {},
+    "replica_set": {},
+    "role_binding": {},
+    "role": {},
+    "secret": {},
+    "service_account": {
+        "default": {
+            "api_version": null,
+            "automount_service_account_token": null,
+            "image_pull_secrets": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:38:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": null,
+                "name": "default",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "359",
+                "self_link": null,
+                "uid": "6c75d5f5-0824-45eb-9dfd-f73158221e23"
+            },
+            "secrets": null
+        }
+    },
+    "service": {
+        "kubernetes": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "component": "apiserver",
+                    "provider": "kubernetes"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:component": {},
+                                    "f:provider": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:clusterIP": {},
+                                "f:internalTrafficPolicy": {},
+                                "f:ipFamilyPolicy": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"port\":443,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    }
+                                },
+                                "f:sessionAffinity": {},
+                                "f:type": {}
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:49+00:00"
+                    }
+                ],
+                "name": "kubernetes",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "225",
+                "self_link": null,
+                "uid": "357fd823-01cb-45b0-99d7-32f27615a543"
+            },
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "10.96.0.1",
+                "cluster_i_ps": [
+                    "10.96.0.1"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": [
+                    {
+                        "app_protocol": null,
+                        "name": "https",
+                        "node_port": null,
+                        "port": 443,
+                        "protocol": "TCP",
+                        "target_port": 6443
+                    }
+                ],
+                "publish_not_ready_addresses": null,
+                "selector": null,
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
+        }
+    },
+    "stateful_set": {},
+    "storage_class": {
+        "standard": {
+            "allow_volume_expansion": null,
+            "allowed_topologies": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"storage.k8s.io/v1\",\"kind\":\"StorageClass\",\"metadata\":{\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"},\"name\":\"standard\"},\"provisioner\":\"rancher.io/local-path\",\"reclaimPolicy\":\"Delete\",\"volumeBindingMode\":\"WaitForFirstConsumer\"}\n",
+                    "storageclass.kubernetes.io/is-default-class": "true"
+                },
+                "creation_timestamp": "2024-01-31T19:37:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "storage.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:storageclass.kubernetes.io/is-default-class": {}
+                                }
+                            },
+                            "f:provisioner": {},
+                            "f:reclaimPolicy": {},
+                            "f:volumeBindingMode": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-01-31T19:37:55+00:00"
+                    }
+                ],
+                "name": "standard",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "309",
+                "self_link": null,
+                "uid": "6cc1c9dd-f3b8-4e35-9ebc-eda8fe3941bd"
+            },
+            "mount_options": null,
+            "parameters": null,
+            "provisioner": "rancher.io/local-path",
+            "reclaim_policy": "Delete",
+            "volume_binding_mode": "WaitForFirstConsumer"
+        }
+    }
+}

--- a/operators/kedacore_keda-olm-operator/yugm2_system_state.json
+++ b/operators/kedacore_keda-olm-operator/yugm2_system_state.json
@@ -7110,6 +7110,18 @@
                     {
                         "match_expressions": null,
                         "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-admin": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-admin": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
                             "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-admin": "true"
                         }
                     },
@@ -7123,18 +7135,6 @@
                         "match_expressions": null,
                         "match_labels": {
                             "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-admin": "true"
-                        }
-                    },
-                    {
-                        "match_expressions": null,
-                        "match_labels": {
-                            "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-admin": "true"
-                        }
-                    },
-                    {
-                        "match_expressions": null,
-                        "match_labels": {
-                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-admin": "true"
                         }
                     }
                 ]
@@ -7165,7 +7165,7 @@
                         "manager": "clusterrole-aggregation-controller",
                         "operation": "Apply",
                         "subresource": null,
-                        "time": "2024-02-05T06:07:57+00:00"
+                        "time": "2024-02-05T17:43:06+00:00"
                     },
                     {
                         "api_version": "rbac.authorization.k8s.io/v1",
@@ -7188,17 +7188,43 @@
                         "manager": "olm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-05T06:07:57+00:00"
+                        "time": "2024-02-05T17:43:06+00:00"
                     }
                 ],
                 "name": "olm.og.global-operators.admin-5UD4U2IfBGbw51Qy2Jaefk1uawvkj2OJILlc3w",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "1122632",
+                "resource_version": "1251985",
                 "self_link": null,
                 "uid": "638a1bdd-0f9a-4e41-8b57-744dc0a1d820"
             },
             "rules": [
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
                 {
                     "api_groups": [
                         "keda.sh"
@@ -7237,50 +7263,12 @@
                     "verbs": [
                         "*"
                     ]
-                },
-                {
-                    "api_groups": [
-                        "keda.sh"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": null,
-                    "resources": [
-                        "scaledobjects"
-                    ],
-                    "verbs": [
-                        "*"
-                    ]
-                },
-                {
-                    "api_groups": [
-                        "keda.sh"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": null,
-                    "resources": [
-                        "triggerauthentications"
-                    ],
-                    "verbs": [
-                        "*"
-                    ]
                 }
             ]
         },
         "olm.og.global-operators.edit-9ZbzBIwu1SlHO7KbWinNtOfyGaVjTWIYhNkNP": {
             "aggregation_rule": {
                 "cluster_role_selectors": [
-                    {
-                        "match_expressions": null,
-                        "match_labels": {
-                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-edit": "true"
-                        }
-                    },
-                    {
-                        "match_expressions": null,
-                        "match_labels": {
-                            "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-edit": "true"
-                        }
-                    },
                     {
                         "match_expressions": null,
                         "match_labels": {
@@ -7298,6 +7286,18 @@
                         "match_labels": {
                             "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-edit": "true"
                         }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-edit": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-610db0e36e2b7553-edit": "true"
+                        }
                     }
                 ]
             },
@@ -7327,7 +7327,7 @@
                         "manager": "clusterrole-aggregation-controller",
                         "operation": "Apply",
                         "subresource": null,
-                        "time": "2024-02-05T06:07:57+00:00"
+                        "time": "2024-02-05T17:43:06+00:00"
                     },
                     {
                         "api_version": "rbac.authorization.k8s.io/v1",
@@ -7350,49 +7350,17 @@
                         "manager": "olm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-05T06:07:57+00:00"
+                        "time": "2024-02-05T17:43:06+00:00"
                     }
                 ],
                 "name": "olm.og.global-operators.edit-9ZbzBIwu1SlHO7KbWinNtOfyGaVjTWIYhNkNP",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "1122637",
+                "resource_version": "1251987",
                 "self_link": null,
                 "uid": "b5205270-653e-43fb-9581-da9e55c6599f"
             },
             "rules": [
-                {
-                    "api_groups": [
-                        "keda.sh"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": null,
-                    "resources": [
-                        "triggerauthentications"
-                    ],
-                    "verbs": [
-                        "create",
-                        "update",
-                        "patch",
-                        "delete"
-                    ]
-                },
-                {
-                    "api_groups": [
-                        "keda.sh"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": null,
-                    "resources": [
-                        "clustertriggerauthentications"
-                    ],
-                    "verbs": [
-                        "create",
-                        "update",
-                        "patch",
-                        "delete"
-                    ]
-                },
                 {
                     "api_groups": [
                         "keda.sh"
@@ -7440,12 +7408,56 @@
                         "patch",
                         "delete"
                     ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustertriggerauthentications"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
                 }
             ]
         },
         "olm.og.global-operators.view-6lzJtrbG08ne4wrZHGxP3h1MBUjq5e7nOF4gax": {
             "aggregation_rule": {
                 "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-view": "true"
+                        }
+                    },
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-view": "true"
+                        }
+                    },
                     {
                         "match_expressions": null,
                         "match_labels": {
@@ -7462,18 +7474,6 @@
                         "match_expressions": null,
                         "match_labels": {
                             "olm.opgroup.permissions/aggregate-to-cebc826c59f4838-view": "true"
-                        }
-                    },
-                    {
-                        "match_expressions": null,
-                        "match_labels": {
-                            "olm.opgroup.permissions/aggregate-to-b5a385278ad0c97a-view": "true"
-                        }
-                    },
-                    {
-                        "match_expressions": null,
-                        "match_labels": {
-                            "olm.opgroup.permissions/aggregate-to-d5c32173553a738b-view": "true"
                         }
                     }
                 ]
@@ -7504,7 +7504,7 @@
                         "manager": "clusterrole-aggregation-controller",
                         "operation": "Apply",
                         "subresource": null,
-                        "time": "2024-02-05T06:07:57+00:00"
+                        "time": "2024-02-05T17:43:06+00:00"
                     },
                     {
                         "api_version": "rbac.authorization.k8s.io/v1",
@@ -7527,17 +7527,77 @@
                         "manager": "olm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-05T06:07:57+00:00"
+                        "time": "2024-02-05T17:43:06+00:00"
                     }
                 ],
                 "name": "olm.og.global-operators.view-6lzJtrbG08ne4wrZHGxP3h1MBUjq5e7nOF4gax",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "1122642",
+                "resource_version": "1251989",
                 "self_link": null,
                 "uid": "21a5e277-aa70-4def-b1f0-0b95937ea20d"
             },
             "rules": [
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "scaledobjects.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "scaledobjects"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "triggerauthentications.keda.sh"
+                    ],
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "keda.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "triggerauthentications"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
                 {
                     "api_groups": [
                         "apiextensions.k8s.io"
@@ -7621,66 +7681,6 @@
                     "resource_names": null,
                     "resources": [
                         "scaledjobs"
-                    ],
-                    "verbs": [
-                        "get",
-                        "list",
-                        "watch"
-                    ]
-                },
-                {
-                    "api_groups": [
-                        "apiextensions.k8s.io"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": [
-                        "scaledobjects.keda.sh"
-                    ],
-                    "resources": [
-                        "customresourcedefinitions"
-                    ],
-                    "verbs": [
-                        "get"
-                    ]
-                },
-                {
-                    "api_groups": [
-                        "keda.sh"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": null,
-                    "resources": [
-                        "scaledobjects"
-                    ],
-                    "verbs": [
-                        "get",
-                        "list",
-                        "watch"
-                    ]
-                },
-                {
-                    "api_groups": [
-                        "apiextensions.k8s.io"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": [
-                        "triggerauthentications.keda.sh"
-                    ],
-                    "resources": [
-                        "customresourcedefinitions"
-                    ],
-                    "verbs": [
-                        "get"
-                    ]
-                },
-                {
-                    "api_groups": [
-                        "keda.sh"
-                    ],
-                    "non_resource_ur_ls": null,
-                    "resource_names": null,
-                    "resources": [
-                        "triggerauthentications"
                     ],
                     "verbs": [
                         "get",
@@ -16728,7 +16728,7 @@
                 "annotations": {
                     "kubernetes.io/description": "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. No other usage is guaranteed across distributions of Kubernetes clusters."
                 },
-                "creation_timestamp": "2024-01-31T19:38:03+00:00",
+                "creation_timestamp": "2024-02-05T06:07:43+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -16754,35 +16754,2244 @@
                         "manager": "kube-controller-manager",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-01-31T19:38:03+00:00"
+                        "time": "2024-02-05T06:07:43+00:00"
                     }
                 ],
                 "name": "kube-root-ca.crt",
-                "namespace": "default",
+                "namespace": "keda",
                 "owner_references": null,
-                "resource_version": "356",
+                "resource_version": "1122372",
                 "self_link": null,
-                "uid": "1f637276-98b3-49ce-9323-417d593736c7"
+                "uid": "d7921ab6-0645-463f-957b-69d4eec05ac1"
             }
         }
     },
     "cron_job": {},
     "daemon_set": {},
-    "deployment": {},
-    "endpoint": {
-        "kubernetes": {
+    "deployment": {
+        "keda-admission": {
             "api_version": null,
             "kind": null,
             "metadata": {
-                "annotations": null,
-                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1",
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"keda-admission-webhooks\",\"app.kubernetes.io/component\":\"admission-webhooks\",\"app.kubernetes.io/name\":\"admission-webhooks\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-admission\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"keda-admission-webhooks\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"keda-admission-webhooks\",\"name\":\"keda-admission-webhooks\"},\"name\":\"keda-admission-webhooks\"},\"spec\":{\"containers\":[{\"args\":[\"--zap-log-level=info\",\"--zap-encoder=console\",\"--zap-time-encoding=rfc3339\"],\"command\":[\"/keda-admission-webhooks\"],\"env\":[{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"WATCH_NAMESPACE\",\"value\":\"\"},{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\",\"value\":\"\"}],\"image\":\"ghcr.io/kedacore/keda-admission-webhooks:2.12.0\",\"imagePullPolicy\":\"Always\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":8081},\"initialDelaySeconds\":25},\"name\":\"keda-admission-webhooks\",\"ports\":[{\"containerPort\":9443,\"name\":\"http\",\"protocol\":\"TCP\"},{\"containerPort\":8080,\"name\":\"metrics\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readyz\",\"port\":8081},\"initialDelaySeconds\":20},\"resources\":{\"limits\":{\"cpu\":\"1000m\",\"memory\":\"1000Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"readOnlyRootFilesystem\":true,\"runAsNonRoot\":true,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}},\"volumeMounts\":[{\"mountPath\":\"/certs\",\"name\":\"certificates\",\"readOnly\":true}]}],\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"},\"securityContext\":{\"runAsNonRoot\":true},\"serviceAccountName\":\"keda-operator\",\"terminationGracePeriodSeconds\":10,\"volumes\":[{\"name\":\"certificates\",\"secret\":{\"defaultMode\":420,\"secretName\":\"kedaorg-certs\"}}]}}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:56+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 2,
+                "labels": {
+                    "app": "keda-admission-webhooks",
+                    "app.kubernetes.io/component": "admission-webhooks",
+                    "app.kubernetes.io/name": "admission-webhooks",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {},
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-admission-webhooks\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    },
+                                                    "k:{\"containerPort\":9443,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:allowPrivilegeEscalation": {},
+                                                    "f:capabilities": {
+                                                        ".": {},
+                                                        "f:drop": {}
+                                                    },
+                                                    "f:readOnlyRootFilesystem": {},
+                                                    "f:runAsNonRoot": {},
+                                                    "f:seccompProfile": {
+                                                        ".": {},
+                                                        "f:type": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:nodeSelector": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsNonRoot": {}
+                                        },
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:59+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:47+00:00"
+                    }
+                ],
+                "name": "keda-admission",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122883",
+                "self_link": null,
+                "uid": "e1159784-5ce4-43e9-a364-49d6ddce8d87"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "paused": null,
+                "progress_deadline_seconds": 600,
+                "replicas": 1,
+                "revision_history_limit": 10,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "keda-admission-webhooks"
+                    }
+                },
+                "strategy": {
+                    "rolling_update": {
+                        "max_surge": "25%",
+                        "max_unavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "keda-admission-webhooks",
+                            "name": "keda-admission-webhooks"
+                        },
+                        "managed_fields": null,
+                        "name": "keda-admission-webhooks",
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "--zap-log-level=info",
+                                    "--zap-encoder=console",
+                                    "--zap-time-encoding=rfc3339"
+                                ],
+                                "command": [
+                                    "/keda-admission-webhooks"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                        "value": null,
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda-admission-webhooks:2.12.0",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 25,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-admission-webhooks",
+                                "ports": [
+                                    {
+                                        "container_port": 9443,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "metrics",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 20,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": false,
+                                    "capabilities": {
+                                        "add": null,
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    },
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": true,
+                                    "run_as_group": null,
+                                    "run_as_non_root": true,
+                                    "run_as_user": null,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": {
+                                        "localhost_profile": null,
+                                        "type": "RuntimeDefault"
+                                    },
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": {
+                            "kubernetes.io/os": "linux"
+                        },
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-operator",
+                        "service_account_name": "keda-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 10,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": null,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "collision_count": null,
+                "conditions": [
+                    {
+                        "last_transition_time": "2024-02-05T06:08:47+00:00",
+                        "last_update_time": "2024-02-05T06:08:47+00:00",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "last_transition_time": "2024-02-05T06:07:56+00:00",
+                        "last_update_time": "2024-02-05T06:08:47+00:00",
+                        "message": "ReplicaSet \"keda-admission-8478d9b4c8\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observed_generation": 2,
+                "ready_replicas": 1,
+                "replicas": 1,
+                "unavailable_replicas": null,
+                "updated_replicas": 1
+            }
+        },
+        "keda-metrics-apiserver": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1",
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"keda-metrics-apiserver\",\"app.kubernetes.io/name\":\"keda-metrics-apiserver\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-metrics-apiserver\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"keda-metrics-apiserver\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"keda-metrics-apiserver\"},\"name\":\"keda-metrics-apiserver\"},\"spec\":{\"containers\":[{\"args\":[\"/usr/local/bin/keda-adapter\",\"--secure-port=6443\",\"--logtostderr=true\",\"--stderrthreshold=ERROR\",\"--v=0\",\"--client-ca-file=/certs/ca.crt\",\"--tls-cert-file=/certs/tls.crt\",\"--tls-private-key-file=/certs/tls.key\",\"--cert-dir=/certs\"],\"env\":[{\"name\":\"WATCH_NAMESPACE\",\"value\":\"\"},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\",\"value\":\"\"}],\"image\":\"ghcr.io/kedacore/keda-metrics-apiserver:2.12.0\",\"imagePullPolicy\":\"Always\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":6443,\"scheme\":\"HTTPS\"},\"initialDelaySeconds\":5},\"name\":\"keda-metrics-apiserver\",\"ports\":[{\"containerPort\":6443,\"name\":\"https\"},{\"containerPort\":8080,\"name\":\"http\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readyz\",\"port\":6443,\"scheme\":\"HTTPS\"},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"1000m\",\"memory\":\"1000Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"readOnlyRootFilesystem\":true,\"runAsNonRoot\":true,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}},\"volumeMounts\":[{\"mountPath\":\"/tmp\",\"name\":\"temp-vol\"},{\"mountPath\":\"/certs\",\"name\":\"certificates\",\"readOnly\":true}]}],\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"},\"securityContext\":{\"runAsNonRoot\":true},\"serviceAccountName\":\"keda-operator\",\"volumes\":[{\"emptyDir\":{},\"name\":\"temp-vol\"},{\"name\":\"certificates\",\"secret\":{\"defaultMode\":420,\"secretName\":\"kedaorg-certs\"}}]}}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 2,
+                "labels": {
+                    "app": "keda-metrics-apiserver",
+                    "app.kubernetes.io/name": "keda-metrics-apiserver",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {},
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-metrics-apiserver\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":6443,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    },
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:allowPrivilegeEscalation": {},
+                                                    "f:capabilities": {
+                                                        ".": {},
+                                                        "f:drop": {}
+                                                    },
+                                                    "f:readOnlyRootFilesystem": {},
+                                                    "f:runAsNonRoot": {},
+                                                    "f:seccompProfile": {
+                                                        ".": {},
+                                                        "f:type": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/tmp\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:nodeSelector": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsNonRoot": {}
+                                        },
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"temp-vol\"}": {
+                                                ".": {},
+                                                "f:emptyDir": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:36+00:00"
+                    }
+                ],
+                "name": "keda-metrics-apiserver",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122845",
+                "self_link": null,
+                "uid": "c6f142e7-22e5-48cf-af35-8fde5edf021e"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "paused": null,
+                "progress_deadline_seconds": 600,
+                "replicas": 1,
+                "revision_history_limit": 10,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "keda-metrics-apiserver"
+                    }
+                },
+                "strategy": {
+                    "rolling_update": {
+                        "max_surge": "25%",
+                        "max_unavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "keda-metrics-apiserver"
+                        },
+                        "managed_fields": null,
+                        "name": "keda-metrics-apiserver",
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "/usr/local/bin/keda-adapter",
+                                    "--secure-port=6443",
+                                    "--logtostderr=true",
+                                    "--stderrthreshold=ERROR",
+                                    "--v=0",
+                                    "--client-ca-file=/certs/ca.crt",
+                                    "--tls-cert-file=/certs/tls.crt",
+                                    "--tls-private-key-file=/certs/tls.key",
+                                    "--cert-dir=/certs"
+                                ],
+                                "command": null,
+                                "env": [
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                        "value": null,
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda-metrics-apiserver:2.12.0",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 6443,
+                                        "scheme": "HTTPS"
+                                    },
+                                    "initial_delay_seconds": 5,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-metrics-apiserver",
+                                "ports": [
+                                    {
+                                        "container_port": 6443,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "https",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 6443,
+                                        "scheme": "HTTPS"
+                                    },
+                                    "initial_delay_seconds": 5,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": false,
+                                    "capabilities": {
+                                        "add": null,
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    },
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": true,
+                                    "run_as_group": null,
+                                    "run_as_non_root": true,
+                                    "run_as_user": null,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": {
+                                        "localhost_profile": null,
+                                        "type": "RuntimeDefault"
+                                    },
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/tmp",
+                                        "mount_propagation": null,
+                                        "name": "temp-vol",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": {
+                            "kubernetes.io/os": "linux"
+                        },
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-operator",
+                        "service_account_name": "keda-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 30,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": {
+                                    "medium": null,
+                                    "size_limit": null
+                                },
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "temp-vol",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": null,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "collision_count": null,
+                "conditions": [
+                    {
+                        "last_transition_time": "2024-02-05T06:08:36+00:00",
+                        "last_update_time": "2024-02-05T06:08:36+00:00",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "last_transition_time": "2024-02-05T06:07:55+00:00",
+                        "last_update_time": "2024-02-05T06:08:36+00:00",
+                        "message": "ReplicaSet \"keda-metrics-apiserver-775bcbbfc5\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observed_generation": 2,
+                "ready_replicas": 1,
+                "replicas": 1,
+                "unavailable_replicas": null,
+                "updated_replicas": 1
+            }
+        },
+        "keda-olm-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creation_timestamp": "2024-02-05T06:07:44+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app.kubernetes.io/part-of": "keda-olm-operator",
+                    "app.kubernetes.io/version": "main"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:app.kubernetes.io/version": {},
+                                            "f:name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-olm-operator\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    "f:httpGet": {
+                                                        "f:path": {},
+                                                        "f:port": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    "f:httpGet": {
+                                                        "f:path": {},
+                                                        "f:port": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    "f:limits": {
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:volumeMounts": {
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:serviceAccountName": {},
+                                        "f:volumes": {
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    "f:optional": {},
+                                                    "f:secretName": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:44+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:15+00:00"
+                    }
+                ],
+                "name": "keda-olm-operator",
+                "namespace": "keda",
+                "owner_references": null,
+                "resource_version": "1122760",
+                "self_link": null,
+                "uid": "5089ce68-e6a3-449d-91c6-b3de2226dc2f"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "paused": null,
+                "progress_deadline_seconds": 600,
+                "replicas": 1,
+                "revision_history_limit": 10,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app.kubernetes.io/part-of": "keda-olm-operator",
+                        "app.kubernetes.io/version": "main",
+                        "name": "keda-olm-operator"
+                    }
+                },
+                "strategy": {
+                    "rolling_update": {
+                        "max_surge": "25%",
+                        "max_unavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app.kubernetes.io/part-of": "keda-olm-operator",
+                            "app.kubernetes.io/version": "main",
+                            "name": "keda-olm-operator"
+                        },
+                        "managed_fields": null,
+                        "name": null,
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "--leader-elect",
+                                    "--zap-log-level=info",
+                                    "--zap-encoder=console",
+                                    "--zap-time-encoding=rfc3339"
+                                ],
+                                "command": [
+                                    "/manager"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": "keda",
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda-olm-operator:main",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 25,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-olm-operator",
+                                "ports": [
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 20,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "500m",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": null,
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": null,
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-olm-operator",
+                        "service_account_name": "keda-olm-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 30,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": true,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "collision_count": null,
+                "conditions": [
+                    {
+                        "last_transition_time": "2024-02-05T06:08:15+00:00",
+                        "last_update_time": "2024-02-05T06:08:15+00:00",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "last_transition_time": "2024-02-05T06:07:44+00:00",
+                        "last_update_time": "2024-02-05T06:08:15+00:00",
+                        "message": "ReplicaSet \"keda-olm-operator-b69d97969\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1,
+                "unavailable_replicas": null,
+                "updated_replicas": 1
+            }
+        },
+        "keda-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1",
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"keda-operator\",\"app.kubernetes.io/component\":\"operator\",\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"keda-operator\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"keda-operator\",\"name\":\"keda-operator\"},\"name\":\"keda-operator\"},\"spec\":{\"containers\":[{\"args\":[\"--leader-elect\",\"--zap-log-level=info\",\"--zap-encoder=console\",\"--zap-time-encoding=rfc3339\",\"--enable-cert-rotation=true\"],\"command\":[\"/keda\"],\"env\":[{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"WATCH_NAMESPACE\",\"value\":\"\"},{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\",\"value\":\"\"}],\"image\":\"ghcr.io/kedacore/keda:2.12.0\",\"imagePullPolicy\":\"Always\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":8081},\"initialDelaySeconds\":25},\"name\":\"keda-operator\",\"ports\":[{\"containerPort\":8080,\"name\":\"http\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readyz\",\"port\":8081},\"initialDelaySeconds\":20},\"resources\":{\"limits\":{\"cpu\":\"1000m\",\"memory\":\"1000Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"readOnlyRootFilesystem\":true,\"runAsNonRoot\":true,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}},\"volumeMounts\":[{\"mountPath\":\"/certs\",\"name\":\"certificates\",\"readOnly\":true}]}],\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"},\"securityContext\":{\"runAsNonRoot\":true},\"serviceAccountName\":\"keda-operator\",\"terminationGracePeriodSeconds\":10,\"volumes\":[{\"name\":\"certificates\",\"secret\":{\"defaultMode\":420,\"optional\":true,\"secretName\":\"kedaorg-certs\"}}]}}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 2,
+                "labels": {
+                    "app": "keda-operator",
+                    "app.kubernetes.io/component": "operator",
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {},
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-operator\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:allowPrivilegeEscalation": {},
+                                                    "f:capabilities": {
+                                                        ".": {},
+                                                        "f:drop": {}
+                                                    },
+                                                    "f:readOnlyRootFilesystem": {},
+                                                    "f:runAsNonRoot": {},
+                                                    "f:seccompProfile": {
+                                                        ".": {},
+                                                        "f:type": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:nodeSelector": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsNonRoot": {}
+                                        },
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:optional": {},
+                                                    "f:secretName": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:25+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122807",
+                "self_link": null,
+                "uid": "eeda5b2e-8878-4242-9f90-404b587edd94"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "paused": null,
+                "progress_deadline_seconds": 600,
+                "replicas": 1,
+                "revision_history_limit": 10,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "keda-operator"
+                    }
+                },
+                "strategy": {
+                    "rolling_update": {
+                        "max_surge": "25%",
+                        "max_unavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "keda-operator",
+                            "name": "keda-operator"
+                        },
+                        "managed_fields": null,
+                        "name": "keda-operator",
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "--leader-elect",
+                                    "--zap-log-level=info",
+                                    "--zap-encoder=console",
+                                    "--zap-time-encoding=rfc3339",
+                                    "--enable-cert-rotation=true"
+                                ],
+                                "command": [
+                                    "/keda"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                        "value": null,
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda:2.12.0",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 25,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-operator",
+                                "ports": [
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 20,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": false,
+                                    "capabilities": {
+                                        "add": null,
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    },
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": true,
+                                    "run_as_group": null,
+                                    "run_as_non_root": true,
+                                    "run_as_user": null,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": {
+                                        "localhost_profile": null,
+                                        "type": "RuntimeDefault"
+                                    },
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": {
+                            "kubernetes.io/os": "linux"
+                        },
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-operator",
+                        "service_account_name": "keda-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 10,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": true,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "collision_count": null,
+                "conditions": [
+                    {
+                        "last_transition_time": "2024-02-05T06:08:25+00:00",
+                        "last_update_time": "2024-02-05T06:08:25+00:00",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    },
+                    {
+                        "last_transition_time": "2024-02-05T06:07:55+00:00",
+                        "last_update_time": "2024-02-05T06:08:25+00:00",
+                        "message": "ReplicaSet \"keda-operator-7f6d47b59\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observed_generation": 2,
+                "ready_replicas": 1,
+                "replicas": 1,
+                "unavailable_replicas": null,
+                "updated_replicas": 1
+            }
+        }
+    },
+    "endpoint": {
+        "keda-admission-webhooks": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2024-02-05T06:08:46Z"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
                 "generate_name": null,
                 "generation": null,
                 "labels": {
-                    "endpointslice.kubernetes.io/skip-mirror": "true"
+                    "app.kubernetes.io/component": "admission-webhooks",
+                    "app.kubernetes.io/created-by": "keda",
+                    "app.kubernetes.io/instance": "admission-webhooks",
+                    "app.kubernetes.io/managed-by": "kustomize",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
                 },
                 "managed_fields": [
                     {
@@ -16790,42 +18999,237 @@
                         "fields_type": "FieldsV1",
                         "fields_v1": {
                             "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:endpoints.kubernetes.io/last-change-trigger-time": {}
+                                },
                                 "f:labels": {
                                     ".": {},
-                                    "f:endpointslice.kubernetes.io/skip-mirror": {}
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
                                 }
                             },
                             "f:subsets": {}
                         },
-                        "manager": "kube-apiserver",
+                        "manager": "kube-controller-manager",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-01-31T19:37:49+00:00"
+                        "time": "2024-02-05T06:08:47+00:00"
                     }
                 ],
-                "name": "kubernetes",
-                "namespace": "default",
+                "name": "keda-admission-webhooks",
+                "namespace": "keda",
                 "owner_references": null,
-                "resource_version": "227",
+                "resource_version": "1122881",
                 "self_link": null,
-                "uid": "223b3ad0-88fe-449e-b60c-0f013a138945"
+                "uid": "421605b0-2942-4781-bc86-2c33b3f6d656"
             },
             "subsets": [
                 {
                     "addresses": [
                         {
                             "hostname": null,
-                            "ip": "172.18.0.5",
-                            "node_name": null,
-                            "target_ref": null
+                            "ip": "10.244.1.10",
+                            "node_name": "kind-worker",
+                            "target_ref": {
+                                "api_version": null,
+                                "field_path": null,
+                                "kind": "Pod",
+                                "name": "keda-admission-8478d9b4c8-tkk97",
+                                "namespace": "keda",
+                                "resource_version": null,
+                                "uid": "6048e6f7-6e8f-48cb-bb0f-9a1067ac0919"
+                            }
                         }
                     ],
                     "not_ready_addresses": null,
                     "ports": [
                         {
                             "app_protocol": null,
+                            "name": "metrics",
+                            "port": 8080,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "http",
+                            "port": 9443,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
+        },
+        "keda-metrics-apiserver": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2024-02-05T06:08:36Z"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-metrics-apiserver",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:endpoints.kubernetes.io/last-change-trigger-time": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:subsets": {}
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:08:36+00:00"
+                    }
+                ],
+                "name": "keda-metrics-apiserver",
+                "namespace": "keda",
+                "owner_references": null,
+                "resource_version": "1122841",
+                "self_link": null,
+                "uid": "d96c0a2e-1672-4431-be47-257853a407d0"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": null,
+                            "ip": "10.244.3.109",
+                            "node_name": "kind-worker2",
+                            "target_ref": {
+                                "api_version": null,
+                                "field_path": null,
+                                "kind": "Pod",
+                                "name": "keda-metrics-apiserver-775bcbbfc5-rf8xk",
+                                "namespace": "keda",
+                                "resource_version": null,
+                                "uid": "27952a85-e28f-4481-bd80-22e8469fa155"
+                            }
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": [
+                        {
+                            "app_protocol": null,
+                            "name": "metrics",
+                            "port": 8080,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
                             "name": "https",
                             "port": 6443,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
+        },
+        "keda-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2024-02-05T06:08:25Z"
+                },
+                "creation_timestamp": "2024-02-05T06:07:54+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:endpoints.kubernetes.io/last-change-trigger-time": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            },
+                            "f:subsets": {}
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:08:25+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": "keda",
+                "owner_references": null,
+                "resource_version": "1122802",
+                "self_link": null,
+                "uid": "b1fcf65f-8258-4033-9507-16d101c0f942"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": null,
+                            "ip": "10.244.2.9",
+                            "node_name": "kind-worker3",
+                            "target_ref": {
+                                "api_version": null,
+                                "field_path": null,
+                                "kind": "Pod",
+                                "name": "keda-operator-7f6d47b59-4qlfg",
+                                "namespace": "keda",
+                                "resource_version": null,
+                                "uid": "2d7b74a6-8e20-41d7-9809-a144824f5a0f"
+                            }
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": [
+                        {
+                            "app_protocol": null,
+                            "name": "metrics",
+                            "port": 8080,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "metricsservice",
+                            "port": 9666,
                             "protocol": "TCP"
                         }
                     ]
@@ -16838,11 +19242,4902 @@
     "network_policy": {},
     "persistent_volume_claim": {},
     "persistent_volume": {},
-    "pod": {},
-    "replica_set": {},
-    "role_binding": {},
-    "role": {},
-    "secret": {},
+    "pod": {
+        "keda-admission-8478d9b4c8-tkk97": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:56+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": "keda-admission-8478d9b4c8-",
+                "generation": null,
+                "labels": {
+                    "app": "keda-admission-webhooks",
+                    "name": "keda-admission-webhooks",
+                    "pod-template-hash": "8478d9b4c8"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:generateName": {},
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:name": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"61ed42c3-e6da-47b9-a962-3571c4d4dcae\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"keda-admission-webhooks\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:livenessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            },
+                                            "k:{\"containerPort\":9443,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:readinessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:allowPrivilegeEscalation": {},
+                                            "f:capabilities": {
+                                                ".": {},
+                                                "f:drop": {}
+                                            },
+                                            "f:readOnlyRootFilesystem": {},
+                                            "f:runAsNonRoot": {},
+                                            "f:seccompProfile": {
+                                                ".": {},
+                                                "f:type": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/certs\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:nodeSelector": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {
+                                    ".": {},
+                                    "f:runAsNonRoot": {}
+                                },
+                                "f:serviceAccount": {},
+                                "f:serviceAccountName": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"certificates\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:56+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"ContainersReady\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Initialized\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:containerStatuses": {},
+                                "f:hostIP": {},
+                                "f:phase": {},
+                                "f:podIP": {},
+                                "f:podIPs": {
+                                    ".": {},
+                                    "k:{\"ip\":\"10.244.1.10\"}": {
+                                        ".": {},
+                                        "f:ip": {}
+                                    }
+                                },
+                                "f:startTime": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:46+00:00"
+                    }
+                ],
+                "name": "keda-admission-8478d9b4c8-tkk97",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "keda-admission-8478d9b4c8",
+                        "uid": "61ed42c3-e6da-47b9-a962-3571c4d4dcae"
+                    }
+                ],
+                "resource_version": "1122879",
+                "self_link": null,
+                "uid": "6048e6f7-6e8f-48cb-bb0f-9a1067ac0919"
+            },
+            "spec": {
+                "active_deadline_seconds": null,
+                "affinity": null,
+                "automount_service_account_token": null,
+                "containers": [
+                    {
+                        "args": [
+                            "--zap-log-level=info",
+                            "--zap-encoder=console",
+                            "--zap-time-encoding=rfc3339"
+                        ],
+                        "command": [
+                            "/keda-admission-webhooks"
+                        ],
+                        "env": [
+                            {
+                                "name": "POD_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "WATCH_NAMESPACE",
+                                "value": null,
+                                "value_from": null
+                            },
+                            {
+                                "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                "value": null,
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": null,
+                        "image": "ghcr.io/kedacore/keda-admission-webhooks:2.12.0",
+                        "image_pull_policy": "Always",
+                        "lifecycle": null,
+                        "liveness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/healthz",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initial_delay_seconds": 25,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "name": "keda-admission-webhooks",
+                        "ports": [
+                            {
+                                "container_port": 9443,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "http",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "container_port": 8080,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/readyz",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initial_delay_seconds": 20,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1000Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "100Mi"
+                            }
+                        },
+                        "security_context": {
+                            "allow_privilege_escalation": false,
+                            "capabilities": {
+                                "add": null,
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": null,
+                            "proc_mount": null,
+                            "read_only_root_filesystem": true,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": {
+                                "localhost_profile": null,
+                                "type": "RuntimeDefault"
+                            },
+                            "windows_options": null
+                        },
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/certs",
+                                "mount_propagation": null,
+                                "name": "certificates",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-7srn9",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    }
+                ],
+                "dns_config": null,
+                "dns_policy": "ClusterFirst",
+                "enable_service_links": true,
+                "ephemeral_containers": null,
+                "host_aliases": null,
+                "host_ipc": null,
+                "host_network": null,
+                "host_pid": null,
+                "host_users": null,
+                "hostname": null,
+                "image_pull_secrets": null,
+                "init_containers": null,
+                "node_name": "kind-worker",
+                "node_selector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "os": null,
+                "overhead": null,
+                "preemption_policy": "PreemptLowerPriority",
+                "priority": 0,
+                "priority_class_name": null,
+                "readiness_gates": null,
+                "resource_claims": null,
+                "restart_policy": "Always",
+                "runtime_class_name": null,
+                "scheduler_name": "default-scheduler",
+                "scheduling_gates": null,
+                "security_context": {
+                    "fs_group": null,
+                    "fs_group_change_policy": null,
+                    "run_as_group": null,
+                    "run_as_non_root": true,
+                    "run_as_user": null,
+                    "se_linux_options": null,
+                    "seccomp_profile": null,
+                    "supplemental_groups": null,
+                    "sysctls": null,
+                    "windows_options": null
+                },
+                "service_account": "keda-operator",
+                "service_account_name": "keda-operator",
+                "set_hostname_as_fqdn": null,
+                "share_process_namespace": null,
+                "subdomain": null,
+                "termination_grace_period_seconds": 10,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    }
+                ],
+                "topology_spread_constraints": null,
+                "volumes": [
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "certificates",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": {
+                            "default_mode": 420,
+                            "items": null,
+                            "optional": null,
+                            "secret_name": "kedaorg-certs"
+                        },
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-7srn9",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": {
+                            "default_mode": 420,
+                            "sources": [
+                                {
+                                    "config_map": null,
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": {
+                                        "audience": null,
+                                        "expiration_seconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "config_map": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "mode": null,
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt",
+                                        "optional": null
+                                    },
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": null
+                                },
+                                {
+                                    "config_map": null,
+                                    "downward_api": {
+                                        "items": [
+                                            {
+                                                "field_ref": {
+                                                    "api_version": "v1",
+                                                    "field_path": "metadata.namespace"
+                                                },
+                                                "mode": null,
+                                                "path": "namespace",
+                                                "resource_field_ref": null
+                                            }
+                                        ]
+                                    },
+                                    "secret": null,
+                                    "service_account_token": null
+                                }
+                            ]
+                        },
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:56+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:46+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:46+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:56+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "container_statuses": [
+                    {
+                        "container_id": "containerd://327e6561419dbea14ab01d00b86485ec994cbbdb65a65d72a30e06119088506e",
+                        "image": "ghcr.io/kedacore/keda-admission-webhooks:2.12.0",
+                        "image_id": "ghcr.io/kedacore/keda-admission-webhooks@sha256:0668bee4ebdb42fdce10ae05baee1eabd97b67418f997b07849c1e9724db7ba0",
+                        "last_state": {
+                            "running": null,
+                            "terminated": {
+                                "container_id": "containerd://bb95839b277b45a76778e24d3d315a110d2d666d174be4bea2c68e2b796207f2",
+                                "exit_code": 1,
+                                "finished_at": "2024-02-05T06:08:03+00:00",
+                                "message": null,
+                                "reason": "Error",
+                                "signal": null,
+                                "started_at": "2024-02-05T06:08:03+00:00"
+                            },
+                            "waiting": null
+                        },
+                        "name": "keda-admission-webhooks",
+                        "ready": true,
+                        "restart_count": 2,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-05T06:08:21+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    }
+                ],
+                "ephemeral_container_statuses": null,
+                "host_ip": "172.18.0.2",
+                "init_container_statuses": null,
+                "message": null,
+                "nominated_node_name": null,
+                "phase": "Running",
+                "pod_ip": "10.244.1.10",
+                "pod_i_ps": [
+                    {
+                        "ip": "10.244.1.10"
+                    }
+                ],
+                "qos_class": "Burstable",
+                "reason": null,
+                "start_time": "2024-02-05T06:07:56+00:00"
+            }
+        },
+        "keda-metrics-apiserver-775bcbbfc5-rf8xk": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": "keda-metrics-apiserver-775bcbbfc5-",
+                "generation": null,
+                "labels": {
+                    "app": "keda-metrics-apiserver",
+                    "pod-template-hash": "775bcbbfc5"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:generateName": {},
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"4b3abc93-d6e5-40db-a2b4-0cf2dd43d911\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"keda-metrics-apiserver\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:livenessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":6443,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            },
+                                            "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:readinessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:allowPrivilegeEscalation": {},
+                                            "f:capabilities": {
+                                                ".": {},
+                                                "f:drop": {}
+                                            },
+                                            "f:readOnlyRootFilesystem": {},
+                                            "f:runAsNonRoot": {},
+                                            "f:seccompProfile": {
+                                                ".": {},
+                                                "f:type": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/certs\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/tmp\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:nodeSelector": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {
+                                    ".": {},
+                                    "f:runAsNonRoot": {}
+                                },
+                                "f:serviceAccount": {},
+                                "f:serviceAccountName": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"certificates\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"temp-vol\"}": {
+                                        ".": {},
+                                        "f:emptyDir": {},
+                                        "f:name": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:55+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"ContainersReady\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Initialized\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:containerStatuses": {},
+                                "f:hostIP": {},
+                                "f:phase": {},
+                                "f:podIP": {},
+                                "f:podIPs": {
+                                    ".": {},
+                                    "k:{\"ip\":\"10.244.3.109\"}": {
+                                        ".": {},
+                                        "f:ip": {}
+                                    }
+                                },
+                                "f:startTime": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:36+00:00"
+                    }
+                ],
+                "name": "keda-metrics-apiserver-775bcbbfc5-rf8xk",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "keda-metrics-apiserver-775bcbbfc5",
+                        "uid": "4b3abc93-d6e5-40db-a2b4-0cf2dd43d911"
+                    }
+                ],
+                "resource_version": "1122840",
+                "self_link": null,
+                "uid": "27952a85-e28f-4481-bd80-22e8469fa155"
+            },
+            "spec": {
+                "active_deadline_seconds": null,
+                "affinity": null,
+                "automount_service_account_token": null,
+                "containers": [
+                    {
+                        "args": [
+                            "/usr/local/bin/keda-adapter",
+                            "--secure-port=6443",
+                            "--logtostderr=true",
+                            "--stderrthreshold=ERROR",
+                            "--v=0",
+                            "--client-ca-file=/certs/ca.crt",
+                            "--tls-cert-file=/certs/tls.crt",
+                            "--tls-private-key-file=/certs/tls.key",
+                            "--cert-dir=/certs"
+                        ],
+                        "command": null,
+                        "env": [
+                            {
+                                "name": "WATCH_NAMESPACE",
+                                "value": null,
+                                "value_from": null
+                            },
+                            {
+                                "name": "POD_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                "value": null,
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": null,
+                        "image": "ghcr.io/kedacore/keda-metrics-apiserver:2.12.0",
+                        "image_pull_policy": "Always",
+                        "lifecycle": null,
+                        "liveness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/healthz",
+                                "port": 6443,
+                                "scheme": "HTTPS"
+                            },
+                            "initial_delay_seconds": 5,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "name": "keda-metrics-apiserver",
+                        "ports": [
+                            {
+                                "container_port": 6443,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "https",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "container_port": 8080,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "http",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/readyz",
+                                "port": 6443,
+                                "scheme": "HTTPS"
+                            },
+                            "initial_delay_seconds": 5,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1000Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "100Mi"
+                            }
+                        },
+                        "security_context": {
+                            "allow_privilege_escalation": false,
+                            "capabilities": {
+                                "add": null,
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": null,
+                            "proc_mount": null,
+                            "read_only_root_filesystem": true,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": {
+                                "localhost_profile": null,
+                                "type": "RuntimeDefault"
+                            },
+                            "windows_options": null
+                        },
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/tmp",
+                                "mount_propagation": null,
+                                "name": "temp-vol",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/certs",
+                                "mount_propagation": null,
+                                "name": "certificates",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-g4gt4",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    }
+                ],
+                "dns_config": null,
+                "dns_policy": "ClusterFirst",
+                "enable_service_links": true,
+                "ephemeral_containers": null,
+                "host_aliases": null,
+                "host_ipc": null,
+                "host_network": null,
+                "host_pid": null,
+                "host_users": null,
+                "hostname": null,
+                "image_pull_secrets": null,
+                "init_containers": null,
+                "node_name": "kind-worker2",
+                "node_selector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "os": null,
+                "overhead": null,
+                "preemption_policy": "PreemptLowerPriority",
+                "priority": 0,
+                "priority_class_name": null,
+                "readiness_gates": null,
+                "resource_claims": null,
+                "restart_policy": "Always",
+                "runtime_class_name": null,
+                "scheduler_name": "default-scheduler",
+                "scheduling_gates": null,
+                "security_context": {
+                    "fs_group": null,
+                    "fs_group_change_policy": null,
+                    "run_as_group": null,
+                    "run_as_non_root": true,
+                    "run_as_user": null,
+                    "se_linux_options": null,
+                    "seccomp_profile": null,
+                    "supplemental_groups": null,
+                    "sysctls": null,
+                    "windows_options": null
+                },
+                "service_account": "keda-operator",
+                "service_account_name": "keda-operator",
+                "set_hostname_as_fqdn": null,
+                "share_process_namespace": null,
+                "subdomain": null,
+                "termination_grace_period_seconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    }
+                ],
+                "topology_spread_constraints": null,
+                "volumes": [
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": {
+                            "medium": null,
+                            "size_limit": null
+                        },
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "temp-vol",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "certificates",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": {
+                            "default_mode": 420,
+                            "items": null,
+                            "optional": null,
+                            "secret_name": "kedaorg-certs"
+                        },
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-g4gt4",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": {
+                            "default_mode": 420,
+                            "sources": [
+                                {
+                                    "config_map": null,
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": {
+                                        "audience": null,
+                                        "expiration_seconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "config_map": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "mode": null,
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt",
+                                        "optional": null
+                                    },
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": null
+                                },
+                                {
+                                    "config_map": null,
+                                    "downward_api": {
+                                        "items": [
+                                            {
+                                                "field_ref": {
+                                                    "api_version": "v1",
+                                                    "field_path": "metadata.namespace"
+                                                },
+                                                "mode": null,
+                                                "path": "namespace",
+                                                "resource_field_ref": null
+                                            }
+                                        ]
+                                    },
+                                    "secret": null,
+                                    "service_account_token": null
+                                }
+                            ]
+                        },
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:55+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:36+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:36+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:55+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "container_statuses": [
+                    {
+                        "container_id": "containerd://8655fb6773f89e1fff1d03e2812b1b8a5a0fac5358e23dbcbfd030c809c9cf99",
+                        "image": "ghcr.io/kedacore/keda-metrics-apiserver:2.12.0",
+                        "image_id": "ghcr.io/kedacore/keda-metrics-apiserver@sha256:1c254dcf859b93bbcaa532fcb5d6de5ff14b67f904a7ae1068ab1dbc19f60479",
+                        "last_state": {
+                            "running": null,
+                            "terminated": {
+                                "container_id": "containerd://a5d42872f30c3b11553163205213b7e675bfe2d958f7cec0abc5e1648652bddb",
+                                "exit_code": 0,
+                                "finished_at": "2024-02-05T06:08:03+00:00",
+                                "message": null,
+                                "reason": "Completed",
+                                "signal": null,
+                                "started_at": "2024-02-05T06:08:03+00:00"
+                            },
+                            "waiting": null
+                        },
+                        "name": "keda-metrics-apiserver",
+                        "ready": true,
+                        "restart_count": 2,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-05T06:08:22+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    }
+                ],
+                "ephemeral_container_statuses": null,
+                "host_ip": "172.18.0.4",
+                "init_container_statuses": null,
+                "message": null,
+                "nominated_node_name": null,
+                "phase": "Running",
+                "pod_ip": "10.244.3.109",
+                "pod_i_ps": [
+                    {
+                        "ip": "10.244.3.109"
+                    }
+                ],
+                "qos_class": "Burstable",
+                "reason": null,
+                "start_time": "2024-02-05T06:07:55+00:00"
+            }
+        },
+        "keda-olm-operator-b69d97969-85r7p": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:44+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": "keda-olm-operator-b69d97969-",
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/part-of": "keda-olm-operator",
+                    "app.kubernetes.io/version": "main",
+                    "name": "keda-olm-operator",
+                    "pod-template-hash": "b69d97969"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:generateName": {},
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:name": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"b1a18774-bfd3-4739-b75c-cc2baa9f4701\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"keda-olm-operator\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:livenessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:readinessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/certs\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {},
+                                "f:serviceAccount": {},
+                                "f:serviceAccountName": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"certificates\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:optional": {},
+                                            "f:secretName": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:44+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"ContainersReady\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Initialized\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:containerStatuses": {},
+                                "f:hostIP": {},
+                                "f:phase": {},
+                                "f:podIP": {},
+                                "f:podIPs": {
+                                    ".": {},
+                                    "k:{\"ip\":\"10.244.3.108\"}": {
+                                        ".": {},
+                                        "f:ip": {}
+                                    }
+                                },
+                                "f:startTime": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:15+00:00"
+                    }
+                ],
+                "name": "keda-olm-operator-b69d97969-85r7p",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "keda-olm-operator-b69d97969",
+                        "uid": "b1a18774-bfd3-4739-b75c-cc2baa9f4701"
+                    }
+                ],
+                "resource_version": "1122757",
+                "self_link": null,
+                "uid": "7ace3299-0a93-44f1-95c8-c28586ab159b"
+            },
+            "spec": {
+                "active_deadline_seconds": null,
+                "affinity": null,
+                "automount_service_account_token": null,
+                "containers": [
+                    {
+                        "args": [
+                            "--leader-elect",
+                            "--zap-log-level=info",
+                            "--zap-encoder=console",
+                            "--zap-time-encoding=rfc3339"
+                        ],
+                        "command": [
+                            "/manager"
+                        ],
+                        "env": [
+                            {
+                                "name": "WATCH_NAMESPACE",
+                                "value": "keda",
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": null,
+                        "image": "ghcr.io/kedacore/keda-olm-operator:main",
+                        "image_pull_policy": "Always",
+                        "lifecycle": null,
+                        "liveness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/healthz",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initial_delay_seconds": 25,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "name": "keda-olm-operator",
+                        "ports": [
+                            {
+                                "container_port": 8080,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "http",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/readyz",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initial_delay_seconds": 20,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "500m",
+                                "memory": "1000Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "100Mi"
+                            }
+                        },
+                        "security_context": null,
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/certs",
+                                "mount_propagation": null,
+                                "name": "certificates",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-wjxtr",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    }
+                ],
+                "dns_config": null,
+                "dns_policy": "ClusterFirst",
+                "enable_service_links": true,
+                "ephemeral_containers": null,
+                "host_aliases": null,
+                "host_ipc": null,
+                "host_network": null,
+                "host_pid": null,
+                "host_users": null,
+                "hostname": null,
+                "image_pull_secrets": null,
+                "init_containers": null,
+                "node_name": "kind-worker2",
+                "node_selector": null,
+                "os": null,
+                "overhead": null,
+                "preemption_policy": "PreemptLowerPriority",
+                "priority": 0,
+                "priority_class_name": null,
+                "readiness_gates": null,
+                "resource_claims": null,
+                "restart_policy": "Always",
+                "runtime_class_name": null,
+                "scheduler_name": "default-scheduler",
+                "scheduling_gates": null,
+                "security_context": {
+                    "fs_group": null,
+                    "fs_group_change_policy": null,
+                    "run_as_group": null,
+                    "run_as_non_root": null,
+                    "run_as_user": null,
+                    "se_linux_options": null,
+                    "seccomp_profile": null,
+                    "supplemental_groups": null,
+                    "sysctls": null,
+                    "windows_options": null
+                },
+                "service_account": "keda-olm-operator",
+                "service_account_name": "keda-olm-operator",
+                "set_hostname_as_fqdn": null,
+                "share_process_namespace": null,
+                "subdomain": null,
+                "termination_grace_period_seconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    }
+                ],
+                "topology_spread_constraints": null,
+                "volumes": [
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "certificates",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": {
+                            "default_mode": 420,
+                            "items": null,
+                            "optional": true,
+                            "secret_name": "kedaorg-certs"
+                        },
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-wjxtr",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": {
+                            "default_mode": 420,
+                            "sources": [
+                                {
+                                    "config_map": null,
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": {
+                                        "audience": null,
+                                        "expiration_seconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "config_map": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "mode": null,
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt",
+                                        "optional": null
+                                    },
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": null
+                                },
+                                {
+                                    "config_map": null,
+                                    "downward_api": {
+                                        "items": [
+                                            {
+                                                "field_ref": {
+                                                    "api_version": "v1",
+                                                    "field_path": "metadata.namespace"
+                                                },
+                                                "mode": null,
+                                                "path": "namespace",
+                                                "resource_field_ref": null
+                                            }
+                                        ]
+                                    },
+                                    "secret": null,
+                                    "service_account_token": null
+                                }
+                            ]
+                        },
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:45+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:15+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:15+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:45+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "container_statuses": [
+                    {
+                        "container_id": "containerd://99a05beb7ce0c8475d134c7cebc9a5524d77ca9a9c7baa594f51e927e35ce259",
+                        "image": "ghcr.io/kedacore/keda-olm-operator:main",
+                        "image_id": "ghcr.io/kedacore/keda-olm-operator@sha256:392248719704ce03164f8fba0f026c92aa915c8afea834c22138ef58941a3854",
+                        "last_state": {
+                            "running": null,
+                            "terminated": null,
+                            "waiting": null
+                        },
+                        "name": "keda-olm-operator",
+                        "ready": true,
+                        "restart_count": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-05T06:07:47+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    }
+                ],
+                "ephemeral_container_statuses": null,
+                "host_ip": "172.18.0.4",
+                "init_container_statuses": null,
+                "message": null,
+                "nominated_node_name": null,
+                "phase": "Running",
+                "pod_ip": "10.244.3.108",
+                "pod_i_ps": [
+                    {
+                        "ip": "10.244.3.108"
+                    }
+                ],
+                "qos_class": "Burstable",
+                "reason": null,
+                "start_time": "2024-02-05T06:07:45+00:00"
+            }
+        },
+        "keda-operator-7f6d47b59-4qlfg": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": "keda-operator-7f6d47b59-",
+                "generation": null,
+                "labels": {
+                    "app": "keda-operator",
+                    "name": "keda-operator",
+                    "pod-template-hash": "7f6d47b59"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:generateName": {},
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:name": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"f7e1d20e-709c-438d-9110-4da4afadea65\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"keda-operator\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:livenessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:readinessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:initialDelaySeconds": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:allowPrivilegeEscalation": {},
+                                            "f:capabilities": {
+                                                ".": {},
+                                                "f:drop": {}
+                                            },
+                                            "f:readOnlyRootFilesystem": {},
+                                            "f:runAsNonRoot": {},
+                                            "f:seccompProfile": {
+                                                ".": {},
+                                                "f:type": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/certs\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:nodeSelector": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {
+                                    ".": {},
+                                    "f:runAsNonRoot": {}
+                                },
+                                "f:serviceAccount": {},
+                                "f:serviceAccountName": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"certificates\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:optional": {},
+                                            "f:secretName": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:55+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"ContainersReady\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Initialized\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:containerStatuses": {},
+                                "f:hostIP": {},
+                                "f:phase": {},
+                                "f:podIP": {},
+                                "f:podIPs": {
+                                    ".": {},
+                                    "k:{\"ip\":\"10.244.2.9\"}": {
+                                        ".": {},
+                                        "f:ip": {}
+                                    }
+                                },
+                                "f:startTime": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:25+00:00"
+                    }
+                ],
+                "name": "keda-operator-7f6d47b59-4qlfg",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "keda-operator-7f6d47b59",
+                        "uid": "f7e1d20e-709c-438d-9110-4da4afadea65"
+                    }
+                ],
+                "resource_version": "1122801",
+                "self_link": null,
+                "uid": "2d7b74a6-8e20-41d7-9809-a144824f5a0f"
+            },
+            "spec": {
+                "active_deadline_seconds": null,
+                "affinity": null,
+                "automount_service_account_token": null,
+                "containers": [
+                    {
+                        "args": [
+                            "--leader-elect",
+                            "--zap-log-level=info",
+                            "--zap-encoder=console",
+                            "--zap-time-encoding=rfc3339",
+                            "--enable-cert-rotation=true"
+                        ],
+                        "command": [
+                            "/keda"
+                        ],
+                        "env": [
+                            {
+                                "name": "POD_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "WATCH_NAMESPACE",
+                                "value": null,
+                                "value_from": null
+                            },
+                            {
+                                "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                "value": null,
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": null,
+                        "image": "ghcr.io/kedacore/keda:2.12.0",
+                        "image_pull_policy": "Always",
+                        "lifecycle": null,
+                        "liveness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/healthz",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initial_delay_seconds": 25,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "name": "keda-operator",
+                        "ports": [
+                            {
+                                "container_port": 8080,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "http",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/readyz",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initial_delay_seconds": 20,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1000Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "100Mi"
+                            }
+                        },
+                        "security_context": {
+                            "allow_privilege_escalation": false,
+                            "capabilities": {
+                                "add": null,
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": null,
+                            "proc_mount": null,
+                            "read_only_root_filesystem": true,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": {
+                                "localhost_profile": null,
+                                "type": "RuntimeDefault"
+                            },
+                            "windows_options": null
+                        },
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/certs",
+                                "mount_propagation": null,
+                                "name": "certificates",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-szv84",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    }
+                ],
+                "dns_config": null,
+                "dns_policy": "ClusterFirst",
+                "enable_service_links": true,
+                "ephemeral_containers": null,
+                "host_aliases": null,
+                "host_ipc": null,
+                "host_network": null,
+                "host_pid": null,
+                "host_users": null,
+                "hostname": null,
+                "image_pull_secrets": null,
+                "init_containers": null,
+                "node_name": "kind-worker3",
+                "node_selector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "os": null,
+                "overhead": null,
+                "preemption_policy": "PreemptLowerPriority",
+                "priority": 0,
+                "priority_class_name": null,
+                "readiness_gates": null,
+                "resource_claims": null,
+                "restart_policy": "Always",
+                "runtime_class_name": null,
+                "scheduler_name": "default-scheduler",
+                "scheduling_gates": null,
+                "security_context": {
+                    "fs_group": null,
+                    "fs_group_change_policy": null,
+                    "run_as_group": null,
+                    "run_as_non_root": true,
+                    "run_as_user": null,
+                    "se_linux_options": null,
+                    "seccomp_profile": null,
+                    "supplemental_groups": null,
+                    "sysctls": null,
+                    "windows_options": null
+                },
+                "service_account": "keda-operator",
+                "service_account_name": "keda-operator",
+                "set_hostname_as_fqdn": null,
+                "share_process_namespace": null,
+                "subdomain": null,
+                "termination_grace_period_seconds": 10,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    }
+                ],
+                "topology_spread_constraints": null,
+                "volumes": [
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "certificates",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": {
+                            "default_mode": 420,
+                            "items": null,
+                            "optional": true,
+                            "secret_name": "kedaorg-certs"
+                        },
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-szv84",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": {
+                            "default_mode": 420,
+                            "sources": [
+                                {
+                                    "config_map": null,
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": {
+                                        "audience": null,
+                                        "expiration_seconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "config_map": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "mode": null,
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt",
+                                        "optional": null
+                                    },
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": null
+                                },
+                                {
+                                    "config_map": null,
+                                    "downward_api": {
+                                        "items": [
+                                            {
+                                                "field_ref": {
+                                                    "api_version": "v1",
+                                                    "field_path": "metadata.namespace"
+                                                },
+                                                "mode": null,
+                                                "path": "namespace",
+                                                "resource_field_ref": null
+                                            }
+                                        ]
+                                    },
+                                    "secret": null,
+                                    "service_account_token": null
+                                }
+                            ]
+                        },
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:55+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:25+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:08:25+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-05T06:07:55+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "container_statuses": [
+                    {
+                        "container_id": "containerd://1dfb67f1c943f92fa88849c80679d58621359c60bee4de99c1770ec40124a8b2",
+                        "image": "ghcr.io/kedacore/keda:2.12.0",
+                        "image_id": "ghcr.io/kedacore/keda@sha256:01a232774016f186ff91983521323a80ead047b42d695fc0236b43c296b6cff8",
+                        "last_state": {
+                            "running": null,
+                            "terminated": {
+                                "container_id": "containerd://da06bd1bac02e1495662baf1c8b80a1d8e25d37ca210db062d590e1c9efa6f72",
+                                "exit_code": 0,
+                                "finished_at": "2024-02-05T06:08:01+00:00",
+                                "message": null,
+                                "reason": "Completed",
+                                "signal": null,
+                                "started_at": "2024-02-05T06:07:58+00:00"
+                            },
+                            "waiting": null
+                        },
+                        "name": "keda-operator",
+                        "ready": true,
+                        "restart_count": 1,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-05T06:08:04+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    }
+                ],
+                "ephemeral_container_statuses": null,
+                "host_ip": "172.18.0.3",
+                "init_container_statuses": null,
+                "message": null,
+                "nominated_node_name": null,
+                "phase": "Running",
+                "pod_ip": "10.244.2.9",
+                "pod_i_ps": [
+                    {
+                        "ip": "10.244.2.9"
+                    }
+                ],
+                "qos_class": "Burstable",
+                "reason": null,
+                "start_time": "2024-02-05T06:07:55+00:00"
+            }
+        }
+    },
+    "replica_set": {
+        "keda-admission-8478d9b4c8": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/desired-replicas": "1",
+                    "deployment.kubernetes.io/max-replicas": "2",
+                    "deployment.kubernetes.io/revision": "1",
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"keda-admission-webhooks\",\"app.kubernetes.io/component\":\"admission-webhooks\",\"app.kubernetes.io/name\":\"admission-webhooks\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-admission\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"keda-admission-webhooks\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"keda-admission-webhooks\",\"name\":\"keda-admission-webhooks\"},\"name\":\"keda-admission-webhooks\"},\"spec\":{\"containers\":[{\"args\":[\"--zap-log-level=info\",\"--zap-encoder=console\",\"--zap-time-encoding=rfc3339\"],\"command\":[\"/keda-admission-webhooks\"],\"env\":[{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"WATCH_NAMESPACE\",\"value\":\"\"},{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\",\"value\":\"\"}],\"image\":\"ghcr.io/kedacore/keda-admission-webhooks:2.12.0\",\"imagePullPolicy\":\"Always\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":8081},\"initialDelaySeconds\":25},\"name\":\"keda-admission-webhooks\",\"ports\":[{\"containerPort\":9443,\"name\":\"http\",\"protocol\":\"TCP\"},{\"containerPort\":8080,\"name\":\"metrics\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readyz\",\"port\":8081},\"initialDelaySeconds\":20},\"resources\":{\"limits\":{\"cpu\":\"1000m\",\"memory\":\"1000Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"readOnlyRootFilesystem\":true,\"runAsNonRoot\":true,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}},\"volumeMounts\":[{\"mountPath\":\"/certs\",\"name\":\"certificates\",\"readOnly\":true}]}],\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"},\"securityContext\":{\"runAsNonRoot\":true},\"serviceAccountName\":\"keda-operator\",\"terminationGracePeriodSeconds\":10,\"volumes\":[{\"name\":\"certificates\",\"secret\":{\"defaultMode\":420,\"secretName\":\"kedaorg-certs\"}}]}}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:56+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app": "keda-admission-webhooks",
+                    "name": "keda-admission-webhooks",
+                    "pod-template-hash": "8478d9b4c8"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/desired-replicas": {},
+                                    "f:deployment.kubernetes.io/max-replicas": {},
+                                    "f:deployment.kubernetes.io/revision": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:name": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"e1159784-5ce4-43e9-a364-49d6ddce8d87\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:name": {},
+                                            "f:pod-template-hash": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-admission-webhooks\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    },
+                                                    "k:{\"containerPort\":9443,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:allowPrivilegeEscalation": {},
+                                                    "f:capabilities": {
+                                                        ".": {},
+                                                        "f:drop": {}
+                                                    },
+                                                    "f:readOnlyRootFilesystem": {},
+                                                    "f:runAsNonRoot": {},
+                                                    "f:seccompProfile": {
+                                                        ".": {},
+                                                        "f:type": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:nodeSelector": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsNonRoot": {}
+                                        },
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:59+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:fullyLabeledReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:47+00:00"
+                    }
+                ],
+                "name": "keda-admission-8478d9b4c8",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Deployment",
+                        "name": "keda-admission",
+                        "uid": "e1159784-5ce4-43e9-a364-49d6ddce8d87"
+                    }
+                ],
+                "resource_version": "1122882",
+                "self_link": null,
+                "uid": "61ed42c3-e6da-47b9-a962-3571c4d4dcae"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "replicas": 1,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "keda-admission-webhooks",
+                        "pod-template-hash": "8478d9b4c8"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "keda-admission-webhooks",
+                            "name": "keda-admission-webhooks",
+                            "pod-template-hash": "8478d9b4c8"
+                        },
+                        "managed_fields": null,
+                        "name": "keda-admission-webhooks",
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "--zap-log-level=info",
+                                    "--zap-encoder=console",
+                                    "--zap-time-encoding=rfc3339"
+                                ],
+                                "command": [
+                                    "/keda-admission-webhooks"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                        "value": null,
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda-admission-webhooks:2.12.0",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 25,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-admission-webhooks",
+                                "ports": [
+                                    {
+                                        "container_port": 9443,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "metrics",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 20,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": false,
+                                    "capabilities": {
+                                        "add": null,
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    },
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": true,
+                                    "run_as_group": null,
+                                    "run_as_non_root": true,
+                                    "run_as_user": null,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": {
+                                        "localhost_profile": null,
+                                        "type": "RuntimeDefault"
+                                    },
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": {
+                            "kubernetes.io/os": "linux"
+                        },
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-operator",
+                        "service_account_name": "keda-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 10,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": null,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "conditions": null,
+                "fully_labeled_replicas": 1,
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1
+            }
+        },
+        "keda-metrics-apiserver-775bcbbfc5": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/desired-replicas": "1",
+                    "deployment.kubernetes.io/max-replicas": "2",
+                    "deployment.kubernetes.io/revision": "1",
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"keda-metrics-apiserver\",\"app.kubernetes.io/name\":\"keda-metrics-apiserver\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-metrics-apiserver\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"keda-metrics-apiserver\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"keda-metrics-apiserver\"},\"name\":\"keda-metrics-apiserver\"},\"spec\":{\"containers\":[{\"args\":[\"/usr/local/bin/keda-adapter\",\"--secure-port=6443\",\"--logtostderr=true\",\"--stderrthreshold=ERROR\",\"--v=0\",\"--client-ca-file=/certs/ca.crt\",\"--tls-cert-file=/certs/tls.crt\",\"--tls-private-key-file=/certs/tls.key\",\"--cert-dir=/certs\"],\"env\":[{\"name\":\"WATCH_NAMESPACE\",\"value\":\"\"},{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\",\"value\":\"\"}],\"image\":\"ghcr.io/kedacore/keda-metrics-apiserver:2.12.0\",\"imagePullPolicy\":\"Always\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":6443,\"scheme\":\"HTTPS\"},\"initialDelaySeconds\":5},\"name\":\"keda-metrics-apiserver\",\"ports\":[{\"containerPort\":6443,\"name\":\"https\"},{\"containerPort\":8080,\"name\":\"http\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readyz\",\"port\":6443,\"scheme\":\"HTTPS\"},\"initialDelaySeconds\":5},\"resources\":{\"limits\":{\"cpu\":\"1000m\",\"memory\":\"1000Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"readOnlyRootFilesystem\":true,\"runAsNonRoot\":true,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}},\"volumeMounts\":[{\"mountPath\":\"/tmp\",\"name\":\"temp-vol\"},{\"mountPath\":\"/certs\",\"name\":\"certificates\",\"readOnly\":true}]}],\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"},\"securityContext\":{\"runAsNonRoot\":true},\"serviceAccountName\":\"keda-operator\",\"volumes\":[{\"emptyDir\":{},\"name\":\"temp-vol\"},{\"name\":\"certificates\",\"secret\":{\"defaultMode\":420,\"secretName\":\"kedaorg-certs\"}}]}}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app": "keda-metrics-apiserver",
+                    "pod-template-hash": "775bcbbfc5"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/desired-replicas": {},
+                                    "f:deployment.kubernetes.io/max-replicas": {},
+                                    "f:deployment.kubernetes.io/revision": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"c6f142e7-22e5-48cf-af35-8fde5edf021e\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:pod-template-hash": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-metrics-apiserver\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":6443,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    },
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:allowPrivilegeEscalation": {},
+                                                    "f:capabilities": {
+                                                        ".": {},
+                                                        "f:drop": {}
+                                                    },
+                                                    "f:readOnlyRootFilesystem": {},
+                                                    "f:runAsNonRoot": {},
+                                                    "f:seccompProfile": {
+                                                        ".": {},
+                                                        "f:type": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/tmp\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:nodeSelector": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsNonRoot": {}
+                                        },
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:secretName": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"temp-vol\"}": {
+                                                ".": {},
+                                                "f:emptyDir": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:fullyLabeledReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:36+00:00"
+                    }
+                ],
+                "name": "keda-metrics-apiserver-775bcbbfc5",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Deployment",
+                        "name": "keda-metrics-apiserver",
+                        "uid": "c6f142e7-22e5-48cf-af35-8fde5edf021e"
+                    }
+                ],
+                "resource_version": "1122843",
+                "self_link": null,
+                "uid": "4b3abc93-d6e5-40db-a2b4-0cf2dd43d911"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "replicas": 1,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "keda-metrics-apiserver",
+                        "pod-template-hash": "775bcbbfc5"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "keda-metrics-apiserver",
+                            "pod-template-hash": "775bcbbfc5"
+                        },
+                        "managed_fields": null,
+                        "name": "keda-metrics-apiserver",
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "/usr/local/bin/keda-adapter",
+                                    "--secure-port=6443",
+                                    "--logtostderr=true",
+                                    "--stderrthreshold=ERROR",
+                                    "--v=0",
+                                    "--client-ca-file=/certs/ca.crt",
+                                    "--tls-cert-file=/certs/tls.crt",
+                                    "--tls-private-key-file=/certs/tls.key",
+                                    "--cert-dir=/certs"
+                                ],
+                                "command": null,
+                                "env": [
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                        "value": null,
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda-metrics-apiserver:2.12.0",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 6443,
+                                        "scheme": "HTTPS"
+                                    },
+                                    "initial_delay_seconds": 5,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-metrics-apiserver",
+                                "ports": [
+                                    {
+                                        "container_port": 6443,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "https",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 6443,
+                                        "scheme": "HTTPS"
+                                    },
+                                    "initial_delay_seconds": 5,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": false,
+                                    "capabilities": {
+                                        "add": null,
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    },
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": true,
+                                    "run_as_group": null,
+                                    "run_as_non_root": true,
+                                    "run_as_user": null,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": {
+                                        "localhost_profile": null,
+                                        "type": "RuntimeDefault"
+                                    },
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/tmp",
+                                        "mount_propagation": null,
+                                        "name": "temp-vol",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": {
+                            "kubernetes.io/os": "linux"
+                        },
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-operator",
+                        "service_account_name": "keda-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 30,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": {
+                                    "medium": null,
+                                    "size_limit": null
+                                },
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "temp-vol",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": null,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "conditions": null,
+                "fully_labeled_replicas": 1,
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1
+            }
+        },
+        "keda-olm-operator-b69d97969": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/desired-replicas": "1",
+                    "deployment.kubernetes.io/max-replicas": "2",
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creation_timestamp": "2024-02-05T06:07:44+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app.kubernetes.io/part-of": "keda-olm-operator",
+                    "app.kubernetes.io/version": "main",
+                    "name": "keda-olm-operator",
+                    "pod-template-hash": "b69d97969"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/desired-replicas": {},
+                                    "f:deployment.kubernetes.io/max-replicas": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:name": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5089ce68-e6a3-449d-91c6-b3de2226dc2f\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app.kubernetes.io/part-of": {},
+                                            "f:app.kubernetes.io/version": {},
+                                            "f:name": {},
+                                            "f:pod-template-hash": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-olm-operator\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:optional": {},
+                                                    "f:secretName": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:44+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:fullyLabeledReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:15+00:00"
+                    }
+                ],
+                "name": "keda-olm-operator-b69d97969",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Deployment",
+                        "name": "keda-olm-operator",
+                        "uid": "5089ce68-e6a3-449d-91c6-b3de2226dc2f"
+                    }
+                ],
+                "resource_version": "1122759",
+                "self_link": null,
+                "uid": "b1a18774-bfd3-4739-b75c-cc2baa9f4701"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "replicas": 1,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app.kubernetes.io/part-of": "keda-olm-operator",
+                        "app.kubernetes.io/version": "main",
+                        "name": "keda-olm-operator",
+                        "pod-template-hash": "b69d97969"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app.kubernetes.io/part-of": "keda-olm-operator",
+                            "app.kubernetes.io/version": "main",
+                            "name": "keda-olm-operator",
+                            "pod-template-hash": "b69d97969"
+                        },
+                        "managed_fields": null,
+                        "name": null,
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "--leader-elect",
+                                    "--zap-log-level=info",
+                                    "--zap-encoder=console",
+                                    "--zap-time-encoding=rfc3339"
+                                ],
+                                "command": [
+                                    "/manager"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": "keda",
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda-olm-operator:main",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 25,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-olm-operator",
+                                "ports": [
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 20,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "500m",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": null,
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": null,
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-olm-operator",
+                        "service_account_name": "keda-olm-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 30,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": true,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "conditions": null,
+                "fully_labeled_replicas": 1,
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1
+            }
+        },
+        "keda-operator-7f6d47b59": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/desired-replicas": "1",
+                    "deployment.kubernetes.io/max-replicas": "2",
+                    "deployment.kubernetes.io/revision": "1",
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"keda-operator\",\"app.kubernetes.io/component\":\"operator\",\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"keda-operator\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"keda-operator\",\"name\":\"keda-operator\"},\"name\":\"keda-operator\"},\"spec\":{\"containers\":[{\"args\":[\"--leader-elect\",\"--zap-log-level=info\",\"--zap-encoder=console\",\"--zap-time-encoding=rfc3339\",\"--enable-cert-rotation=true\"],\"command\":[\"/keda\"],\"env\":[{\"name\":\"POD_NAMESPACE\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}},{\"name\":\"WATCH_NAMESPACE\",\"value\":\"\"},{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\",\"value\":\"\"}],\"image\":\"ghcr.io/kedacore/keda:2.12.0\",\"imagePullPolicy\":\"Always\",\"livenessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":8081},\"initialDelaySeconds\":25},\"name\":\"keda-operator\",\"ports\":[{\"containerPort\":8080,\"name\":\"http\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/readyz\",\"port\":8081},\"initialDelaySeconds\":20},\"resources\":{\"limits\":{\"cpu\":\"1000m\",\"memory\":\"1000Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}},\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"readOnlyRootFilesystem\":true,\"runAsNonRoot\":true,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}},\"volumeMounts\":[{\"mountPath\":\"/certs\",\"name\":\"certificates\",\"readOnly\":true}]}],\"nodeSelector\":{\"kubernetes.io/os\":\"linux\"},\"securityContext\":{\"runAsNonRoot\":true},\"serviceAccountName\":\"keda-operator\",\"terminationGracePeriodSeconds\":10,\"volumes\":[{\"name\":\"certificates\",\"secret\":{\"defaultMode\":420,\"optional\":true,\"secretName\":\"kedaorg-certs\"}}]}}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app": "keda-operator",
+                    "name": "keda-operator",
+                    "pod-template-hash": "7f6d47b59"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/desired-replicas": {},
+                                    "f:deployment.kubernetes.io/max-replicas": {},
+                                    "f:deployment.kubernetes.io/revision": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:name": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"eeda5b2e-8878-4242-9f90-404b587edd94\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:name": {},
+                                            "f:pod-template-hash": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"keda-operator\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"KEDA_HTTP_DEFAULT_TIMEOUT\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"POD_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"WATCH_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    }
+                                                },
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:livenessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":8080,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:initialDelaySeconds": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:allowPrivilegeEscalation": {},
+                                                    "f:capabilities": {
+                                                        ".": {},
+                                                        "f:drop": {}
+                                                    },
+                                                    "f:readOnlyRootFilesystem": {},
+                                                    "f:runAsNonRoot": {},
+                                                    "f:seccompProfile": {
+                                                        ".": {},
+                                                        "f:type": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/certs\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {},
+                                                        "f:readOnly": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:nodeSelector": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsNonRoot": {}
+                                        },
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"certificates\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:secret": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:optional": {},
+                                                    "f:secretName": {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:fullyLabeledReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-05T06:08:25+00:00"
+                    }
+                ],
+                "name": "keda-operator-7f6d47b59",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Deployment",
+                        "name": "keda-operator",
+                        "uid": "eeda5b2e-8878-4242-9f90-404b587edd94"
+                    }
+                ],
+                "resource_version": "1122804",
+                "self_link": null,
+                "uid": "f7e1d20e-709c-438d-9110-4da4afadea65"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "replicas": 1,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "keda-operator",
+                        "pod-template-hash": "7f6d47b59"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "keda-operator",
+                            "name": "keda-operator",
+                            "pod-template-hash": "7f6d47b59"
+                        },
+                        "managed_fields": null,
+                        "name": "keda-operator",
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "--leader-elect",
+                                    "--zap-log-level=info",
+                                    "--zap-encoder=console",
+                                    "--zap-time-encoding=rfc3339",
+                                    "--enable-cert-rotation=true"
+                                ],
+                                "command": [
+                                    "/keda"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "POD_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "WATCH_NAMESPACE",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KEDA_HTTP_DEFAULT_TIMEOUT",
+                                        "value": null,
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": null,
+                                "image": "ghcr.io/kedacore/keda:2.12.0",
+                                "image_pull_policy": "Always",
+                                "lifecycle": null,
+                                "liveness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/healthz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 25,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "name": "keda-operator",
+                                "ports": [
+                                    {
+                                        "container_port": 8080,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/readyz",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": 20,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "1000Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "100Mi"
+                                    }
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": false,
+                                    "capabilities": {
+                                        "add": null,
+                                        "drop": [
+                                            "ALL"
+                                        ]
+                                    },
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": true,
+                                    "run_as_group": null,
+                                    "run_as_non_root": true,
+                                    "run_as_user": null,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": {
+                                        "localhost_profile": null,
+                                        "type": "RuntimeDefault"
+                                    },
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/certs",
+                                        "mount_propagation": null,
+                                        "name": "certificates",
+                                        "read_only": true,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": {
+                            "kubernetes.io/os": "linux"
+                        },
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": true,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "keda-operator",
+                        "service_account_name": "keda-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 10,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "certificates",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "optional": true,
+                                    "secret_name": "kedaorg-certs"
+                                },
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "conditions": null,
+                "fully_labeled_replicas": 1,
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1
+            }
+        }
+    },
+    "role_binding": {
+        "keda-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"RoleBinding\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"Role\",\"name\":\"keda-operator\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"keda-operator\",\"namespace\":\"keda\"}]}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:54+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:56+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122627",
+                "self_link": null,
+                "uid": "643dad53-0804-429e-b177-7852601e3e97"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "Role",
+                "name": "keda-operator"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "keda-operator",
+                    "namespace": "keda"
+                }
+            ]
+        }
+    },
+    "role": {
+        "keda-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"Role\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"secrets\"],\"verbs\":[\"create\",\"delete\",\"get\",\"list\",\"patch\",\"update\",\"watch\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:54+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:56+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122625",
+                "self_link": null,
+                "uid": "9529e718-e68e-4f3e-889d-44acc3071433"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        }
+    },
+    "secret": {
+        "kedaorg-certs": {
+            "api_version": null,
+            "data": {
+                "ca.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFRENDQWZpZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFoTVJBd0RnWURWUVFLRXdkTFJVUkIKVDFKSE1RMHdDd1lEVlFRREV3UkxSVVJCTUI0WERUSTBNREl3TlRBMU1EYzFPVm9YRFRNME1ESXdNakEyTURjMQpPVm93SVRFUU1BNEdBMVVFQ2hNSFMwVkVRVTlTUnpFTk1Bc0dBMVVFQXhNRVMwVkVRVENDQVNJd0RRWUpLb1pJCmh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDdKc3hZUEcwUm0zcHZxK3p3QjVIK0Y1QVF4MStFdGp6eCsKV2RsWE0yekhEQm5EdWRQKzBkaHJKNnNSVmJaYlBDRFZiWVlHcHpWQm9VZEZuamExWWZ5cTN2SlRpVmxBMTdCcApISWNzNkJYVHdKdWJFMm5uSFdkaU52K21GMGN2NjNtQWZIMHZDLy8wNng5cFRDTlJQS1VDUkU1QkdGb0xhTzYrCkFLSHNBMEV0Z3ZkWituT25CS0FZOURxZWNNMmRQNUZvSjdOOFpIYVFURWhsSThONUo1endiblBYdVUwOW5iZ1kKQ1dlNDJFYUkreFRCTlI5U2JhYzFEWmZUZkFSbzVYWXFDaHR3Qlo2bWZOSURWVkJWcUtrcUxFcTI2b2dOUnpCNwpEeGpZWkRETGRmc3NCSFBGaHpaZjhtRXBBUk9TbHVjWS8rQTNYZWRKNTNNWWU5SnZtRGNDQXdFQUFhTlRNRkV3CkRnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkR5NkdiK0cKM3FvSTVUR3lnQS92V2Y1b0hLclNNQThHQTFVZEVRUUlNQWFDQkV0RlJFRXdEUVlKS29aSWh2Y05BUUVMQlFBRApnZ0VCQUpLeGE1bXhRQUdUelJTM1UvM2FiL01oYlNYVit6c1RGY25LWm5WNkRuYXA5WFd6N2JwQWo1eXZyOWY0CklTNUswbmJvSnBCSUJJajdBMGlWTUlGenI0MmlPQ2plN05OT2tIdEVKaWtUZlNXdDhIalJIZUpuWnJ6RzJqOVEKL2g1eFE0Q0JYTkRvUWRGbHRHcm9VQVptZ3hXcktGODEramplRFZqUWpnM3NyZ1FpM3JjempLRVducFUzU1NiZwpIMDQ0K3lQV0JQZldXbEN3N3FLQTY4a3NGeDVVZUt5M01SYlhFQTQ1Z0ZiMHp2TWM3TEo1a01SWGxpV2g3V0ZqCitmamh3YUFSZzVxMEFnK3dVTjIwdFVzcjZpek9XeXl4ODlCZGZQbkxvMUV3TVpvQzA2a1JMUnpqLzRjOTlHK3oKS1VUeEFUb2NueE0yQUJzcEZPeERQMVNKdTlBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+                "ca.key": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdnNtekZnOGJSR2JlbStyN1BBSGtmNFhrQkRIWDRTMlBQSDVaMlZjemJNY01HY081CjAvN1IyR3NucXhGVnRsczhJTlZ0aGdhbk5VR2hSMFdlTnJWaC9LcmU4bE9KV1VEWHNHa2NoeXpvRmRQQW01c1QKYWVjZFoySTIvNllYUnkvcmVZQjhmUzhMLy9UckgybE1JMUU4cFFKRVRrRVlXZ3RvN3I0QW9ld0RRUzJDOTFuNgpjNmNFb0JqME9wNXd6WjAva1dnbnMzeGtkcEJNU0dVancza25uUEJ1YzllNVRUMmR1QmdKWjdqWVJvajdGTUUxCkgxSnRwelVObDlOOEJHamxkaW9LRzNBRm5xWjgwZ05WVUZXb3FTb3NTcmJxaUExSE1Ic1BHTmhrTU10MSt5d0UKYzhXSE5sL3lZU2tCRTVLVzV4ai80RGRkNTBubmN4aDcwbStZTndJREFRQUJBb0lCQUdmY2E2YWRrSzE3QnNLQQplRVpoalYreXByOTExdHpaclhrMEczdUswZzdzaVBUWnJTYndPSktGT3ZJUW5NV0tBMENvajFmLzlUU3p4cldDCis2OHlyT1ljcXdQbVlBWDdtNitJZVNSSldRclEzTENaQ2tlRHJta2llV2hRcGFsMk44MU1HZmtZRElOSmRGb0UKTzVPYVhOWkRWcVgzSCtlZEFJRy9ZNTdDV2I4M3NoQTJOSW5wQmlNeStWdkRZa21oaThXb0F6Qm9oRmJTQkVCbwpwVUVsK1I2dThWZUJqbitNWE0zWThjanVWMnVmbFNmd0RsMGxIQlpUQ1A4OUMraHZWV05QYkVpZFJDaGRoYWtECjJpTXByWkp2YmE3dlJQSEFUaXJEbnJxRGFXTlJUSWRtbnJwQ1daaGlLdTlrUXZVOGhiZlgxc2VLL21CQWhWeksKaWh1eTFma0NnWUVBdy9YTXNyb2haN1pzNE9FT0tqcUEwUCtUR2hGNFYvczZRRko5SWJVWXBtQ2IwZlkvbnRaZQpLVGd6d1VuZi9uVGRhMEIvRHV1RlQ5MmdCWEUzVFB5bEhiUmFVUXhwYjRETTk1cjlhOXFZY05WNTlUeTVPT0ppCnBkMzZlTXR1UUVxNFkvT0M2Ri92ZWw3VVpMemFjUjFacGU2VU1HekoxT04zcGx1RGJWWUMzeE1DZ1lFQStUNDIKS0RzSzdSR1BWMFppcFhodE5mQnhVS1loSmEzLzdRdW1GUUE5Vjg2TlhvYnFkTnB2RGo5UWFXMFZ5aThTMFppUQpYOUFiMWtYN2xyMSsrbms4ZXdLMU9nbXlrODhKVU80eUF1ejJGQjBaelRMK3pwZkpqcDlZbmJpTkJXQktLanBUClhtcHZ3N3VaS2JScUdYRE9HVHJXZmQ2M3FuR2JhRmIrSmtrUjhzMENnWUFDY3VqcTl0NkNBRXFlQ05IM2Z5R3EKK3Zhb3BiMCtSRHAzSVZERkFoRmJ5dXRIbFc4NEdlKzFUaWwvYWQvdHV5SWxPL29hZ3FENDNZa3BhRC9McTRDWQp2VzgvZ2dzelJJWExObG1pWm1udlJ3dXVIK01rcmRlVHdSRm5Qd3VTckJ4ZnkyUkFhU3FCK2Z0bmd1Q3I5elR1Cm1PdXJLMERlY3pWRWsvSXhoSmltbHdLQmdRQ3BXQXVUNmduU2FVdnJFSGVWMWV6ZDZUQVVpOHVadms5VXo4VlkKSDRHT1YxaldFUFRiMEU0RWNDQkNnVXQ4dzk4VmFZTXVsa2RUbnRrQjRsNlQ4Q3VYcUk5Wmo1MDFzRVcwSnlMegp1ZXk0WGMxYURudnlBaytBQitROXhWYUxnSkRqZ0IyRTJPeDNJTTgvOXNUZjVEVWtEMFlNMzNZSzZJV2VydnlmCkpxWjdRUUtCZ0FmellIdnRDU3hZV1BjcFZRaTZpYnFJSTJhOG0xb3VqR0FaeSs5RXpuUTNaZnF2WlFONHcrZVMKMkNSUjlVYnFVMVNXeERJTWVPZysvV1ozeWZqeW9hcm9xNkorT0VnWmJuYVRmNlNrbXc1bHRzYWJVdGxWUWx0ZwpZSjNTbEVGVEVGVklieVQ0RlFZNmFYS1NtR1FMQTNhYjZoMHRraUpPMXZrZ05RWld2K1hmCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==",
+                "tls.crt": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVwekNDQTQrZ0F3SUJBZ0lCQVRBTkJna3Foa2lHOXcwQkFRc0ZBREFoTVJBd0RnWURWUVFLRXdkTFJVUkIKVDFKSE1RMHdDd1lEVlFRREV3UkxSVVJCTUI0WERUSTBNREl3TlRBMU1EYzFPVm9YRFRNME1ESXdNakEyTURjMQpPVm93R0RFV01CUUdBMVVFQXhNTmEyVmtZUzF2Y0dWeVlYUnZjakNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFECmdnRVBBRENDQVFvQ2dnRUJBTnlzRHBEMWw0d2RiVkl5SDNDanN3Skx2NE5ra3FxRzdnaTFEWitIT2kzSHFHRlIKWGxHUWFZZDFpOWpZSDB4NUlBNFlzb1RIVndMSldNWi81YVVrRytyMVNxRGZLSVNrcCtjVU5sTUIreHFJMlFpQwpxcURjOXlIZDdMRTM1QnV1RStqa2dMb2xWY2J3NnZTbnBDSnhQTXk3R1NRaU5HcUlNcllNV2ZubkRiQWt0NUd0CkdBWUlNR1pRL1JVck1CenpCdDA0OFFPTGpKM3VNZWc1QlllenZFWU5VbHdxY2cveTdLbkgyZzZXanVYNk5QTEsKeVRENzhOeVlGTEJVa3hoSEdNNytENW16TmVmblNkbkFCOHBmN084THpoczYvTTNMdldhTDRnazBkK3kvMXliZgp3WDhreVkzaVNTdy9YTmNHSlMvWVZMcURhSDNuREJVMWszejhheThDQXdFQUFhT0NBZkV3Z2dIdE1BNEdBMVVkCkR3RUIvd1FFQXdJRm9EQWRCZ05WSFNVRUZqQVVCZ2dyQmdFRkJRY0RBUVlJS3dZQkJRVUhBd0l3REFZRFZSMFQKQVFIL0JBSXdBREFmQmdOVkhTTUVHREFXZ0JROHVobS9odDZxQ09VeHNvQVA3MW4rYUJ5cTBqQ0NBWXNHQTFVZApFUVNDQVlJd2dnRitnZzFyWldSaExXOXdaWEpoZEc5eWdnMXJaV1JoTFc5d1pYSmhkRzl5Z2hKclpXUmhMVzl3ClpYSmhkRzl5TG10bFpHR0NGbXRsWkdFdGIzQmxjbUYwYjNJdWEyVmtZUzV6ZG1PQ0pHdGxaR0V0YjNCbGNtRjAKYjNJdWEyVmtZUzV6ZG1NdVkyeDFjM1JsY2k1c2IyTmhiSUlYYTJWa1lTMWhaRzFwYzNOcGIyNHRkMlZpYUc5dgphM09DSEd0bFpHRXRZV1J0YVhOemFXOXVMWGRsWW1odmIydHpMbXRsWkdHQ0lHdGxaR0V0WVdSdGFYTnphVzl1CkxYZGxZbWh2YjJ0ekxtdGxaR0V1YzNaamdpNXJaV1JoTFdGa2JXbHpjMmx2YmkxM1pXSm9iMjlyY3k1clpXUmgKTG5OMll5NWpiSFZ6ZEdWeUxteHZZMkZzZ2haclpXUmhMVzFsZEhKcFkzTXRZWEJwYzJWeWRtVnlnaHRyWldSaApMVzFsZEhKcFkzTXRZWEJwYzJWeWRtVnlMbXRsWkdHQ0gydGxaR0V0YldWMGNtbGpjeTFoY0dselpYSjJaWEl1CmEyVmtZUzV6ZG1PQ0xXdGxaR0V0YldWMGNtbGpjeTFoY0dselpYSjJaWEl1YTJWa1lTNXpkbU11WTJ4MWMzUmwKY2k1c2IyTmhiREFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBdUpVYi96UGhBSTkvMkdoSUJtMk1qMjNld2hrVwpJVDFSdTEvTHdzenFKcnhFcFNVb05HckNMOGN6ZU13UFlwMVpKNzhVK04zNDJlZ2c2a2t0R3YwUFRqbjMwVHlMCm9VNGVMTTNPY0o4V1VHVFNjSlNYcDd4RTdDZXlNTjA2M1pxM1JkeHp1dkxiUEtyZ2RKeFh1aXRqMEtNR1ZZa2QKWXVkSTlaSmIvd3B6VFI3eE5ZMmlMZWhkbEJndC9pRDZSbkd1d1RFM01lSVFUdGtneWF2Y1A0SGF4RERkLzJzbgp2VkhtSk1tN01EOGNTaWtXOWRVRjJPeTFNNFpkOFNQR3VXUWt1WG5JNm9rSHFacFl2YjE4TmZKYUhwdGVVU2JiCmxWM3g5MXVTS2dyZTRlOFFjcmkvZWZQcW1jeloyL0ZHZE13dmZlMlZLUkNmYlRiTU1HVVRiMHR0M1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+                "tls.key": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBM0t3T2tQV1hqQjF0VWpJZmNLT3pBa3UvZzJTU3FvYnVDTFVObjRjNkxjZW9ZVkZlClVaQnBoM1dMMk5nZlRIa2dEaGl5aE1kWEFzbFl4bi9scFNRYjZ2VktvTjhvaEtTbjV4UTJVd0g3R29qWkNJS3EKb056M0lkM3NzVGZrRzY0VDZPU0F1aVZWeHZEcTlLZWtJbkU4ekxzWkpDSTBhb2d5dGd4WitlY05zQ1Mza2EwWQpCZ2d3WmxEOUZTc3dIUE1HM1RqeEE0dU1uZTR4NkRrRmg3TzhSZzFTWENweUQvTHNxY2ZhRHBhTzVmbzA4c3JKCk1QdnczSmdVc0ZTVEdFY1l6djRQbWJNMTUrZEoyY0FIeWwvczd3dk9HenI4emN1OVpvdmlDVFIzN0wvWEp0L0IKZnlUSmplSkpMRDljMXdZbEw5aFV1b05vZmVjTUZUV1RmUHhyTHdJREFRQUJBb0lCQUZhaTdtMFhIdEtSMHhQTQpQZSs1TlZTWGJLOG5VelhFRjd3dmFSUFN3WktycW4zYXRrOExoWUw3TVZhSE0zS1FzM2NWVnpFdUdna3NCOENYCkFoQWQ1eUFPQWFpN05Hc3ZRZ1JGT1RiSnRrNHFvQnJwUWhnNTZJVFJYbFlOZlc4b253UjJnZHVUUU9RRVBocWoKbnBzdkhoRzYreG5tbS9HZlcxbUI2K2xqUDBxQnhUV0R5YUY5aXQwUkVCUS9lUldkZlFjdEIrdFFKQThlWHJpTQp6ZWZPbEZDZ08zUDJEamptQkptaDU2dHBSbkZWaGhtaFp0c2FHUlhVczdaK0F4azV2alEvUkVMWGJTSU1ob0RSClI4bzFXbWZQbFAzZWlhRGtnV2plQkdKY1hMWk9qL2ZDZWVCTzdnTTcxcjR1bllab1IvYTBSdGtmV0pKMHhhbTMKVHRuZmpORUNnWUVBNzNXcGc1VDZValJ1K3c4SFJ3QVNoUmozY0FTTlo5WnRjRmxvcEFWYjFPQXJ2cUYreGRPVAp2WUQyenlhcGFDNTdXTnBMRkg3eXR0bTFWOHg3QTBSN1laTlA5d3ZHNkhRT1JPdXNqSUxzNVgwMGhvRVlKV0FjClhRZjFCZlZXUm96M1d5REJtbGpzb0RQejJHUjh4ZHRvZm5Zb3JNbUkxYkJUekFrb2lGUzN0Zk1DZ1lFQTYrb3QKVmhyNnd1MWZHZWphZlhmeTR4c045R2dVR1RTYXlSY2xlL0xqRTNFMzFwWjFtd09FbzVkNE9IczZtWEswaUdpOApneDlGbEFqcXpTem0wWStuUkR5NFZyek8zMHdTdUlFdzhpUC9lRUtaMS9sMDdmL2hua2dIa3lUcDlsMzZ4REcyClE1M3NaeXo3TFJWNHpyQ1VMUGxINHkrOCtDWjlmOXV2MU0wdjJOVUNnWUJXQ2pVS2JuRXpNRnZnSVpvL3pLcmEKNEFtb1dqcGs0UXNabjBhV0NNYmlTbG50ZVNHUCsySE9hWlJGQW1ORVo4OHlNZDFnVSt6cC9uZkdRRmJDNmN4YgpWdzhZZVViVEowQXBTM1VJVjlLKzhxbjQybEhPdkNYMDEzTVczUHhQQlQrcm9xMXR4QjNod2trUHE2dVpmQ2lqCnA5a2RuSnhxQzUxUVpzb0Zra3NnT1FLQmdFbXIvYkJ3Q0hNckVaSFR4N2Q2NTl6SUxCbHhEeVczNmNaMmRmdzUKSTNTRTNMMGtpMkYzUGNxZ21LaDZ3eGY4WENobEhNbU4wSHFrTmo4UWtKeE0waDFiSU8zbFZHMGpJbzEvdXJ0RApScHBWb2hseUMzUHZmcE9oUnN4S3NNMkJGN2lCRmJ3VDZ5bGxRS01abTNwZ1prV05LMGZsTm92LzZSMHVpOEJXCnUyUnBBb0dBZnJmdEtwTSs1WXc1aitBSTgwbldjUEJsekJMNWg5V2tiakJXS0RoT05iV0pwUXU4TFNkUnBOdUEKdXJkck1pdzVtSWduK09FU0s1SEZZNlJ4UU54VzJwOFc1NCsvV0l3N2Z2SVFoQ3NRT011eHFId25uRG5vaFlNVApFdGV4RVhlaFFDNTBORjByekszKzU2bDJiRG9LNE81ZXg1elpOTEFOWnpTM3lJZ1E5N009Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg=="
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"labels\":{\"app\":\"keda-operator\",\"app.kubernetes.io/component\":\"keda-operator\",\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda\"},\"name\":\"kedaorg-certs\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "keda-operator",
+                    "app.kubernetes.io/component": "keda-operator",
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:type": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:ca.crt": {},
+                                "f:ca.key": {},
+                                "f:tls.crt": {},
+                                "f:tls.key": {}
+                            }
+                        },
+                        "manager": "keda",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:08:01+00:00"
+                    }
+                ],
+                "name": "kedaorg-certs",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122697",
+                "self_link": null,
+                "uid": "f371a93b-f9f5-4197-a63a-26aee9bd86ad"
+            },
+            "string_data": null,
+            "type": "Opaque"
+        }
+    },
     "service_account": {
         "default": {
             "api_version": null,
@@ -16851,7 +24146,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-01-31T19:38:03+00:00",
+                "creation_timestamp": "2024-02-05T06:07:43+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -16860,30 +24155,30 @@
                 "labels": null,
                 "managed_fields": null,
                 "name": "default",
-                "namespace": "default",
+                "namespace": "keda",
                 "owner_references": null,
-                "resource_version": "359",
+                "resource_version": "1122374",
                 "self_link": null,
-                "uid": "6c75d5f5-0824-45eb-9dfd-f73158221e23"
+                "uid": "102fb079-e486-450b-83e0-1b7aa6d52029"
             },
             "secrets": null
-        }
-    },
-    "service": {
-        "kubernetes": {
+        },
+        "keda-olm-operator": {
             "api_version": null,
+            "automount_service_account_token": null,
+            "image_pull_secrets": null,
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-01-31T19:37:49+00:00",
+                "creation_timestamp": "2024-02-05T06:07:44+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
                 "generate_name": null,
                 "generation": null,
                 "labels": {
-                    "component": "apiserver",
-                    "provider": "kubernetes"
+                    "app.kubernetes.io/part-of": "keda-olm-operator",
+                    "app.kubernetes.io/version": "main"
                 },
                 "managed_fields": [
                     {
@@ -16892,15 +24187,145 @@
                         "fields_v1": {
                             "f:metadata": {
                                 "f:labels": {
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                }
+                            }
+                        },
+                        "manager": "kubectl",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:44+00:00"
+                    }
+                ],
+                "name": "keda-olm-operator",
+                "namespace": "keda",
+                "owner_references": null,
+                "resource_version": "1122392",
+                "self_link": null,
+                "uid": "b0e9c2b8-c00c-4767-9e6a-d88e81108d0b"
+            },
+            "secrets": null
+        },
+        "keda-operator": {
+            "api_version": null,
+            "automount_service_account_token": null,
+            "image_pull_secrets": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:54+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
                                     ".": {},
-                                    "f:component": {},
-                                    "f:provider": {}
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:56+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122621",
+                "self_link": null,
+                "uid": "4649d5ca-1ae6-48a9-9235-ff2b6b82301e"
+            },
+            "secrets": null
+        }
+    },
+    "service": {
+        "keda-admission-webhooks": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"labels\":{\"app.kubernetes.io/component\":\"admission-webhooks\",\"app.kubernetes.io/created-by\":\"keda\",\"app.kubernetes.io/instance\":\"admission-webhooks\",\"app.kubernetes.io/managed-by\":\"kustomize\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-admission-webhooks\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":443,\"protocol\":\"TCP\",\"targetPort\":9443},{\"name\":\"metrics\",\"port\":8080,\"protocol\":\"TCP\",\"targetPort\":8080}],\"selector\":{\"app\":\"keda-admission-webhooks\"}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "admission-webhooks",
+                    "app.kubernetes.io/created-by": "keda",
+                    "app.kubernetes.io/instance": "admission-webhooks",
+                    "app.kubernetes.io/managed-by": "kustomize",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
                                 }
                             },
                             "f:spec": {
-                                "f:clusterIP": {},
                                 "f:internalTrafficPolicy": {},
-                                "f:ipFamilyPolicy": {},
                                 "f:ports": {
                                     ".": {},
                                     "k:{\"port\":443,\"protocol\":\"TCP\"}": {
@@ -16909,30 +24334,185 @@
                                         "f:port": {},
                                         "f:protocol": {},
                                         "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":8080,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
                                     }
                                 },
+                                "f:selector": {},
                                 "f:sessionAffinity": {},
                                 "f:type": {}
                             }
                         },
-                        "manager": "kube-apiserver",
+                        "manager": "manager",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-01-31T19:37:49+00:00"
+                        "time": "2024-02-05T06:07:58+00:00"
                     }
                 ],
-                "name": "kubernetes",
-                "namespace": "default",
-                "owner_references": null,
-                "resource_version": "225",
+                "name": "keda-admission-webhooks",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122658",
                 "self_link": null,
-                "uid": "357fd823-01cb-45b0-99d7-32f27615a543"
+                "uid": "dfeaf3d5-a123-4884-87aa-42c730e19762"
             },
             "spec": {
                 "allocate_load_balancer_node_ports": null,
-                "cluster_ip": "10.96.0.1",
+                "cluster_ip": "10.96.247.61",
                 "cluster_i_ps": [
-                    "10.96.0.1"
+                    "10.96.247.61"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": [
+                    {
+                        "app_protocol": null,
+                        "name": "http",
+                        "node_port": null,
+                        "port": 443,
+                        "protocol": "TCP",
+                        "target_port": 9443
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "metrics",
+                        "node_port": null,
+                        "port": 8080,
+                        "protocol": "TCP",
+                        "target_port": 8080
+                    }
+                ],
+                "publish_not_ready_addresses": null,
+                "selector": {
+                    "app": "keda-admission-webhooks"
+                },
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
+        },
+        "keda-metrics-apiserver": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-metrics-apiserver\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-metrics-apiserver\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"ports\":[{\"name\":\"https\",\"port\":443,\"targetPort\":6443},{\"name\":\"metrics\",\"port\":8080,\"targetPort\":8080}],\"selector\":{\"app\":\"keda-metrics-apiserver\"}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:55+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-metrics-apiserver",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:internalTrafficPolicy": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"port\":443,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":8080,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    }
+                                },
+                                "f:selector": {},
+                                "f:sessionAffinity": {},
+                                "f:type": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:57+00:00"
+                    }
+                ],
+                "name": "keda-metrics-apiserver",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122648",
+                "self_link": null,
+                "uid": "82f76753-25f2-4ba4-a309-055ce4f947bb"
+            },
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "10.96.1.227",
+                "cluster_i_ps": [
+                    "10.96.1.227"
                 ],
                 "external_i_ps": null,
                 "external_name": null,
@@ -16954,10 +24534,158 @@
                         "port": 443,
                         "protocol": "TCP",
                         "target_port": 6443
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "metrics",
+                        "node_port": null,
+                        "port": 8080,
+                        "protocol": "TCP",
+                        "target_port": 8080
                     }
                 ],
                 "publish_not_ready_addresses": null,
-                "selector": null,
+                "selector": {
+                    "app": "keda-metrics-apiserver"
+                },
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
+        },
+        "keda-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "manifestival": "new",
+                    "olm-operator.keda.sh/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"labels\":{\"app.kubernetes.io/name\":\"keda-operator\",\"app.kubernetes.io/part-of\":\"keda-operator\",\"app.kubernetes.io/version\":\"2.12.0\"},\"name\":\"keda-operator\",\"namespace\":\"keda\",\"ownerReferences\":[{\"apiVersion\":\"keda.sh/v1alpha1\",\"blockOwnerDeletion\":true,\"controller\":true,\"kind\":\"KedaController\",\"name\":\"keda\",\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}]},\"spec\":{\"ports\":[{\"name\":\"metricsservice\",\"port\":9666,\"targetPort\":9666},{\"name\":\"metrics\",\"port\":8080,\"targetPort\":8080}],\"selector\":{\"app\":\"keda-operator\"}}}\n"
+                },
+                "creation_timestamp": "2024-02-05T06:07:54+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/name": "keda-operator",
+                    "app.kubernetes.io/part-of": "keda-operator",
+                    "app.kubernetes.io/version": "2.12.0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:manifestival": {},
+                                    "f:olm-operator.keda.sh/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {},
+                                    "f:app.kubernetes.io/version": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"5cb7e3cc-82af-4f48-9604-d37f15559fb5\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:internalTrafficPolicy": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"port\":8080,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":9666,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    }
+                                },
+                                "f:selector": {},
+                                "f:sessionAffinity": {},
+                                "f:type": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-05T06:07:56+00:00"
+                    }
+                ],
+                "name": "keda-operator",
+                "namespace": "keda",
+                "owner_references": [
+                    {
+                        "api_version": "keda.sh/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "KedaController",
+                        "name": "keda",
+                        "uid": "5cb7e3cc-82af-4f48-9604-d37f15559fb5"
+                    }
+                ],
+                "resource_version": "1122629",
+                "self_link": null,
+                "uid": "667026f5-b855-4580-b518-23dddf8ee356"
+            },
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "10.96.71.254",
+                "cluster_i_ps": [
+                    "10.96.71.254"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": [
+                    {
+                        "app_protocol": null,
+                        "name": "metricsservice",
+                        "node_port": null,
+                        "port": 9666,
+                        "protocol": "TCP",
+                        "target_port": 9666
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "metrics",
+                        "node_port": null,
+                        "port": 8080,
+                        "protocol": "TCP",
+                        "target_port": 8080
+                    }
+                ],
+                "publish_not_ready_addresses": null,
+                "selector": {
+                    "app": "keda-operator"
+                },
                 "session_affinity": "None",
                 "session_affinity_config": null,
                 "type": "ClusterIP"


### PR DESCRIPTION
netid: yugm2
CRD to analyze: ScaledObjects
CRD descriptions: https://keda.sh/docs/2.13/concepts/#architecture

**Field categorizations (Look at the `openAPIV3Schema` specs in the CRD)**:
* Advanced properties:
  * `horizontalPodAutoscalerConfig` -- As I mentioned in my old proposal, Keda tries to autoscale through horizontal scaling (or creating more pods. I see that its `behavior` property includes `scaleUp` and `scaleDown`, and each of these has policies that keep track of the policies that are to be used during scaling. Each policy item stores the period for which the policy should hold (called `periodSeconds`), the type of scaling policy (also called `type`), and the value of how much to change (called value).
  * `restoreToOriginalReplicaCount` -- Decides when to keep track of when to restore to original replica count. This makes sense as depending on CPU usage, if CPU usage becomes lower, we would want to keep track of when to go back to the original replica count
  * `scalingModifiers` - Decides when and how to scale the pods to the application. `metricType` looks at the application metric being targeted. `formula` describes the formula on how to scale the pods to the application I believe. 
*  Rest of the properties:
   * `cooldownPeriod` -- Describes the time to cool down after scaling up/scaling down
   * `fallback` -- Describes the settings to go to in case of failure
   * `idleReplicaCount` -- Indicates the number of replicas to go to in idle stage
   * `maxReplicaCount` -- Number of pods we can scale up to at maximum
   * `minReplicaCount` -- Number of pods we can scale down to at minimum
   * `pollingInterval` -- The period of time in which to begin polling
   * `scaleTargetRef` -- As stated by description, "ScaleTarget holds the reference to the scale target Object". Keeps track of name and container name. This is a required property.
   * `triggers` -- Indicates what trigger the scaler being used. This is a required property.
* Status properties (describe autoscaling status) --
  * `conditions` -- Indicates the conditions to go across when autoscaling and describes those conditions
  * `externalMetricNames` -- Keeps track of secondary metrics during scaling
  * `health` -- Indicates whether object health is happy or failing.
  * `hpaName` -- Name of the Horizontal Pod Autoscaler
  * `lastActiveTime` -- The time when Autoscaler was last active
  * `originalReplicaCount` -- Number of pods application started with
  * `pausedReplicaCount` -- Number of replicas that we scaled up/down to
  * `scaleTargetGVKR` -- According to field description, "GroupVersionKindResource provides unified structure for schema.GroupVersionKind and Resource"

**My complexity metric**
So in this case, I will be looking at the depth (maximum) and breadth of my CRD and the advanced fields (Because those advanced fields are the main contributors to help out with autoscaling).

 The depth allows us to see how much implementation would be in each part of the CRD. The depth measures the complexity well because it allows us to see the layers of the properties and the scale of what is required of many of the properties. This is analogous to how many helper functions a programmer would have to implement (i.e program --> class --> function --> helper 1 --> helper 2 --> helper 3 --> .. --> helper n).

The breadth indicates the number of fields (and their values) in total by the CRD or the advanced field. This highlights the complexity of the CRD because it describes how much has to be accounted for by the CRD or the advanced field. From a programming standpoint, this is like how much code a developer has to write for one class (i.e what classes are in the project, what functions and member variables are in the classes, how are those functions implemented, etc.).

Depth is calculated by doing a recursive depth-first search across the CRD (with the value of the depth being incremented and returned), and whichever is the highest value of the depth is returned.

Breadth is calculated by counting the keys and values of each object (something like a Breadth-first search across the keys and values).

Calculations:
Depth of entire CRD: 21
Breadth of entire CRD: 364
Depth of openAPIV3Schema:  16
Breadth of openAPIV3Schema:  265
Depth of horizontalPodAutoscalerConfig:  10
Breadth of horizontalPodAutoscalerConfig:  80
Depth of restoreToOriginalReplicaCount:  1
Breadth of restoreToOriginalReplicaCount:  2
Depth of scalingModifiers:  3
Breadth of scalingModifiers:  13



**-------------------------------------------------------- old proposal --------------------------------------------------------------**
My primary metric: Looking at the number of pods (specifically looking at how many pods the operator increases/decreases to).
Reason for this metric: Looking through the Keda documentation, Keda follows Horizontal Autoscaling procedure, where it attempts to scale up to the application through deploying more pods (as opposed to Vertical Autoscaling, which would assign more resources to the pods to account for the resource). I plan to deploy one of the scalers and events of the website and see as when I deploy an application, I see how many pods it scales to and measure it to see how it used Horizontal Autoscaling to better accommodate for the application. 

My hypothesis: "For CPU-intensive applications, this will increase the number of pods until the CPU usage is enough to be accounted for. Similar scenario for memory-intensive or resource-intensive applications. And when resource usage of those applications decrease, that's when number of pods will decrease"


Looking at the CRD, I see that the CRD keeps track of the number of replicas and has a policy on when to scale up (called `scaleUp` in CRD) and when to scale down (called `scaleDown` in CRD). This is all under `HorizontalPodAutoscalerBehavior`, which, according to the description, decides whether to scale up or to scale down. I also see `scaleUp` and `scaleDown` also have certain properties (one such includes `policies`, which specifies the scaling policies that can be used, and another is `stabilizationWindowSeconds` for the time to go through recommendations regarding what to scale up/down to.

Secondary metrics (to add emphasis to the primary metric):
Look at CPU and Memory usage of each pod to see how much the autoscaling has distributed the load.
Also look at the events passed during that time that would have triggered the pods to scale up. These can be received through looking at https://keda.sh/docs/2.13/operate/events/. We can also look at the metrics provided by KEDA themselves (https://keda.sh/docs/2.13/operate/metrics-server/) to see how exactly the events are triggering the autoscaling and why exactly.