### PR TITLE
Upload `clusters.postgresql.cnpg.io` CRD definition

### DIFF
--- a/operators/cloudnative-pg_cloudnative-pg/clusters.postgresql.cnpg.io.yaml
+++ b/operators/cloudnative-pg_cloudnative-pg/clusters.postgresql.cnpg.io.yaml
@@ -1,0 +1,4687 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: cnpg
+    meta.helm.sh/release-namespace: default
+  creationTimestamp: "2024-01-31T06:47:05Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: clusters.postgresql.cnpg.io
+  resourceVersion: "143481"
+  uid: e3f267eb-0789-4a4a-9f52-feaf47dd2819
+spec:
+  conversion:
+    strategy: None
+  group: postgresql.cnpg.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Number of instances
+      jsonPath: .status.instances
+      name: Instances
+      type: integer
+    - description: Number of ready instances
+      jsonPath: .status.readyInstances
+      name: Ready
+      type: integer
+    - description: Cluster current status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Primary pod
+      jsonPath: .status.currentPrimary
+      name: Primary
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the PostgreSQL API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the cluster. More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              affinity:
+                description: Affinity/Anti-affinity rules for Pods
+                properties:
+                  additionalPodAffinity:
+                    description: AdditionalPodAffinity allows to specify pod affinity
+                      terms to be passed to all the cluster's pods.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  additionalPodAntiAffinity:
+                    description: AdditionalPodAntiAffinity allows to specify pod anti-affinity
+                      terms to be added to the ones generated by the operator if EnablePodAntiAffinity
+                      is set to true (default) or to be used exclusively if set to
+                      false.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  enablePodAntiAffinity:
+                    description: Activates anti-affinity for the pods. The operator
+                      will define pods anti-affinity unless this field is explicitly
+                      set to false
+                    type: boolean
+                  nodeAffinity:
+                    description: 'NodeAffinity describes node affinity scheduling
+                      rules for the pod. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity'
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is map of key-value pairs used to define
+                      the nodes on which the pods can run. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  podAntiAffinityType:
+                    description: 'PodAntiAffinityType allows the user to decide whether
+                      pod anti-affinity between cluster instance has to be considered
+                      a strong requirement during scheduling or not. Allowed values
+                      are: "preferred" (default if empty) or "required". Setting it
+                      to "required", could lead to instances remaining pending until
+                      new kubernetes nodes are added if all the existing nodes don''t
+                      match the required pod anti-affinity rule. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity'
+                    type: string
+                  tolerations:
+                    description: 'Tolerations is a list of Tolerations that should
+                      be set for all the pods, in order to allow them to run on tainted
+                      nodes. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologyKey:
+                    description: TopologyKey to use for anti-affinity configuration.
+                      See k8s documentation for more info on that
+                    type: string
+                type: object
+              backup:
+                description: The configuration to be used for backups
+                properties:
+                  barmanObjectStore:
+                    description: The configuration for the barman-cloud tool suite
+                    properties:
+                      azureCredentials:
+                        description: The credentials to use to upload data to Azure
+                          Blob Storage
+                        properties:
+                          connectionString:
+                            description: The connection string to be used
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          inheritFromAzureAD:
+                            description: Use the Azure AD based authentication without
+                              providing explicitly the keys.
+                            type: boolean
+                          storageAccount:
+                            description: The storage account where to upload data
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageKey:
+                            description: The storage account key to be used in conjunction
+                              with the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageSasToken:
+                            description: A shared-access-signature to be used in conjunction
+                              with the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
+                      data:
+                        description: The configuration to be used to backup the data
+                          files When not defined, base backups files will be stored
+                          uncompressed and may be unencrypted in the object store,
+                          according to the bucket default policy.
+                        properties:
+                          compression:
+                            description: Compress a backup file (a tar file per tablespace)
+                              while streaming it to the object store. Available options
+                              are empty string (no compression, default), `gzip`,
+                              `bzip2` or `snappy`.
+                            enum:
+                            - gzip
+                            - bzip2
+                            - snappy
+                            type: string
+                          encryption:
+                            description: Whenever to force the encryption of files
+                              (if the bucket is not already configured for that).
+                              Allowed options are empty string (use the bucket policy,
+                              default), `AES256` and `aws:kms`
+                            enum:
+                            - AES256
+                            - aws:kms
+                            type: string
+                          immediateCheckpoint:
+                            description: Control whether the I/O workload for the
+                              backup initial checkpoint will be limited, according
+                              to the `checkpoint_completion_target` setting on the
+                              PostgreSQL server. If set to true, an immediate checkpoint
+                              will be used, meaning PostgreSQL will complete the checkpoint
+                              as soon as possible. `false` by default.
+                            type: boolean
+                          jobs:
+                            description: The number of parallel jobs to be used to
+                              upload the backup, defaults to 2
+                            format: int32
+                            minimum: 1
+                            type: integer
+                        type: object
+                      destinationPath:
+                        description: The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                          this path, with different destination folders, will be used
+                          for WALs and for data
+                        minLength: 1
+                        type: string
+                      endpointCA:
+                        description: EndpointCA store the CA bundle of the barman
+                          endpoint. Useful when using self-signed certificates to
+                          avoid errors with certificate issuer and barman-cloud-wal-archive
+                        properties:
+                          key:
+                            description: The key to select
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      endpointURL:
+                        description: Endpoint to be used to upload data to the cloud,
+                          overriding the automatic endpoint discovery
+                        type: string
+                      googleCredentials:
+                        description: The credentials to use to upload data to Google
+                          Cloud Storage
+                        properties:
+                          applicationCredentials:
+                            description: The secret containing the Google Cloud Storage
+                              JSON file with the credentials
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          gkeEnvironment:
+                            description: If set to true, will presume that it's running
+                              inside a GKE environment, default to false.
+                            type: boolean
+                        type: object
+                      historyTags:
+                        additionalProperties:
+                          type: string
+                        description: HistoryTags is a list of key value pairs that
+                          will be passed to the Barman --history-tags option.
+                        type: object
+                      s3Credentials:
+                        description: The credentials to use to upload data to S3
+                        properties:
+                          accessKeyId:
+                            description: The reference to the access key id
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          inheritFromIAMRole:
+                            description: Use the role based authentication without
+                              providing explicitly the keys.
+                            type: boolean
+                          region:
+                            description: The reference to the secret containing the
+                              region name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          secretAccessKey:
+                            description: The reference to the secret access key
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          sessionToken:
+                            description: The references to the session key
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
+                      serverName:
+                        description: The server name on S3, the cluster name is used
+                          if this parameter is omitted
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a list of key value pairs that will be
+                          passed to the Barman --tags option.
+                        type: object
+                      wal:
+                        description: The configuration for the backup of the WAL stream.
+                          When not defined, WAL files will be stored uncompressed
+                          and may be unencrypted in the object store, according to
+                          the bucket default policy.
+                        properties:
+                          compression:
+                            description: Compress a WAL file before sending it to
+                              the object store. Available options are empty string
+                              (no compression, default), `gzip`, `bzip2` or `snappy`.
+                            enum:
+                            - gzip
+                            - bzip2
+                            - snappy
+                            type: string
+                          encryption:
+                            description: Whenever to force the encryption of files
+                              (if the bucket is not already configured for that).
+                              Allowed options are empty string (use the bucket policy,
+                              default), `AES256` and `aws:kms`
+                            enum:
+                            - AES256
+                            - aws:kms
+                            type: string
+                          maxParallel:
+                            description: Number of WAL files to be either archived
+                              in parallel (when the PostgreSQL instance is archiving
+                              to a backup object store) or restored in parallel (when
+                              a PostgreSQL standby is fetching WAL files from a recovery
+                              object store). If not specified, WAL files will be processed
+                              one at a time. It accepts a positive integer as a value
+                              - with 1 being the minimum accepted value.
+                            minimum: 1
+                            type: integer
+                        type: object
+                    required:
+                    - destinationPath
+                    type: object
+                  retentionPolicy:
+                    description: RetentionPolicy is the retention policy to be used
+                      for backups and WALs (i.e. '60d'). The retention policy is expressed
+                      in the form of `XXu` where `XX` is a positive integer and `u`
+                      is in `[dwm]` - days, weeks, months. It's currently only applicable
+                      when using the BarmanObjectStore method.
+                    pattern: ^[1-9][0-9]*[dwm]$
+                    type: string
+                  target:
+                    default: prefer-standby
+                    description: The policy to decide which instance should perform
+                      backups. Available options are empty string, which will default
+                      to `prefer-standby` policy, `primary` to have backups run always
+                      on primary instances, `prefer-standby` to have backups run preferably
+                      on the most updated standby, if available.
+                    enum:
+                    - primary
+                    - prefer-standby
+                    type: string
+                  volumeSnapshot:
+                    description: VolumeSnapshot provides the configuration for the
+                      execution of volume snapshot backups.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations key-value pairs that will be added
+                          to .metadata.annotations snapshot resources.
+                        type: object
+                      className:
+                        description: ClassName specifies the Snapshot Class to be
+                          used for PG_DATA PersistentVolumeClaim. It is the default
+                          class for the other types if no specific class is present
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels are key-value pairs that will be added
+                          to .metadata.labels snapshot resources.
+                        type: object
+                      online:
+                        default: true
+                        description: Whether the default type of backup with volume
+                          snapshots is online/hot (`true`, default) or offline/cold
+                          (`false`)
+                        type: boolean
+                      onlineConfiguration:
+                        default:
+                          immediateCheckpoint: false
+                          waitForArchive: true
+                        description: Configuration parameters to control the online/hot
+                          backup with volume snapshots
+                        properties:
+                          immediateCheckpoint:
+                            description: Control whether the I/O workload for the
+                              backup initial checkpoint will be limited, according
+                              to the `checkpoint_completion_target` setting on the
+                              PostgreSQL server. If set to true, an immediate checkpoint
+                              will be used, meaning PostgreSQL will complete the checkpoint
+                              as soon as possible. `false` by default.
+                            type: boolean
+                          waitForArchive:
+                            default: true
+                            description: If false, the function will return immediately
+                              after the backup is completed, without waiting for WAL
+                              to be archived. This behavior is only useful with backup
+                              software that independently monitors WAL archiving.
+                              Otherwise, WAL required to make the backup consistent
+                              might be missing and make the backup useless. By default,
+                              or when this parameter is true, pg_backup_stop will
+                              wait for WAL to be archived when archiving is enabled.
+                              On a standby, this means that it will wait only when
+                              archive_mode = always. If write activity on the primary
+                              is low, it may be useful to run pg_switch_wal on the
+                              primary in order to trigger an immediate segment switch.
+                            type: boolean
+                        type: object
+                      snapshotOwnerReference:
+                        default: none
+                        description: SnapshotOwnerReference indicates the type of
+                          owner reference the snapshot should have
+                        enum:
+                        - none
+                        - cluster
+                        - backup
+                        type: string
+                      tablespaceClassName:
+                        additionalProperties:
+                          type: string
+                        description: TablespaceClassName specifies the Snapshot Class
+                          to be used for the tablespaces. defaults to the PGDATA Snapshot
+                          Class, if set
+                        type: object
+                      walClassName:
+                        description: WalClassName specifies the Snapshot Class to
+                          be used for the PG_WAL PersistentVolumeClaim.
+                        type: string
+                    type: object
+                type: object
+              bootstrap:
+                description: Instructions to bootstrap this cluster
+                properties:
+                  initdb:
+                    description: Bootstrap the cluster via initdb
+                    properties:
+                      dataChecksums:
+                        description: 'Whether the `-k` option should be passed to
+                          initdb, enabling checksums on data pages (default: `false`)'
+                        type: boolean
+                      database:
+                        description: 'Name of the database used by the application.
+                          Default: `app`.'
+                        type: string
+                      encoding:
+                        description: The value to be passed as option `--encoding`
+                          for initdb (default:`UTF8`)
+                        type: string
+                      import:
+                        description: Bootstraps the new cluster by importing data
+                          from an existing PostgreSQL instance using logical backup
+                          (`pg_dump` and `pg_restore`)
+                        properties:
+                          databases:
+                            description: The databases to import
+                            items:
+                              type: string
+                            type: array
+                          postImportApplicationSQL:
+                            description: List of SQL queries to be executed as a superuser
+                              in the application database right after is imported
+                              - to be used with extreme care (by default empty). Only
+                              available in microservice type.
+                            items:
+                              type: string
+                            type: array
+                          roles:
+                            description: The roles to import
+                            items:
+                              type: string
+                            type: array
+                          schemaOnly:
+                            description: 'When set to true, only the `pre-data` and
+                              `post-data` sections of `pg_restore` are invoked, avoiding
+                              data import. Default: `false`.'
+                            type: boolean
+                          source:
+                            description: The source of the import
+                            properties:
+                              externalCluster:
+                                description: The name of the externalCluster used
+                                  for import
+                                type: string
+                            required:
+                            - externalCluster
+                            type: object
+                          type:
+                            description: The import type. Can be `microservice` or
+                              `monolith`.
+                            enum:
+                            - microservice
+                            - monolith
+                            type: string
+                        required:
+                        - databases
+                        - source
+                        - type
+                        type: object
+                      localeCType:
+                        description: The value to be passed as option `--lc-ctype`
+                          for initdb (default:`C`)
+                        type: string
+                      localeCollate:
+                        description: The value to be passed as option `--lc-collate`
+                          for initdb (default:`C`)
+                        type: string
+                      options:
+                        description: 'The list of options that must be passed to initdb
+                          when creating the cluster. Deprecated: This could lead to
+                          inconsistent configurations, please use the explicit provided
+                          parameters instead. If defined, explicit values will be
+                          ignored.'
+                        items:
+                          type: string
+                        type: array
+                      owner:
+                        description: Name of the owner of the database in the instance
+                          to be used by applications. Defaults to the value of the
+                          `database` key.
+                        type: string
+                      postInitApplicationSQL:
+                        description: List of SQL queries to be executed as a superuser
+                          in the application database right after is created - to
+                          be used with extreme care (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      postInitApplicationSQLRefs:
+                        description: PostInitApplicationSQLRefs points references
+                          to ConfigMaps or Secrets which contain SQL files, the general
+                          implementation order to these references is from all Secrets
+                          to all ConfigMaps, and inside Secrets or ConfigMaps, the
+                          implementation order is same as the order of each array
+                          (by default empty)
+                        properties:
+                          configMapRefs:
+                            description: ConfigMapRefs holds a list of references
+                              to ConfigMaps
+                            items:
+                              description: ConfigMapKeySelector contains enough information
+                                to let you locate the key of a ConfigMap
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                          secretRefs:
+                            description: SecretRefs holds a list of references to
+                              Secrets
+                            items:
+                              description: SecretKeySelector contains enough information
+                                to let you locate the key of a Secret
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      postInitSQL:
+                        description: List of SQL queries to be executed as a superuser
+                          immediately after the cluster has been created - to be used
+                          with extreme care (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      postInitTemplateSQL:
+                        description: List of SQL queries to be executed as a superuser
+                          in the `template1` after the cluster has been created -
+                          to be used with extreme care (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      secret:
+                        description: Name of the secret containing the initial credentials
+                          for the owner of the user database. If empty a new secret
+                          will be created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      walSegmentSize:
+                        description: 'The value in megabytes (1 to 1024) to be passed
+                          to the `--wal-segsize` option for initdb (default: empty,
+                          resulting in PostgreSQL default: 16MB)'
+                        maximum: 1024
+                        minimum: 1
+                        type: integer
+                    type: object
+                  pg_basebackup:
+                    description: Bootstrap the cluster taking a physical backup of
+                      another compatible PostgreSQL instance
+                    properties:
+                      database:
+                        description: 'Name of the database used by the application.
+                          Default: `app`.'
+                        type: string
+                      owner:
+                        description: Name of the owner of the database in the instance
+                          to be used by applications. Defaults to the value of the
+                          `database` key.
+                        type: string
+                      secret:
+                        description: Name of the secret containing the initial credentials
+                          for the owner of the user database. If empty a new secret
+                          will be created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      source:
+                        description: The name of the server of which we need to take
+                          a physical backup
+                        minLength: 1
+                        type: string
+                    required:
+                    - source
+                    type: object
+                  recovery:
+                    description: Bootstrap the cluster from a backup
+                    properties:
+                      backup:
+                        description: The backup object containing the physical base
+                          backup from which to initiate the recovery procedure. Mutually
+                          exclusive with `source` and `volumeSnapshots`.
+                        properties:
+                          endpointCA:
+                            description: EndpointCA store the CA bundle of the barman
+                              endpoint. Useful when using self-signed certificates
+                              to avoid errors with certificate issuer and barman-cloud-wal-archive.
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      database:
+                        description: 'Name of the database used by the application.
+                          Default: `app`.'
+                        type: string
+                      owner:
+                        description: Name of the owner of the database in the instance
+                          to be used by applications. Defaults to the value of the
+                          `database` key.
+                        type: string
+                      recoveryTarget:
+                        description: 'By default, the recovery process applies all
+                          the available WAL files in the archive (full recovery).
+                          However, you can also end the recovery as soon as a consistent
+                          state is reached or recover to a point-in-time (PITR) by
+                          specifying a `RecoveryTarget` object, as expected by PostgreSQL
+                          (i.e., timestamp, transaction Id, LSN, ...). More info:
+                          https://www.postgresql.org/docs/current/runtime-config-wal.html#RUNTIME-CONFIG-WAL-RECOVERY-TARGET'
+                        properties:
+                          backupID:
+                            description: The ID of the backup from which to start
+                              the recovery process. If empty (default) the operator
+                              will automatically detect the backup based on targetTime
+                              or targetLSN if specified. Otherwise use the latest
+                              available backup in chronological order.
+                            type: string
+                          exclusive:
+                            description: Set the target to be exclusive. If omitted,
+                              defaults to false, so that in Postgres, `recovery_target_inclusive`
+                              will be true
+                            type: boolean
+                          targetImmediate:
+                            description: End recovery as soon as a consistent state
+                              is reached
+                            type: boolean
+                          targetLSN:
+                            description: The target LSN (Log Sequence Number)
+                            type: string
+                          targetName:
+                            description: The target name (to be previously created
+                              with `pg_create_restore_point`)
+                            type: string
+                          targetTLI:
+                            description: The target timeline ("latest" or a positive
+                              integer)
+                            type: string
+                          targetTime:
+                            description: The target time as a timestamp in the RFC3339
+                              standard
+                            type: string
+                          targetXID:
+                            description: The target transaction ID
+                            type: string
+                        type: object
+                      secret:
+                        description: Name of the secret containing the initial credentials
+                          for the owner of the user database. If empty a new secret
+                          will be created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      source:
+                        description: The external cluster whose backup we will restore.
+                          This is also used as the name of the folder under which
+                          the backup is stored, so it must be set to the name of the
+                          source cluster Mutually exclusive with `backup`.
+                        type: string
+                      volumeSnapshots:
+                        description: The static PVC data source(s) from which to initiate
+                          the recovery procedure. Currently supporting `VolumeSnapshot`
+                          and `PersistentVolumeClaim` resources that map an existing
+                          PVC group, compatible with CloudNativePG, and taken with
+                          a cold backup copy on a fenced Postgres instance (limitation
+                          which will be removed in the future when online backup will
+                          be implemented). Mutually exclusive with `backup`.
+                        properties:
+                          storage:
+                            description: Configuration of the storage of the instances
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          tablespaceStorage:
+                            additionalProperties:
+                              description: TypedLocalObjectReference contains enough
+                                information to let you locate the typed referenced
+                                object inside the same namespace.
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            description: Configuration of the storage for PostgreSQL
+                              tablespaces
+                            type: object
+                          walStorage:
+                            description: Configuration of the storage for PostgreSQL
+                              WAL (Write-Ahead Log)
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - storage
+                        type: object
+                    type: object
+                type: object
+              certificates:
+                description: The configuration for the CA and related certificates
+                properties:
+                  clientCASecret:
+                    description: 'The secret containing the Client CA certificate.
+                      If not defined, a new secret will be created with a self-signed
+                      CA and will be used to generate all the client certificates.<br
+                      /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
+                      be used to validate the client certificates, used as `ssl_ca_file`
+                      of all the instances.<br /> - `ca.key`: key used to generate
+                      client certificates, if ReplicationTLSSecret is provided, this
+                      can be omitted.<br />'
+                    type: string
+                  replicationTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the
+                      client certificate to authenticate as the `streaming_replica`
+                      user. If not defined, ClientCASecret must provide also `ca.key`,
+                      and a new secret will be created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be
+                      added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: 'The secret containing the Server CA certificate.
+                      If not defined, a new secret will be created with a self-signed
+                      CA and will be used to generate the TLS certificate ServerTLSSecret.<br
+                      /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
+                      be used to validate the server certificate, used as `sslrootcert`
+                      in client connection strings.<br /> - `ca.key`: key used to
+                      generate Server SSL certs, if ServerTLSSecret is provided, this
+                      can be omitted.<br />'
+                    type: string
+                  serverTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the
+                      server TLS certificate and key that will be set as `ssl_cert_file`
+                      and `ssl_key_file` so that clients can connect to postgres securely.
+                      If not defined, ServerCASecret must provide also `ca.key` and
+                      a new secret will be created using the provided CA.
+                    type: string
+                type: object
+              description:
+                description: Description of this PostgreSQL cluster
+                type: string
+              enableSuperuserAccess:
+                default: false
+                description: When this option is enabled, the operator will use the
+                  `SuperuserSecret` to update the `postgres` user password (if the
+                  secret is not present, the operator will automatically create one).
+                  When this option is disabled, the operator will ignore the `SuperuserSecret`
+                  content, delete it when automatically created, and then blank the
+                  password of the `postgres` user by setting it to `NULL`. Disabled
+                  by default.
+                type: boolean
+              env:
+                description: Env follows the Env format to pass environment variables
+                  to the pods created in the cluster
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: EnvFrom follows the EnvFrom format to pass environment
+                  variables sources to the pods to be used by Env
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              ephemeralVolumesSizeLimit:
+                description: EphemeralVolumesSizeLimit allows the user to set the
+                  limits for the ephemeral volumes
+                properties:
+                  shm:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Shm is the size limit of the shared memory volume
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  temporaryData:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: TemporaryData is the size limit of the temporary
+                      data volume
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              externalClusters:
+                description: The list of external clusters which are used in the configuration
+                items:
+                  description: ExternalCluster represents the connection parameters
+                    to an external cluster which is used in the other sections of
+                    the configuration
+                  properties:
+                    barmanObjectStore:
+                      description: The configuration for the barman-cloud tool suite
+                      properties:
+                        azureCredentials:
+                          description: The credentials to use to upload data to Azure
+                            Blob Storage
+                          properties:
+                            connectionString:
+                              description: The connection string to be used
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            inheritFromAzureAD:
+                              description: Use the Azure AD based authentication without
+                                providing explicitly the keys.
+                              type: boolean
+                            storageAccount:
+                              description: The storage account where to upload data
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageKey:
+                              description: The storage account key to be used in conjunction
+                                with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageSasToken:
+                              description: A shared-access-signature to be used in
+                                conjunction with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        data:
+                          description: The configuration to be used to backup the
+                            data files When not defined, base backups files will be
+                            stored uncompressed and may be unencrypted in the object
+                            store, according to the bucket default policy.
+                          properties:
+                            compression:
+                              description: Compress a backup file (a tar file per
+                                tablespace) while streaming it to the object store.
+                                Available options are empty string (no compression,
+                                default), `gzip`, `bzip2` or `snappy`.
+                              enum:
+                              - gzip
+                              - bzip2
+                              - snappy
+                              type: string
+                            encryption:
+                              description: Whenever to force the encryption of files
+                                (if the bucket is not already configured for that).
+                                Allowed options are empty string (use the bucket policy,
+                                default), `AES256` and `aws:kms`
+                              enum:
+                              - AES256
+                              - aws:kms
+                              type: string
+                            immediateCheckpoint:
+                              description: Control whether the I/O workload for the
+                                backup initial checkpoint will be limited, according
+                                to the `checkpoint_completion_target` setting on the
+                                PostgreSQL server. If set to true, an immediate checkpoint
+                                will be used, meaning PostgreSQL will complete the
+                                checkpoint as soon as possible. `false` by default.
+                              type: boolean
+                            jobs:
+                              description: The number of parallel jobs to be used
+                                to upload the backup, defaults to 2
+                              format: int32
+                              minimum: 1
+                              type: integer
+                          type: object
+                        destinationPath:
+                          description: The path where to store the backup (i.e. s3://bucket/path/to/folder)
+                            this path, with different destination folders, will be
+                            used for WALs and for data
+                          minLength: 1
+                          type: string
+                        endpointCA:
+                          description: EndpointCA store the CA bundle of the barman
+                            endpoint. Useful when using self-signed certificates to
+                            avoid errors with certificate issuer and barman-cloud-wal-archive
+                          properties:
+                            key:
+                              description: The key to select
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        endpointURL:
+                          description: Endpoint to be used to upload data to the cloud,
+                            overriding the automatic endpoint discovery
+                          type: string
+                        googleCredentials:
+                          description: The credentials to use to upload data to Google
+                            Cloud Storage
+                          properties:
+                            applicationCredentials:
+                              description: The secret containing the Google Cloud
+                                Storage JSON file with the credentials
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            gkeEnvironment:
+                              description: If set to true, will presume that it's
+                                running inside a GKE environment, default to false.
+                              type: boolean
+                          type: object
+                        historyTags:
+                          additionalProperties:
+                            type: string
+                          description: HistoryTags is a list of key value pairs that
+                            will be passed to the Barman --history-tags option.
+                          type: object
+                        s3Credentials:
+                          description: The credentials to use to upload data to S3
+                          properties:
+                            accessKeyId:
+                              description: The reference to the access key id
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            inheritFromIAMRole:
+                              description: Use the role based authentication without
+                                providing explicitly the keys.
+                              type: boolean
+                            region:
+                              description: The reference to the secret containing
+                                the region name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            secretAccessKey:
+                              description: The reference to the secret access key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            sessionToken:
+                              description: The references to the session key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        serverName:
+                          description: The server name on S3, the cluster name is
+                            used if this parameter is omitted
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          description: Tags is a list of key value pairs that will
+                            be passed to the Barman --tags option.
+                          type: object
+                        wal:
+                          description: The configuration for the backup of the WAL
+                            stream. When not defined, WAL files will be stored uncompressed
+                            and may be unencrypted in the object store, according
+                            to the bucket default policy.
+                          properties:
+                            compression:
+                              description: Compress a WAL file before sending it to
+                                the object store. Available options are empty string
+                                (no compression, default), `gzip`, `bzip2` or `snappy`.
+                              enum:
+                              - gzip
+                              - bzip2
+                              - snappy
+                              type: string
+                            encryption:
+                              description: Whenever to force the encryption of files
+                                (if the bucket is not already configured for that).
+                                Allowed options are empty string (use the bucket policy,
+                                default), `AES256` and `aws:kms`
+                              enum:
+                              - AES256
+                              - aws:kms
+                              type: string
+                            maxParallel:
+                              description: Number of WAL files to be either archived
+                                in parallel (when the PostgreSQL instance is archiving
+                                to a backup object store) or restored in parallel
+                                (when a PostgreSQL standby is fetching WAL files from
+                                a recovery object store). If not specified, WAL files
+                                will be processed one at a time. It accepts a positive
+                                integer as a value - with 1 being the minimum accepted
+                                value.
+                              minimum: 1
+                              type: integer
+                          type: object
+                      required:
+                      - destinationPath
+                      type: object
+                    connectionParameters:
+                      additionalProperties:
+                        type: string
+                      description: The list of connection parameters, such as dbname,
+                        host, username, etc
+                      type: object
+                    name:
+                      description: The server name, required
+                      type: string
+                    password:
+                      description: The reference to the password to be used to connect
+                        to the server. If a password is provided, CloudNativePG creates
+                        a PostgreSQL passfile at `/controller/external/NAME/pass`
+                        (where "NAME" is the cluster's name). This passfile is automatically
+                        referenced in the connection string when establishing a connection
+                        to the remote PostgreSQL server from the current PostgreSQL
+                        `Cluster`. This ensures secure and efficient password management
+                        for external clusters.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslCert:
+                      description: The reference to an SSL certificate to be used
+                        to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslKey:
+                      description: The reference to an SSL private key to be used
+                        to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslRootCert:
+                      description: The reference to an SSL CA public key to be used
+                        to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  type: object
+                type: array
+              failoverDelay:
+                default: 0
+                description: The amount of time (in seconds) to wait before triggering
+                  a failover after the primary PostgreSQL instance in the cluster
+                  was detected to be unhealthy
+                format: int32
+                type: integer
+              imageName:
+                description: Name of the container image, supporting both tags (`<image>:<tag>`)
+                  and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`)
+                type: string
+              imagePullPolicy:
+                description: 'Image pull policy. One of `Always`, `Never` or `IfNotPresent`.
+                  If not defined, it defaults to `IfNotPresent`. Cannot be updated.
+                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                type: string
+              imagePullSecrets:
+                description: The list of pull secrets to be used to pull the images
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate a local object with a known type inside the same
+                    namespace
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              inheritedMetadata:
+                description: Metadata that will be inherited by all objects related
+                  to the Cluster
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              instances:
+                default: 1
+                description: Number of instances required in the cluster
+                minimum: 1
+                type: integer
+              logLevel:
+                default: info
+                description: 'The instances'' log level, one of the following values:
+                  error, warning, info (default), debug, trace'
+                enum:
+                - error
+                - warning
+                - info
+                - debug
+                - trace
+                type: string
+              managed:
+                description: The configuration that is used by the portions of PostgreSQL
+                  that are managed by the instance manager
+                properties:
+                  roles:
+                    description: Database roles managed by the `Cluster`
+                    items:
+                      description: "RoleConfiguration is the representation, in Kubernetes,
+                        of a PostgreSQL role with the additional field Ensure specifying
+                        whether to ensure the presence or absence of the role in the
+                        database \n The defaults of the CREATE ROLE command are applied
+                        Reference: https://www.postgresql.org/docs/current/sql-createrole.html"
+                      properties:
+                        bypassrls:
+                          description: Whether a role bypasses every row-level security
+                            (RLS) policy. Default is `false`.
+                          type: boolean
+                        comment:
+                          description: Description of the role
+                          type: string
+                        connectionLimit:
+                          default: -1
+                          description: If the role can log in, this specifies how
+                            many concurrent connections the role can make. `-1` (the
+                            default) means no limit.
+                          format: int64
+                          type: integer
+                        createdb:
+                          description: When set to `true`, the role being defined
+                            will be allowed to create new databases. Specifying `false`
+                            (default) will deny a role the ability to create databases.
+                          type: boolean
+                        createrole:
+                          description: Whether the role will be permitted to create,
+                            alter, drop, comment on, change the security label for,
+                            and grant or revoke membership in other roles. Default
+                            is `false`.
+                          type: boolean
+                        disablePassword:
+                          description: DisablePassword indicates that a role's password
+                            should be set to NULL in Postgres
+                          type: boolean
+                        ensure:
+                          default: present
+                          description: Ensure the role is `present` or `absent` -
+                            defaults to "present"
+                          enum:
+                          - present
+                          - absent
+                          type: string
+                        inRoles:
+                          description: List of one or more existing roles to which
+                            this role will be immediately added as a new member. Default
+                            empty.
+                          items:
+                            type: string
+                          type: array
+                        inherit:
+                          default: true
+                          description: Whether a role "inherits" the privileges of
+                            roles it is a member of. Defaults is `true`.
+                          type: boolean
+                        login:
+                          description: Whether the role is allowed to log in. A role
+                            having the `login` attribute can be thought of as a user.
+                            Roles without this attribute are useful for managing database
+                            privileges, but are not users in the usual sense of the
+                            word. Default is `false`.
+                          type: boolean
+                        name:
+                          description: Name of the role
+                          type: string
+                        passwordSecret:
+                          description: Secret containing the password of the role
+                            (if present) If null, the password will be ignored unless
+                            DisablePassword is set
+                          properties:
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        replication:
+                          description: Whether a role is a replication role. A role
+                            must have this attribute (or be a superuser) in order
+                            to be able to connect to the server in replication mode
+                            (physical or logical replication) and in order to be able
+                            to create or drop replication slots. A role having the
+                            `replication` attribute is a very highly privileged role,
+                            and should only be used on roles actually used for replication.
+                            Default is `false`.
+                          type: boolean
+                        superuser:
+                          description: Whether the role is a `superuser` who can override
+                            all access restrictions within the database - superuser
+                            status is dangerous and should be used only when really
+                            needed. You must yourself be a superuser to create a new
+                            superuser. Defaults is `false`.
+                          type: boolean
+                        validUntil:
+                          description: Date and time after which the role's password
+                            is no longer valid. When omitted, the password will never
+                            expire (default).
+                          format: date-time
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              maxSyncReplicas:
+                default: 0
+                description: The target value for the synchronous replication quorum,
+                  that can be decreased if the number of ready standbys is lower than
+                  this. Undefined or 0 disable synchronous replication.
+                minimum: 0
+                type: integer
+              minSyncReplicas:
+                default: 0
+                description: Minimum number of instances required in synchronous replication
+                  with the primary. Undefined or 0 allow writes to complete when no
+                  standby is available.
+                minimum: 0
+                type: integer
+              monitoring:
+                description: The configuration of the monitoring infrastructure of
+                  this cluster
+                properties:
+                  customQueriesConfigMap:
+                    description: The list of config maps containing the custom queries
+                    items:
+                      description: ConfigMapKeySelector contains enough information
+                        to let you locate the key of a ConfigMap
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                  customQueriesSecret:
+                    description: The list of secrets containing the custom queries
+                    items:
+                      description: SecretKeySelector contains enough information to
+                        let you locate the key of a Secret
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                  disableDefaultQueries:
+                    default: false
+                    description: 'Whether the default queries should be injected.
+                      Set it to `true` if you don''t want to inject default queries
+                      into the cluster. Default: false.'
+                    type: boolean
+                  enablePodMonitor:
+                    default: false
+                    description: Enable or disable the `PodMonitor`
+                    type: boolean
+                  podMonitorMetricRelabelings:
+                    description: The list of metric relabelings for the `PodMonitor`.
+                      Applied to samples before ingestion.
+                    items:
+                      description: "RelabelConfig allows dynamic rewriting of the
+                        label set for targets, alerts, scraped samples and remote
+                        write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                      properties:
+                        action:
+                          default: replace
+                          description: "Action to perform based on the regex matching.
+                            \n `Uppercase` and `Lowercase` actions require Prometheus
+                            >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                            Prometheus >= v2.41.0. \n Default: \"Replace\""
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: "Modulus to take of the hash of the source
+                            label values. \n Only applicable when the action is `HashMod`."
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: "Replacement value against which a Replace
+                            action is performed if the regular expression matches.
+                            \n Regex capture groups are available."
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            Separator and matched against the configured regular expression.
+                          items:
+                            description: LabelName is a valid Prometheus label name
+                              which may only contain ASCII letters, numbers, as well
+                              as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: "Label to which the resulting string is written
+                            in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                            `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual`
+                            actions. \n Regex capture groups are available."
+                          type: string
+                      type: object
+                    type: array
+                  podMonitorRelabelings:
+                    description: The list of relabelings for the `PodMonitor`. Applied
+                      to samples before scraping.
+                    items:
+                      description: "RelabelConfig allows dynamic rewriting of the
+                        label set for targets, alerts, scraped samples and remote
+                        write samples. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
+                      properties:
+                        action:
+                          default: replace
+                          description: "Action to perform based on the regex matching.
+                            \n `Uppercase` and `Lowercase` actions require Prometheus
+                            >= v2.36.0. `DropEqual` and `KeepEqual` actions require
+                            Prometheus >= v2.41.0. \n Default: \"Replace\""
+                          enum:
+                          - replace
+                          - Replace
+                          - keep
+                          - Keep
+                          - drop
+                          - Drop
+                          - hashmod
+                          - HashMod
+                          - labelmap
+                          - LabelMap
+                          - labeldrop
+                          - LabelDrop
+                          - labelkeep
+                          - LabelKeep
+                          - lowercase
+                          - Lowercase
+                          - uppercase
+                          - Uppercase
+                          - keepequal
+                          - KeepEqual
+                          - dropequal
+                          - DropEqual
+                          type: string
+                        modulus:
+                          description: "Modulus to take of the hash of the source
+                            label values. \n Only applicable when the action is `HashMod`."
+                          format: int64
+                          type: integer
+                        regex:
+                          description: Regular expression against which the extracted
+                            value is matched.
+                          type: string
+                        replacement:
+                          description: "Replacement value against which a Replace
+                            action is performed if the regular expression matches.
+                            \n Regex capture groups are available."
+                          type: string
+                        separator:
+                          description: Separator is the string between concatenated
+                            SourceLabels.
+                          type: string
+                        sourceLabels:
+                          description: The source labels select values from existing
+                            labels. Their content is concatenated using the configured
+                            Separator and matched against the configured regular expression.
+                          items:
+                            description: LabelName is a valid Prometheus label name
+                              which may only contain ASCII letters, numbers, as well
+                              as underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          type: array
+                        targetLabel:
+                          description: "Label to which the resulting string is written
+                            in a replacement. \n It is mandatory for `Replace`, `HashMod`,
+                            `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual`
+                            actions. \n Regex capture groups are available."
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              nodeMaintenanceWindow:
+                description: Define a maintenance window for the Kubernetes nodes
+                properties:
+                  inProgress:
+                    default: false
+                    description: Is there a node maintenance activity in progress?
+                    type: boolean
+                  reusePVC:
+                    default: true
+                    description: Reuse the existing PVC (wait for the node to come
+                      up again) or not (recreate it elsewhere - when `instances` >1)
+                    type: boolean
+                type: object
+              postgresGID:
+                default: 26
+                description: The GID of the `postgres` user inside the image, defaults
+                  to `26`
+                format: int64
+                type: integer
+              postgresUID:
+                default: 26
+                description: The UID of the `postgres` user inside the image, defaults
+                  to `26`
+                format: int64
+                type: integer
+              postgresql:
+                description: Configuration of the PostgreSQL server
+                properties:
+                  enableAlterSystem:
+                    description: If this parameter is true, the user will be able
+                      to invoke `ALTER SYSTEM` on this CloudNativePG Cluster. This
+                      should only be used for debugging and troubleshooting. Defaults
+                      to false.
+                    type: boolean
+                  ldap:
+                    description: Options to specify LDAP configuration
+                    properties:
+                      bindAsAuth:
+                        description: Bind as authentication configuration
+                        properties:
+                          prefix:
+                            description: Prefix for the bind authentication option
+                            type: string
+                          suffix:
+                            description: Suffix for the bind authentication option
+                            type: string
+                        type: object
+                      bindSearchAuth:
+                        description: Bind+Search authentication configuration
+                        properties:
+                          baseDN:
+                            description: Root DN to begin the user search
+                            type: string
+                          bindDN:
+                            description: DN of the user to bind to the directory
+                            type: string
+                          bindPassword:
+                            description: Secret with the password for the user to
+                              bind to the directory
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          searchAttribute:
+                            description: Attribute to match against the username
+                            type: string
+                          searchFilter:
+                            description: Search filter to use when doing the search+bind
+                              authentication
+                            type: string
+                        type: object
+                      port:
+                        description: LDAP server port
+                        type: integer
+                      scheme:
+                        description: LDAP schema to be used, possible options are
+                          `ldap` and `ldaps`
+                        enum:
+                        - ldap
+                        - ldaps
+                        type: string
+                      server:
+                        description: LDAP hostname or IP address
+                        type: string
+                      tls:
+                        description: Set to 'true' to enable LDAP over TLS. 'false'
+                          is default
+                        type: boolean
+                    type: object
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: PostgreSQL configuration options (postgresql.conf)
+                    type: object
+                  pg_hba:
+                    description: PostgreSQL Host Based Authentication rules (lines
+                      to be appended to the pg_hba.conf file)
+                    items:
+                      type: string
+                    type: array
+                  promotionTimeout:
+                    description: Specifies the maximum number of seconds to wait when
+                      promoting an instance to primary. Default value is 40000000,
+                      greater than one year in seconds, big enough to simulate an
+                      infinite timeout
+                    format: int32
+                    type: integer
+                  shared_preload_libraries:
+                    description: Lists of shared preload libraries to add to the default
+                      ones
+                    items:
+                      type: string
+                    type: array
+                  syncReplicaElectionConstraint:
+                    description: Requirements to be met by sync replicas. This will
+                      affect how the "synchronous_standby_names" parameter will be
+                      set up.
+                    properties:
+                      enabled:
+                        description: This flag enables the constraints for sync replicas
+                        type: boolean
+                      nodeLabelsAntiAffinity:
+                        description: A list of node labels values to extract and compare
+                          to evaluate if the pods reside in the same topology or not
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - enabled
+                    type: object
+                type: object
+              primaryUpdateMethod:
+                default: restart
+                description: 'Method to follow to upgrade the primary server during
+                  a rolling update procedure, after all replicas have been successfully
+                  updated: it can be with a switchover (`switchover`) or in-place
+                  (`restart` - default)'
+                enum:
+                - switchover
+                - restart
+                type: string
+              primaryUpdateStrategy:
+                default: unsupervised
+                description: 'Deployment strategy to follow to upgrade the primary
+                  server during a rolling update procedure, after all replicas have
+                  been successfully updated: it can be automated (`unsupervised` -
+                  default) or manual (`supervised`)'
+                enum:
+                - unsupervised
+                - supervised
+                type: string
+              priorityClassName:
+                description: Name of the priority class which will be used in every
+                  generated Pod, if the PriorityClass specified does not exist, the
+                  pod will not be able to schedule.  Please refer to https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
+                  for more information
+                type: string
+              projectedVolumeTemplate:
+                description: Template to be used to define projected volumes, projected
+                  volumes will be mounted under `/projected` base folder
+                properties:
+                  defaultMode:
+                    description: defaultMode are the mode bits used to set permissions
+                      on created files by default. Must be an octal value between
+                      0000 and 0777 or a decimal value between 0 and 511. YAML accepts
+                      both octal and decimal values, JSON requires decimal values
+                      for mode bits. Directories within the path are not affected
+                      by this setting. This might be in conflict with other options
+                      that affect the file mode, like fsGroup, and the result can
+                      be other mode bits set.
+                    format: int32
+                    type: integer
+                  sources:
+                    description: sources is the list of volume projections
+                    items:
+                      description: Projection that may be projected along with other
+                        supported volume types
+                      properties:
+                        configMap:
+                          description: configMap information about the configMap data
+                            to project
+                          properties:
+                            items:
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        downwardAPI:
+                          description: downwardAPI information about the downwardAPI
+                            data to project
+                          properties:
+                            items:
+                              description: Items is a list of DownwardAPIVolume file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        secret:
+                          description: secret information about the secret data to
+                            project
+                          properties:
+                            items:
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its key must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        serviceAccountToken:
+                          description: serviceAccountToken is information about the
+                            serviceAccountToken data to project
+                          properties:
+                            audience:
+                              description: audience is the intended audience of the
+                                token. A recipient of a token must identify itself
+                                with an identifier specified in the audience of the
+                                token, and otherwise should reject the token. The
+                                audience defaults to the identifier of the apiserver.
+                              type: string
+                            expirationSeconds:
+                              description: expirationSeconds is the requested duration
+                                of validity of the service account token. As the token
+                                approaches expiration, the kubelet volume plugin will
+                                proactively rotate the service account token. The
+                                kubelet will start trying to rotate the token if the
+                                token is older than 80 percent of its time to live
+                                or if the token is older than 24 hours.Defaults to
+                                1 hour and must be at least 10 minutes.
+                              format: int64
+                              type: integer
+                            path:
+                              description: path is the path relative to the mount
+                                point of the file to project the token into.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              replica:
+                description: Replica cluster configuration
+                properties:
+                  enabled:
+                    description: If replica mode is enabled, this cluster will be
+                      a replica of an existing cluster. Replica cluster can be created
+                      from a recovery object store or via streaming through pg_basebackup.
+                      Refer to the Replica clusters page of the documentation for
+                      more information.
+                    type: boolean
+                  source:
+                    description: The name of the external cluster which is the replication
+                      origin
+                    minLength: 1
+                    type: string
+                required:
+                - enabled
+                - source
+                type: object
+              replicationSlots:
+                default:
+                  highAvailability:
+                    enabled: true
+                description: Replication slots management configuration
+                properties:
+                  highAvailability:
+                    default:
+                      enabled: true
+                    description: Replication slots for high availability configuration
+                    properties:
+                      enabled:
+                        default: true
+                        description: If enabled (default), the operator will automatically
+                          manage replication slots on the primary instance and use
+                          them in streaming replication connections with all the standby
+                          instances that are part of the HA cluster. If disabled,
+                          the operator will not take advantage of replication slots
+                          in streaming connections with the replicas. This feature
+                          also controls replication slots in replica cluster, from
+                          the designated primary to its cascading replicas.
+                        type: boolean
+                      slotPrefix:
+                        default: _cnpg_
+                        description: Prefix for replication slots managed by the operator
+                          for HA. It may only contain lower case letters, numbers,
+                          and the underscore character. This can only be set at creation
+                          time. By default set to `_cnpg_`.
+                        pattern: ^[0-9a-z_]*$
+                        type: string
+                    type: object
+                  updateInterval:
+                    default: 30
+                    description: Standby will update the status of the local replication
+                      slots every `updateInterval` seconds (default 30).
+                    minimum: 1
+                    type: integer
+                type: object
+              resources:
+                description: Resources requirements of every generated Pod. Please
+                  refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                  for more information.
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              schedulerName:
+                description: 'If specified, the pod will be dispatched by specified
+                  Kubernetes scheduler. If not specified, the pod will be dispatched
+                  by the default scheduler. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/'
+                type: string
+              seccompProfile:
+                description: 'The SeccompProfile applied to every Pod and Container.
+                  Defaults to: `RuntimeDefault`'
+                properties:
+                  localhostProfile:
+                    description: localhostProfile indicates a profile defined in a
+                      file on the node should be used. The profile must be preconfigured
+                      on the node to work. Must be a descending path, relative to
+                      the kubelet's configured seccomp profile location. Must be set
+                      if type is "Localhost". Must NOT be set for any other type.
+                    type: string
+                  type:
+                    description: "type indicates which kind of seccomp profile will
+                      be applied. Valid options are: \n Localhost - a profile defined
+                      in a file on the node should be used. RuntimeDefault - the container
+                      runtime default profile should be used. Unconfined - no profile
+                      should be applied."
+                    type: string
+                required:
+                - type
+                type: object
+              serviceAccountTemplate:
+                description: Configure the generation of the service account
+                properties:
+                  metadata:
+                    description: Metadata are the metadata to be used for the generated
+                      service account
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                required:
+                - metadata
+                type: object
+              smartShutdownTimeout:
+                default: 180
+                description: 'The time in seconds that controls the window of time
+                  reserved for the smart shutdown of Postgres to complete. Make sure
+                  you reserve enough time for the operator to request a fast shutdown
+                  of Postgres (that is: `stopDelay` - `smartShutdownTimeout`).'
+                format: int32
+                type: integer
+              startDelay:
+                default: 3600
+                description: 'The time in seconds that is allowed for a PostgreSQL
+                  instance to successfully start up (default 3600). The startup probe
+                  failure threshold is derived from this value using the formula:
+                  ceiling(startDelay / 10).'
+                format: int32
+                type: integer
+              stopDelay:
+                default: 1800
+                description: The time in seconds that is allowed for a PostgreSQL
+                  instance to gracefully shutdown (default 1800)
+                format: int32
+                type: integer
+              storage:
+                description: Configuration of the storage of the instances
+                properties:
+                  pvcTemplate:
+                    description: Template to be used to generate the Persistent Volume
+                      Claim
+                    properties:
+                      accessModes:
+                        description: 'accessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim) If the provisioner
+                          or an external controller can support the specified data
+                          source, it will create a new volume based on the contents
+                          of the specified data source. When the AnyVolumeDataSource
+                          feature gate is enabled, dataSource contents will be copied
+                          to dataSourceRef, and dataSourceRef contents will be copied
+                          to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not
+                          be copied to dataSource.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: 'dataSourceRef specifies the object from which
+                          to populate the volume with data, if a non-empty volume
+                          is desired. This may be any object from a non-empty API
+                          group (non core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed
+                          if the type of the specified object matches some installed
+                          volume populator or dynamic provisioner. This field will
+                          replace the functionality of the dataSource field and as
+                          such if both fields are non-empty, they must have the same
+                          value. For backwards compatibility, when namespace isn''t
+                          specified in dataSourceRef, both fields (dataSource and
+                          dataSourceRef) will be set to the same value automatically
+                          if one of them is empty and the other is non-empty. When
+                          namespace is specified in dataSourceRef, dataSource isn''t
+                          set to the same value and must be empty. There are three
+                          important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects,
+                          dataSourceRef allows any non-core object, as well as PersistentVolumeClaim
+                          objects. * While dataSource ignores disallowed values (dropping
+                          them), dataSourceRef preserves all values, and generates
+                          an error if a disallowed value is specified. * While dataSource
+                          only allows local objects, dataSourceRef allows objects
+                          in any namespaces. (Beta) Using this field requires the
+                          AnyVolumeDataSource feature gate to be enabled. (Alpha)
+                          Using the namespace field of dataSourceRef requires the
+                          CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of resource being
+                              referenced Note that when a namespace is specified,
+                              a gateway.networking.k8s.io/ReferenceGrant object is
+                              required in the referent namespace to allow that namespace's
+                              owner to accept the reference. See the ReferenceGrant
+                              documentation for details. (Alpha) This field requires
+                              the CrossNamespaceVolumeDataSource feature gate to be
+                              enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: 'resources represents the minimum resources the
+                          volume should have. If RecoverVolumeExpansionFailure feature
+                          is enabled users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher
+                          than capacity recorded in the status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: 'storageClassName is the name of the StorageClass
+                          required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required
+                          by the claim. Value of Filesystem is implied when not included
+                          in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  resizeInUseVolumes:
+                    default: true
+                    description: Resize existent PVCs, defaults to true
+                    type: boolean
+                  size:
+                    description: Size of the storage. Required if not already specified
+                      in the PVC template. Changes to this field are automatically
+                      reapplied to the created PVCs. Size cannot be decreased.
+                    type: string
+                  storageClass:
+                    description: StorageClass to use for PVCs. Applied after evaluating
+                      the PVC template, if available. If not specified, the generated
+                      PVCs will use the default storage class
+                    type: string
+                type: object
+              superuserSecret:
+                description: The secret containing the superuser password. If not
+                  defined a new secret will be created with a randomly generated password
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              switchoverDelay:
+                default: 3600
+                description: The time in seconds that is allowed for a primary PostgreSQL
+                  instance to gracefully shutdown during a switchover. Default value
+                  is 3600 seconds (1 hour).
+                format: int32
+                type: integer
+              tablespaces:
+                description: The tablespaces configuration
+                items:
+                  description: TablespaceConfiguration is the configuration of a tablespace,
+                    and includes the storage specification for the tablespace
+                  properties:
+                    name:
+                      description: The name of the tablespace
+                      type: string
+                    owner:
+                      description: Owner is the PostgreSQL user owning the tablespace
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    storage:
+                      description: The storage configuration for the tablespace
+                      properties:
+                        pvcTemplate:
+                          description: Template to be used to generate the Persistent
+                            Volume Claim
+                          properties:
+                            accessModes:
+                              description: 'accessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'dataSource field can be used to specify
+                                either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                * An existing PVC (PersistentVolumeClaim) If the provisioner
+                                or an external controller can support the specified
+                                data source, it will create a new volume based on
+                                the contents of the specified data source. When the
+                                AnyVolumeDataSource feature gate is enabled, dataSource
+                                contents will be copied to dataSourceRef, and dataSourceRef
+                                contents will be copied to dataSource when dataSourceRef.namespace
+                                is not specified. If the namespace is specified, then
+                                dataSourceRef will not be copied to dataSource.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            dataSourceRef:
+                              description: 'dataSourceRef specifies the object from
+                                which to populate the volume with data, if a non-empty
+                                volume is desired. This may be any object from a non-empty
+                                API group (non core object) or a PersistentVolumeClaim
+                                object. When this field is specified, volume binding
+                                will only succeed if the type of the specified object
+                                matches some installed volume populator or dynamic
+                                provisioner. This field will replace the functionality
+                                of the dataSource field and as such if both fields
+                                are non-empty, they must have the same value. For
+                                backwards compatibility, when namespace isn''t specified
+                                in dataSourceRef, both fields (dataSource and dataSourceRef)
+                                will be set to the same value automatically if one
+                                of them is empty and the other is non-empty. When
+                                namespace is specified in dataSourceRef, dataSource
+                                isn''t set to the same value and must be empty. There
+                                are three important differences between dataSource
+                                and dataSourceRef: * While dataSource only allows
+                                two specific types of objects, dataSourceRef allows
+                                any non-core object, as well as PersistentVolumeClaim
+                                objects. * While dataSource ignores disallowed values
+                                (dropping them), dataSourceRef preserves all values,
+                                and generates an error if a disallowed value is specified.
+                                * While dataSource only allows local objects, dataSourceRef
+                                allows objects in any namespaces. (Beta) Using this
+                                field requires the AnyVolumeDataSource feature gate
+                                to be enabled. (Alpha) Using the namespace field of
+                                dataSourceRef requires the CrossNamespaceVolumeDataSource
+                                feature gate to be enabled.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of resource
+                                    being referenced Note that when a namespace is
+                                    specified, a gateway.networking.k8s.io/ReferenceGrant
+                                    object is required in the referent namespace to
+                                    allow that namespace's owner to accept the reference.
+                                    See the ReferenceGrant documentation for details.
+                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource
+                                    feature gate to be enabled.
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'resources represents the minimum resources
+                                the volume should have. If RecoverVolumeExpansionFailure
+                                feature is enabled users are allowed to specify resource
+                                requirements that are lower than previous value but
+                                must still be higher than capacity recorded in the
+                                status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                claims:
+                                  description: "Claims lists the names of resources,
+                                    defined in spec.resourceClaims, that are used
+                                    by this container. \n This is an alpha field and
+                                    requires enabling the DynamicResourceAllocation
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: Name must match the name of one
+                                          entry in pod.spec.resourceClaims of the
+                                          Pod where this field is used. It makes that
+                                          resource available inside a container.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. Requests cannot
+                                    exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: selector is a label query over volumes
+                                to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            storageClassName:
+                              description: 'storageClassName is the name of the StorageClass
+                                required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: volumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                        resizeInUseVolumes:
+                          default: true
+                          description: Resize existent PVCs, defaults to true
+                          type: boolean
+                        size:
+                          description: Size of the storage. Required if not already
+                            specified in the PVC template. Changes to this field are
+                            automatically reapplied to the created PVCs. Size cannot
+                            be decreased.
+                          type: string
+                        storageClass:
+                          description: StorageClass to use for PVCs. Applied after
+                            evaluating the PVC template, if available. If not specified,
+                            the generated PVCs will use the default storage class
+                          type: string
+                      type: object
+                    temporary:
+                      default: false
+                      description: When set to true, the tablespace will be added
+                        as a `temp_tablespaces` entry in PostgreSQL, and will be available
+                        to automatically house temp database objects, or other temporary
+                        files. Please refer to PostgreSQL documentation for more information
+                        on the `temp_tablespaces` GUC.
+                      type: boolean
+                  required:
+                  - name
+                  - storage
+                  type: object
+                type: array
+              topologySpreadConstraints:
+                description: 'TopologySpreadConstraints specifies how to spread matching
+                  pods among the given topology. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/'
+                items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
+                  properties:
+                    labelSelector:
+                      description: LabelSelector is used to find matching pods. Pods
+                        that match this label selector are counted to determine the
+                        number of pods in their corresponding topology domain.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: "MatchLabelKeys is a set of pod label keys to select
+                        the pods over which spreading will be calculated. The keys
+                        are used to lookup values from the incoming pod labels, those
+                        key-value labels are ANDed with labelSelector to select the
+                        group of existing pods over which spreading will be calculated
+                        for the incoming pod. The same key is forbidden to exist in
+                        both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot
+                        be set when LabelSelector isn't set. Keys that don't exist
+                        in the incoming pod labels will be ignored. A null or empty
+                        list means only match against labelSelector. \n This is a
+                        beta field and requires the MatchLabelKeysInPodTopologySpread
+                        feature gate to be enabled (enabled by default)."
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    maxSkew:
+                      description: 'MaxSkew describes the degree to which pods may
+                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                        it is the maximum permitted difference between the number
+                        of matching pods in the target topology and the global minimum.
+                        The global minimum is the minimum number of matching pods
+                        in an eligible domain or zero if the number of eligible domains
+                        is less than MinDomains. For example, in a 3-zone cluster,
+                        MaxSkew is set to 1, and pods with the same labelSelector
+                        spread as 2/2/1: In this case, the global minimum is 1. |
+                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                        is 1, incoming pod can only be scheduled to zone3 to become
+                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
+                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
+                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                        it is used to give higher precedence to topologies that satisfy
+                        it. It''s a required field. Default value is 1 and 0 is not
+                        allowed.'
+                      format: int32
+                      type: integer
+                    minDomains:
+                      description: "MinDomains indicates a minimum number of eligible
+                        domains. When the number of eligible domains with matching
+                        topology keys is less than minDomains, Pod Topology Spread
+                        treats \"global minimum\" as 0, and then the calculation of
+                        Skew is performed. And when the number of eligible domains
+                        with matching topology keys equals or greater than minDomains,
+                        this value has no effect on scheduling. As a result, when
+                        the number of eligible domains is less than minDomains, scheduler
+                        won't schedule more than maxSkew Pods to those domains. If
+                        value is nil, the constraint behaves as if MinDomains is equal
+                        to 1. Valid values are integers greater than 0. When value
+                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
+                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
+                        is set to 5 and pods with the same labelSelector spread as
+                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                        The number of domains is less than 5(MinDomains), so \"global
+                        minimum\" is treated as 0. In this situation, new pod with
+                        the same labelSelector cannot be scheduled, because computed
+                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
+                        three zones, it will violate MaxSkew. \n This is a beta field
+                        and requires the MinDomainsInPodTopologySpread feature gate
+                        to be enabled (enabled by default)."
+                      format: int32
+                      type: integer
+                    nodeAffinityPolicy:
+                      description: "NodeAffinityPolicy indicates how we will treat
+                        Pod's nodeAffinity/nodeSelector when calculating pod topology
+                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                        are ignored. All nodes are included in the calculations. \n
+                        If this value is nil, the behavior is equivalent to the Honor
+                        policy. This is a beta-level feature default enabled by the
+                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                      type: string
+                    nodeTaintsPolicy:
+                      description: "NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew. Options
+                        are: - Honor: nodes without taints, along with tainted nodes
+                        for which the incoming pod has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+                        \n If this value is nil, the behavior is equivalent to the
+                        Ignore policy. This is a beta-level feature default enabled
+                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                      type: string
+                    topologyKey:
+                      description: TopologyKey is the key of node labels. Nodes that
+                        have a label with this key and identical values are considered
+                        to be in the same topology. We consider each <key, value>
+                        as a "bucket", and try to put balanced number of pods into
+                        each bucket. We define a domain as a particular instance of
+                        a topology. Also, we define an eligible domain as a domain
+                        whose nodes meet the requirements of nodeAffinityPolicy and
+                        nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                        each Node is a domain of that topology. And, if TopologyKey
+                        is "topology.kubernetes.io/zone", each zone is a domain of
+                        that topology. It's a required field.
+                      type: string
+                    whenUnsatisfiable:
+                      description: 'WhenUnsatisfiable indicates how to deal with a
+                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
+                        tells the scheduler to schedule the pod in any location, but
+                        giving higher precedence to topologies that would help reduce
+                        the skew. A constraint is considered "Unsatisfiable" for an
+                        incoming pod if and only if every possible node assignment
+                        for that pod would violate "MaxSkew" on some topology. For
+                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
+                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
+                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
+                        set to DoNotSchedule, incoming pod can only be scheduled to
+                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
+                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
+                        can still be imbalanced, but scheduler won''t make it *more*
+                        imbalanced. It''s a required field.'
+                      type: string
+                  required:
+                  - maxSkew
+                  - topologyKey
+                  - whenUnsatisfiable
+                  type: object
+                type: array
+              walStorage:
+                description: Configuration of the storage for PostgreSQL WAL (Write-Ahead
+                  Log)
+                properties:
+                  pvcTemplate:
+                    description: Template to be used to generate the Persistent Volume
+                      Claim
+                    properties:
+                      accessModes:
+                        description: 'accessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim) If the provisioner
+                          or an external controller can support the specified data
+                          source, it will create a new volume based on the contents
+                          of the specified data source. When the AnyVolumeDataSource
+                          feature gate is enabled, dataSource contents will be copied
+                          to dataSourceRef, and dataSourceRef contents will be copied
+                          to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not
+                          be copied to dataSource.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: 'dataSourceRef specifies the object from which
+                          to populate the volume with data, if a non-empty volume
+                          is desired. This may be any object from a non-empty API
+                          group (non core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed
+                          if the type of the specified object matches some installed
+                          volume populator or dynamic provisioner. This field will
+                          replace the functionality of the dataSource field and as
+                          such if both fields are non-empty, they must have the same
+                          value. For backwards compatibility, when namespace isn''t
+                          specified in dataSourceRef, both fields (dataSource and
+                          dataSourceRef) will be set to the same value automatically
+                          if one of them is empty and the other is non-empty. When
+                          namespace is specified in dataSourceRef, dataSource isn''t
+                          set to the same value and must be empty. There are three
+                          important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects,
+                          dataSourceRef allows any non-core object, as well as PersistentVolumeClaim
+                          objects. * While dataSource ignores disallowed values (dropping
+                          them), dataSourceRef preserves all values, and generates
+                          an error if a disallowed value is specified. * While dataSource
+                          only allows local objects, dataSourceRef allows objects
+                          in any namespaces. (Beta) Using this field requires the
+                          AnyVolumeDataSource feature gate to be enabled. (Alpha)
+                          Using the namespace field of dataSourceRef requires the
+                          CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of resource being
+                              referenced Note that when a namespace is specified,
+                              a gateway.networking.k8s.io/ReferenceGrant object is
+                              required in the referent namespace to allow that namespace's
+                              owner to accept the reference. See the ReferenceGrant
+                              documentation for details. (Alpha) This field requires
+                              the CrossNamespaceVolumeDataSource feature gate to be
+                              enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: 'resources represents the minimum resources the
+                          volume should have. If RecoverVolumeExpansionFailure feature
+                          is enabled users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher
+                          than capacity recorded in the status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                              in spec.resourceClaims, that are used by this container.
+                              \n This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate. \n This field
+                              is immutable. It can only be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: 'storageClassName is the name of the StorageClass
+                          required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required
+                          by the claim. Value of Filesystem is implied when not included
+                          in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  resizeInUseVolumes:
+                    default: true
+                    description: Resize existent PVCs, defaults to true
+                    type: boolean
+                  size:
+                    description: Size of the storage. Required if not already specified
+                      in the PVC template. Changes to this field are automatically
+                      reapplied to the created PVCs. Size cannot be decreased.
+                    type: string
+                  storageClass:
+                    description: StorageClass to use for PVCs. Applied after evaluating
+                      the PVC template, if available. If not specified, the generated
+                      PVCs will use the default storage class
+                    type: string
+                type: object
+            required:
+            - instances
+            type: object
+          status:
+            description: 'Most recently observed status of the cluster. This data
+              may not be up to date. Populated by the system. Read-only. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              azurePVCUpdateEnabled:
+                description: AzurePVCUpdateEnabled shows if the PVC online upgrade
+                  is enabled for this cluster
+                type: boolean
+              certificates:
+                description: The configuration for the CA and related certificates,
+                  initialized with defaults.
+                properties:
+                  clientCASecret:
+                    description: 'The secret containing the Client CA certificate.
+                      If not defined, a new secret will be created with a self-signed
+                      CA and will be used to generate all the client certificates.<br
+                      /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
+                      be used to validate the client certificates, used as `ssl_ca_file`
+                      of all the instances.<br /> - `ca.key`: key used to generate
+                      client certificates, if ReplicationTLSSecret is provided, this
+                      can be omitted.<br />'
+                    type: string
+                  expirations:
+                    additionalProperties:
+                      type: string
+                    description: Expiration dates for all certificates.
+                    type: object
+                  replicationTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the
+                      client certificate to authenticate as the `streaming_replica`
+                      user. If not defined, ClientCASecret must provide also `ca.key`,
+                      and a new secret will be created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be
+                      added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: 'The secret containing the Server CA certificate.
+                      If not defined, a new secret will be created with a self-signed
+                      CA and will be used to generate the TLS certificate ServerTLSSecret.<br
+                      /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should
+                      be used to validate the server certificate, used as `sslrootcert`
+                      in client connection strings.<br /> - `ca.key`: key used to
+                      generate Server SSL certs, if ServerTLSSecret is provided, this
+                      can be omitted.<br />'
+                    type: string
+                  serverTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the
+                      server TLS certificate and key that will be set as `ssl_cert_file`
+                      and `ssl_key_file` so that clients can connect to postgres securely.
+                      If not defined, ServerCASecret must provide also `ca.key` and
+                      a new secret will be created using the provided CA.
+                    type: string
+                type: object
+              cloudNativePGCommitHash:
+                description: The commit hash number of which this operator running
+                type: string
+              cloudNativePGOperatorHash:
+                description: The hash of the binary of the operator
+                type: string
+              conditions:
+                description: Conditions for cluster object
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              configMapResourceVersion:
+                description: The list of resource versions of the configmaps, managed
+                  by the operator. Every change here is done in the interest of the
+                  instance manager, which will refresh the configmap data
+                properties:
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: A map with the versions of all the config maps used
+                      to pass metrics. Map keys are the config map names, map values
+                      are the versions
+                    type: object
+                type: object
+              currentPrimary:
+                description: Current primary instance
+                type: string
+              currentPrimaryFailingSinceTimestamp:
+                description: The timestamp when the primary was detected to be unhealthy
+                  This field is reported when `.spec.failoverDelay` is populated or
+                  during online upgrades
+                type: string
+              currentPrimaryTimestamp:
+                description: The timestamp when the last actual promotion to primary
+                  has occurred
+                type: string
+              danglingPVC:
+                description: List of all the PVCs created by this cluster and still
+                  available which are not attached to a Pod
+                items:
+                  type: string
+                type: array
+              firstRecoverabilityPoint:
+                description: The first recoverability point, stored as a date in RFC3339
+                  format. This field is calculated from the content of FirstRecoverabilityPointByMethod
+                type: string
+              firstRecoverabilityPointByMethod:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: The first recoverability point, stored as a date in RFC3339
+                  format, per backup method type
+                type: object
+              healthyPVC:
+                description: List of all the PVCs not dangling nor initializing
+                items:
+                  type: string
+                type: array
+              initializingPVC:
+                description: List of all the PVCs that are being initialized by this
+                  cluster
+                items:
+                  type: string
+                type: array
+              instanceNames:
+                description: List of instance names in the cluster
+                items:
+                  type: string
+                type: array
+              instances:
+                description: The total number of PVC Groups detected in the cluster.
+                  It may differ from the number of existing instance pods.
+                type: integer
+              instancesReportedState:
+                additionalProperties:
+                  description: InstanceReportedState describes the last reported state
+                    of an instance during a reconciliation loop
+                  properties:
+                    isPrimary:
+                      description: indicates if an instance is the primary one
+                      type: boolean
+                    timeLineID:
+                      description: indicates on which TimelineId the instance is
+                      type: integer
+                  required:
+                  - isPrimary
+                  type: object
+                description: The reported state of the instances during the last reconciliation
+                  loop
+                type: object
+              instancesStatus:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: InstancesStatus indicates in which status the instances
+                  are
+                type: object
+              jobCount:
+                description: How many Jobs have been created by this cluster
+                format: int32
+                type: integer
+              lastFailedBackup:
+                description: Stored as a date in RFC3339 format
+                type: string
+              lastSuccessfulBackup:
+                description: Last successful backup, stored as a date in RFC3339 format
+                  This field is calculated from the content of LastSuccessfulBackupByMethod
+                type: string
+              lastSuccessfulBackupByMethod:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: Last successful backup, stored as a date in RFC3339 format,
+                  per backup method type
+                type: object
+              latestGeneratedNode:
+                description: ID of the latest generated node (used to avoid node name
+                  clashing)
+                type: integer
+              managedRolesStatus:
+                description: ManagedRolesStatus reports the state of the managed roles
+                  in the cluster
+                properties:
+                  byStatus:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: ByStatus gives the list of roles in each state
+                    type: object
+                  cannotReconcile:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: CannotReconcile lists roles that cannot be reconciled
+                      in PostgreSQL, with an explanation of the cause
+                    type: object
+                  passwordStatus:
+                    additionalProperties:
+                      description: PasswordState represents the state of the password
+                        of a managed RoleConfiguration
+                      properties:
+                        resourceVersion:
+                          description: the resource version of the password secret
+                          type: string
+                        transactionID:
+                          description: the last transaction ID to affect the role
+                            definition in PostgreSQL
+                          format: int64
+                          type: integer
+                      type: object
+                    description: PasswordStatus gives the last transaction id and
+                      password secret version for each managed role
+                    type: object
+                type: object
+              onlineUpdateEnabled:
+                description: OnlineUpdateEnabled shows if the online upgrade is enabled
+                  inside the cluster
+                type: boolean
+              phase:
+                description: Current phase of the cluster
+                type: string
+              phaseReason:
+                description: Reason for the current phase
+                type: string
+              poolerIntegrations:
+                description: The integration needed by poolers referencing the cluster
+                properties:
+                  pgBouncerIntegration:
+                    description: PgBouncerIntegrationStatus encapsulates the needed
+                      integration for the pgbouncer poolers referencing the cluster
+                    properties:
+                      secrets:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              pvcCount:
+                description: How many PVCs have been created by this cluster
+                format: int32
+                type: integer
+              readService:
+                description: Current list of read pods
+                type: string
+              readyInstances:
+                description: The total number of ready instances in the cluster. It
+                  is equal to the number of ready instance pods.
+                type: integer
+              resizingPVC:
+                description: List of all the PVCs that have ResizingPVC condition.
+                items:
+                  type: string
+                type: array
+              secretsResourceVersion:
+                description: The list of resource versions of the secrets managed
+                  by the operator. Every change here is done in the interest of the
+                  instance manager, which will refresh the secret data
+                properties:
+                  applicationSecretVersion:
+                    description: The resource version of the "app" user secret
+                    type: string
+                  barmanEndpointCA:
+                    description: The resource version of the Barman Endpoint CA if
+                      provided
+                    type: string
+                  caSecretVersion:
+                    description: Unused. Retained for compatibility with old versions.
+                    type: string
+                  clientCaSecretVersion:
+                    description: The resource version of the PostgreSQL client-side
+                      CA secret version
+                    type: string
+                  externalClusterSecretVersion:
+                    additionalProperties:
+                      type: string
+                    description: The resource versions of the external cluster secrets
+                    type: object
+                  managedRoleSecretVersion:
+                    additionalProperties:
+                      type: string
+                    description: The resource versions of the managed roles secrets
+                    type: object
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: A map with the versions of all the secrets used to
+                      pass metrics. Map keys are the secret names, map values are
+                      the versions
+                    type: object
+                  replicationSecretVersion:
+                    description: The resource version of the "streaming_replica" user
+                      secret
+                    type: string
+                  serverCaSecretVersion:
+                    description: The resource version of the PostgreSQL server-side
+                      CA secret version
+                    type: string
+                  serverSecretVersion:
+                    description: The resource version of the PostgreSQL server-side
+                      secret version
+                    type: string
+                  superuserSecretVersion:
+                    description: The resource version of the "postgres" user secret
+                    type: string
+                type: object
+              tablespacesStatus:
+                description: TablespacesStatus reports the state of the declarative
+                  tablespaces in the cluster
+                items:
+                  description: TablespaceState represents the state of a tablespace
+                    in a cluster
+                  properties:
+                    error:
+                      description: Error is the reconciliation error, if any
+                      type: string
+                    name:
+                      description: Name is the name of the tablespace
+                      type: string
+                    owner:
+                      description: Owner is the PostgreSQL user owning the tablespace
+                      type: string
+                    state:
+                      description: State is the latest reconciliation state
+                      type: string
+                  required:
+                  - name
+                  - state
+                  type: object
+                type: array
+              targetPrimary:
+                description: Target primary instance, this is different from the previous
+                  one during a switchover or a failover
+                type: string
+              targetPrimaryTimestamp:
+                description: The timestamp when the last request for a new primary
+                  has occurred
+                type: string
+              timelineID:
+                description: The timeline of the Postgres cluster
+                type: integer
+              topology:
+                description: Instances topology.
+                properties:
+                  instances:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      description: PodTopologyLabels represent the topology of a Pod.
+                        map[labelName]labelValue
+                      type: object
+                    description: Instances contains the pod topology of the instances
+                    type: object
+                  nodesUsed:
+                    description: NodesUsed represents the count of distinct nodes
+                      accommodating the instances. A value of '1' suggests that all
+                      instances are hosted on a single node, implying the absence
+                      of High Availability (HA). Ideally, this value should be the
+                      same as the number of instances in the Postgres HA cluster,
+                      implying shared nothing architecture on the compute side.
+                    format: int32
+                    type: integer
+                  successfullyExtracted:
+                    description: SuccessfullyExtracted indicates if the topology data
+                      was extract. It is useful to enact fallback behaviors in synchronous
+                      replica election in case of failures
+                    type: boolean
+                type: object
+              unusablePVC:
+                description: List of all the PVCs that are unusable because another
+                  PVC is missing
+                items:
+                  type: string
+                type: array
+              writeService:
+                description: Current write pod
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.instances
+        statusReplicasPath: .status.instances
+      status: {}
+status:
+  acceptedNames:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  conditions:
+  - lastTransitionTime: "2024-01-31T06:47:05Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2024-01-31T06:47:05Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1


### PR DESCRIPTION
# CRD Property Categorization

When a company launches a new service, the operations engineers need to understand the goal, deploy the software in a proper environment and configure it. After the service becomes online, they need to continuously maintain it. I categorize the options by asking the question: in which of these stages is this option involved?

## Purpose

What is this cluster used for?
`description`, `replica`, `replicationSlots`

## Deployment

How should the operator deploy the cluster onto the (K8s) infrastructure?
`affinity`, `bootstrap`, `certificate`, `env`, `envFrom`, `ephemeralVolumeSizeLimit`, `externalClusters`, `imageName`, `imagePullPolicy`, `imagePullSecrets`, `inheritedMetadata`, `postgresGID`, `postgresUID`, `priorityClassName`, `resources`, `schedulerName`, `seccompProfile`, `serviceAccountTemplate`, `storage`, `topologySpreadConstraints`, `walStorage`

## Configuration

How should the operator configure the managed PostgreSQL instance?
`enableSuperuserAccess`, `managed`, `postgresql`, `superuserSecret`, `tablespaces`

## Operations

How should the operator maintain the cluster and keep it healthy? This includes backup, observability and HA policies.
`backup`, `failoverDelay`, `instances`, `logLevel`, `maxSyncReplicas`, `minSyncReplicas`, `monitoring`, `nodeMaintenanceWindow`, `primaryUpdateMethod`, `primaryUpdateStrategy`, `smartShutdownTimeout`, `startDelay`, `stopDelay`, `switchoverDelay`

# Complexity Metric

I define the _human-efforts complexity_ in terms of the efforts required from the human operations engineer. This inevitably introduces some subjectivity, and the definition needs to be refined carefully over time. Currently my metric measures the minimum number of options that need to be explicitly specified to:

1. launch the software for evaluation purposes. The software must run without errors, and must appear to be ready for use.
2. make the software instance usable for hobbyist workloads. The following, if applicable, must be properly set up: persistent storage, data backup, necessary security features (encryption, access control, etc.), and utilization of other services whenever needed (e.g. external database connections).
3. be production-ready. The following, if applicable, must be properly set up: automatic failover, observability, scaling/replication and multitenancy. This shall be expressed in terms of scale parameters.

Only primitive-type options should be counted because composite fields eventually boil down to the primitives. Exact K8s resources (as per Acto) are not expanded for simplicity.

The rationale is that some options exist to provide *flexibility* when needed. These options should have sane defaults and only need to be manually tuned if the human operator has a very specific requirement. Thus, these options should not be considered a burden in terms of operator complexity.

## Complexity of `clusters.postgresql.cnpg.io`

In terms of maintenance efforts, CNPG needs at least these two options to start working:

1. `instances` (integer, >=1)
2. `storage.size` (string, valid specifier for storage space)

To deploy a typical hobbyist Postgres cluster, the following needs to be configured in addition:

1. `bootstrap.*.{database,owner,secret}` (string / string / &Secret) - while CNPG has a default it is often desirable to customize it
2. `enableSuperuserAccess` (boolean) - enabling superuser access saves the operator some efforts to implement declarative role management, and is okay for hobbyist projects.
3. `imageName` (string, container image) - nobody should ever use a nondeterministic image for any real world workload
4. `postgresql.parameters` (string, PG configuration options) - very versatile, likely needed
5. `storage.storageClass` (&StorageClass) - useful whenever there is more than one storage class available

To achieve production readiness, the following needs to be configured in addition:

1. `affinity.nodeSelector` (dict) - easiest way to specify node affinity
2. `backup.barmanObjectStore.s3Credentials.{accessKeyId,region,secretAccessKey}.{key,name}` (&Secret / string) - assume S3 is used for backup storage
3. `backup.barmanObjectStore.{data,wal}.{compression,encryption}` (enum) - even if defaults are used these should be paid attention to
4. `backup.retentionPolicy` (string, a time specifier conforming to a specific regex)
5. `backup.initdb.{postInitApplicationSQL,postInitSQL,postInitTemplateSQL}` (string, SQL code) - useful for declarative DB creation
6. `certificates.{clientCASecret,serverCAsecret,serverTLSSecret}` (&Secret) - while CNPG can manage certs automatically, external cert management is often desirable e.g. with cert-manager
7. `imagePullSecrets` (&Secret[]) - useful when custom / self-hosted images are used
8. `logLevel` (enum) - `info` is likely too verbose for production
9. `managed.roles[*].{inRoles,login,name,passwordSecret}` (boolean / boolean / string / &Secret) - depends on #roles
10. `{maxSyncReplicas,minSyncReplicas}` (integer, >=0) - CNPG does not do quorum-based synchronous replication by default, but it provides stronger consistency guarantees and should be investigated
11. `monitoring.enablePodMonitor` (boolean) - required for observability
12. `postgresql.pg_hba` (string, PG Host-Based Auth rules)
13. `postgresql.syncReplicaElectionConstraint.{enabled,nodelabelsAntiAffinity}` (boolean / string[]) - configures what nodes to use for sync replicas
14. `primaryUpdateMethod` (enum) - should be investigated
15. `priorityClassName` (&PriorityClass)
16. `{storage,walStorage}.pvcTemplate` (PVC) - more fine-grained control over the underlying storage
17. `tablespaces[*].{name,owner}` (string) - tablespaces offer fine-grained StorageClass-to-table mapping
18. `tablespaces[*].pvcTemplate` (PVC)

The following are no longer needed:

1. `enableSuperuserAccess` - defaults to `false`
2. `storage.{size,storageClass}` - shadowed by `storage.pvcTemplate`

Thus, the human-efforts complexity of `clusters.postgresql.cnpg.io` is evaluated to

$(2, 9, 36+2C\_\mathrm{PVC}+(2+C\_\mathrm{PVC})\mathrm{\\#\_{tablespaces}}+4\mathrm{\\#\_{roles}})$

where $C_\mathrm{PVC}$ is the human-efforts complexity of the standard PVC resource.
