### PR TITLE
HW2: Analysis of CRD for kubeblocks mysql

### DIFF
--- a/operators/apecloud_kubeblocks-mysql/HW2-CRD-analysis.md
+++ b/operators/apecloud_kubeblocks-mysql/HW2-CRD-analysis.md
@@ -1,0 +1,66 @@
+### Info
+
+netid: qhng2  
+name: Quan Hao Ng  
+operator: kubeblocks for mysql  
+
+### Chosen CRD
+
+The chosen CRD is called `apps.kubeblocks.io_clusters.yaml`. It is taken from the `kubeblocks/config/crd/bases` directory of the kubeblocks project repo. I chose this CRD because it is the one that is used when I first installed and setup a simple cluster using the kubeblocks operator for MySQL. 
+
+In the setup process, I has to write a simply yaml file for this Custom Resource and then use `kubectl apply -f` to apply this Custom Resource.
+
+### The fields of the CRD 
+
+In the CRD, I focused on the fields defined in `spec.versions.schema.openAPIV3Schema.properties.spec.properties`.
+
+I initially considered splitting by what fields are required, as a measurement of how much effort it takes for a minimal setup. However, the only required field is `terminationPolicy`, which describes what happens when the cluster terminates.
+
+These are the categorisations I now use:
+
+Cluster description
+- `componentSpecs`
+- `clusterVersionRef`
+- `clusterDefinitionRef`
+
+Policies
+- `tolerations`
+- `terminationPolicy`
+- `monitor`
+- `availabilityPolicy`
+
+Pods distribution
+- `tenancy`
+- `affinity`
+
+Storage related
+- `storage`
+- `shardingSpecs`
+- `resources`
+- `replicas`
+- `backup`
+
+Networking
+- `services`
+- `network`
+
+### Complexity metric
+
+For complexity, I decided to analyze the `spec.versions.schema.openAPIV3Schema.properties.spec.properties.componentSpecs` and `spec.versions.schema.openAPIV3Schema.properties.spec.properties.shardingSpecs` in greater detail because this is the core portion that dictates how we want the cluster to eventually look like. One of the 2 has to be defined. 
+
+The complexity metric that I'm using is the greatest depth. I think this is the one that causes the most confusion for me when I was analyzing through the CRD. The depth of these 2 fields is also interesting because they seem to have a recursive structure that mirror the parent (Something like components of components). 
+
+I realised I could not find a simple utility to get the depths of a YAML file so I wrote a short python utility to help me get the depth of a particular node I'm interested in.
+
+This is the depth for the primary fields listed above:  
+`[('affinity', 5), ('availabilityPolicy', 3), ('backup', 4), ('clusterDefinitionRef', 4), ('clusterVersionRef', 2), ('componentSpecs', 15), ('monitor', 6), ('network', 4), ('replicas', 2), ('resources', 6), ('services', 12), ('shardingSpecs', 17), ('storage', 6), ('tenancy', 3), ('terminationPolicy', 3), ('tolerations', 5)]`
+
+As expected, the componentSpecs and shardingSpecs have the greatest depth.
+
+This is the depth for `componentSpecs`:  
+`[('description', 1), ('items', 14), ('maxItems', 1), ('minItems', 1), ('type', 1), ('x-kubernetes-validations', 3)]`
+
+This is the depth for `shardingSpecs`:  
+`[('description', 1), ('items', 16), ('maxItems', 1), ('minItems', 1), ('type', 1), ('x-kubernetes-list-map-keys', 2), ('x-kubernetes-list-type', 1)]`
+
+For both: `items` is the subtree with the highest depth and is the one that seems to mirror the parent structure.

--- a/operators/apecloud_kubeblocks-mysql/apps.kubeblocks.io_clusters.yaml
+++ b/operators/apecloud_kubeblocks-mysql/apps.kubeblocks.io_clusters.yaml
@@ -1,0 +1,2520 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.1
+  labels:
+    app.kubernetes.io/name: kubeblocks
+  name: clusters.apps.kubeblocks.io
+spec:
+  group: apps.kubeblocks.io
+  names:
+    categories:
+    - kubeblocks
+    - all
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: ClusterDefinition referenced by cluster.
+      jsonPath: .spec.clusterDefinitionRef
+      name: CLUSTER-DEFINITION
+      type: string
+    - description: Cluster Application Version.
+      jsonPath: .spec.clusterVersionRef
+      name: VERSION
+      type: string
+    - description: Cluster termination policy.
+      jsonPath: .spec.terminationPolicy
+      name: TERMINATION-POLICY
+      type: string
+    - description: Cluster Status.
+      jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              affinity:
+                description: affinity is a group of affinity scheduling rules.
+                properties:
+                  nodeLabels:
+                    additionalProperties:
+                      type: string
+                    description: nodeLabels describes that pods must be scheduled
+                      to the nodes with the specified node labels.
+                    type: object
+                  podAntiAffinity:
+                    default: Preferred
+                    description: podAntiAffinity describes the anti-affinity level
+                      of pods within a component. Preferred means try spread pods
+                      by `TopologyKeys`. Required means must spread pods by `TopologyKeys`.
+                    enum:
+                    - Preferred
+                    - Required
+                    type: string
+                  tenancy:
+                    default: SharedNode
+                    description: tenancy describes how pods are distributed across
+                      node. SharedNode means multiple pods may share the same node.
+                      DedicatedNode means each pod runs on their own dedicated node.
+                    enum:
+                    - SharedNode
+                    - DedicatedNode
+                    type: string
+                  topologyKeys:
+                    description: topologyKey is the key of node labels. Nodes that
+                      have a label with this key and identical values are considered
+                      to be in the same topology. It's used as the topology domain
+                      for pod anti-affinity and pod spread constraint. Some well-known
+                      label keys, such as "kubernetes.io/hostname" and "topology.kubernetes.io/zone"
+                      are often used as TopologyKey, as well as any other custom label
+                      key.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              availabilityPolicy:
+                description: availabilityPolicy describes the availability policy,
+                  including zone, node, and none.
+                enum:
+                - zone
+                - node
+                - none
+                type: string
+              backup:
+                description: cluster backup configuration.
+                properties:
+                  cronExpression:
+                    description: the cron expression for schedule, the timezone is
+                      in UTC. see https://en.wikipedia.org/wiki/Cron.
+                    type: string
+                  enabled:
+                    default: false
+                    description: enabled defines whether to enable automated backup.
+                    type: boolean
+                  method:
+                    description: backup method name to use, that is defined in backupPolicy.
+                    type: string
+                  pitrEnabled:
+                    default: false
+                    description: pitrEnabled defines whether to enable point-in-time
+                      recovery.
+                    type: boolean
+                  repoName:
+                    description: repoName is the name of the backupRepo, if not set,
+                      will use the default backupRepo.
+                    type: string
+                  retentionPeriod:
+                    default: 7d
+                    description: "retentionPeriod determines a duration up to which
+                      the backup should be kept. controller will remove all backups
+                      that are older than the RetentionPeriod. For example, RetentionPeriod
+                      of `30d` will keep only the backups of last 30 days. Sample
+                      duration format: - years: \t2y - months: \t6mo - days: \t\t30d
+                      - hours: \t12h - minutes: \t30m You can also combine the above
+                      durations. For example: 30d12h30m"
+                    type: string
+                  startingDeadlineMinutes:
+                    description: startingDeadlineMinutes defines the deadline in minutes
+                      for starting the backup job if it misses scheduled time for
+                      any reason.
+                    format: int64
+                    maximum: 1440
+                    minimum: 0
+                    type: integer
+                type: object
+              clusterDefinitionRef:
+                description: Cluster referencing ClusterDefinition name. This is an
+                  immutable attribute. If ClusterDefRef is not specified, ComponentDef
+                  must be specified for each Component in ComponentSpecs.
+                maxLength: 63
+                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                type: string
+                x-kubernetes-validations:
+                - message: clusterDefinitionRef is immutable
+                  rule: self == oldSelf
+              clusterVersionRef:
+                description: Cluster referencing ClusterVersion name.
+                maxLength: 63
+                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                type: string
+              componentSpecs:
+                description: List of componentSpec which is used to define the components
+                  that make up a cluster. ComponentSpecs and ShardingSpecs cannot
+                  both be empty at the same time.
+                items:
+                  description: ClusterComponentSpec defines the cluster component
+                    spec. //(TODO) +kubebuilder:validation:XValidation:rule="!has(oldSelf.componentDefRef)
+                    || has(self.componentDefRef)", message="componentDefRef is required
+                    once set" //(TODO) +kubebuilder:validation:XValidation:rule="!has(oldSelf.componentDef)
+                    || has(self.componentDef)", message="componentDef is required
+                    once set"
+                  properties:
+                    affinity:
+                      description: affinity describes affinities specified by users.
+                      properties:
+                        nodeLabels:
+                          additionalProperties:
+                            type: string
+                          description: nodeLabels describes that pods must be scheduled
+                            to the nodes with the specified node labels.
+                          type: object
+                        podAntiAffinity:
+                          default: Preferred
+                          description: podAntiAffinity describes the anti-affinity
+                            level of pods within a component. Preferred means try
+                            spread pods by `TopologyKeys`. Required means must spread
+                            pods by `TopologyKeys`.
+                          enum:
+                          - Preferred
+                          - Required
+                          type: string
+                        tenancy:
+                          default: SharedNode
+                          description: tenancy describes how pods are distributed
+                            across node. SharedNode means multiple pods may share
+                            the same node. DedicatedNode means each pod runs on their
+                            own dedicated node.
+                          enum:
+                          - SharedNode
+                          - DedicatedNode
+                          type: string
+                        topologyKeys:
+                          description: topologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. It's used as the
+                            topology domain for pod anti-affinity and pod spread constraint.
+                            Some well-known label keys, such as "kubernetes.io/hostname"
+                            and "topology.kubernetes.io/zone" are often used as TopologyKey,
+                            as well as any other custom label key.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    classDefRef:
+                      description: classDefRef references the class defined in ComponentClassDefinition.
+                      properties:
+                        class:
+                          description: Class refers to the name of the class that
+                            is defined in the ComponentClassDefinition.
+                          type: string
+                        name:
+                          description: Name refers to the name of the ComponentClassDefinition.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - class
+                      type: object
+                    componentDef:
+                      description: componentDef references the name of the ComponentDefinition.
+                        If both componentDefRef and componentDef are provided, the
+                        componentDef will take precedence over componentDefRef. //(TODO)
+                        +kubebuilder:validation:XValidation:rule="self == oldSelf",message="componentDef
+                        is immutable"
+                      maxLength: 22
+                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      type: string
+                    componentDefRef:
+                      description: componentDefRef references componentDef defined
+                        in ClusterDefinition spec. Need to comply with IANA Service
+                        Naming rule. //(TODO) +kubebuilder:validation:XValidation:rule="self
+                        == oldSelf",message="componentDefRef is immutable"
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                      type: string
+                    enabledLogs:
+                      description: enabledLogs indicates which log file takes effect
+                        in the database cluster. element is the log type which is
+                        defined in cluster definition logConfig.name, and will set
+                        relative variables about this log type in database kernel.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    instances:
+                      description: Instances defines the list of instance to be deleted
+                        priorly If the RsmTransformPolicy is specified as ToPod,the
+                        list of instances will be used.
+                      items:
+                        type: string
+                      type: array
+                    issuer:
+                      description: issuer defines provider context for TLS certs.
+                        required when TLS enabled
+                      properties:
+                        name:
+                          default: KubeBlocks
+                          description: 'Name of issuer. Options supported: - KubeBlocks
+                            - Certificates signed by KubeBlocks Operator. - UserProvided
+                            - User provided own CA-signed certificates.'
+                          enum:
+                          - KubeBlocks
+                          - UserProvided
+                          type: string
+                        secretRef:
+                          description: secretRef. TLS certs Secret reference required
+                            when from is UserProvided
+                          properties:
+                            ca:
+                              description: CA cert key in Secret
+                              type: string
+                            cert:
+                              description: Cert key in Secret
+                              type: string
+                            key:
+                              description: Key of TLS private key in Secret
+                              type: string
+                            name:
+                              description: Name of the Secret
+                              type: string
+                          required:
+                          - ca
+                          - cert
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    monitor:
+                      default: false
+                      description: monitor is a switch to enable monitoring and is
+                        set as false by default. KubeBlocks provides an extension
+                        mechanism to support component level monitoring, which will
+                        scrape metrics auto or manually from servers in component
+                        and export metrics to Time Series Database.
+                      type: boolean
+                    name:
+                      description: name defines cluster's component name, this name
+                        is also part of Service DNS name, so this name will comply
+                        with IANA Service Naming rule. When ClusterComponentSpec is
+                        referenced as a template, name is optional. Otherwise, it
+                        is required. //(TODO) +kubebuilder:validation:XValidation:rule="self
+                        == oldSelf",message="name is immutable"
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                      type: string
+                    nodes:
+                      description: Nodes defines the list of nodes that pods can schedule
+                        If the RsmTransformPolicy is specified as ToPod,the list of
+                        nodes will be used. If the list of nodes is empty, no specific
+                        node will be assigned. However, if the list of node is filled,
+                        all pods will be evenly scheduled across the nodes in the
+                        list.
+                      items:
+                        description: "NodeName is a type that holds a api.Node's Name
+                          identifier. Being a type captures intent and helps make
+                          sure that the node name is not confused with similar concepts
+                          (the hostname, the cloud provider id, the cloud provider
+                          name etc) \n To clarify the various types: \n - Node.Name
+                          is the Name field of the Node in the API.  This should be
+                          stored in a NodeName. Unfortunately, because Name is part
+                          of ObjectMeta, we can't store it as a NodeName at the API
+                          level. \n - Hostname is the hostname of the local machine
+                          (from uname -n). However, some components allow the user
+                          to pass in a --hostname-override flag, which will override
+                          this in most places. In the absence of anything more meaningful,
+                          kubelet will use Hostname as the Node.Name when it creates
+                          the Node. \n * The cloudproviders have the own names: GCE
+                          has InstanceName, AWS has InstanceId. \n For GCE, InstanceName
+                          is the Name of an Instance object in the GCE API.  On GCE,
+                          Instance.Name becomes the Hostname, and thus it makes sense
+                          also to use it as the Node.Name.  But that is GCE specific,
+                          and it is up to the cloudprovider how to do this mapping.
+                          \n For AWS, the InstanceID is not yet suitable for use as
+                          a Node.Name, so we actually use the PrivateDnsName for the
+                          Node.Name.  And this is _not_ always the same as the hostname:
+                          if we are using a custom DHCP domain it won't be."
+                        type: string
+                      type: array
+                    replicas:
+                      default: 1
+                      description: Component replicas.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: Resources requests and limits of workload.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                            in spec.resourceClaims, that are used by this container.
+                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                            feature gate. \n This field is immutable. It can only
+                            be set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry
+                                  in pod.spec.resourceClaims of the Pod where this
+                                  field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    rsmTransformPolicy:
+                      default: ToSts
+                      description: 'RsmTransformPolicy defines the policy generate
+                        sts using rsm. ToSts: rsm transforms to statefulSet ToPod:
+                        rsm transforms to pods'
+                      enum:
+                      - ToPod
+                      - ToSts
+                      type: string
+                    serviceAccountName:
+                      description: serviceAccountName is the name of the ServiceAccount
+                        that running component depends on.
+                      type: string
+                    serviceRefs:
+                      description: 'serviceRefs define service references for the
+                        current component. Based on the referenced services, they
+                        can be categorized into two types: Service provided by external
+                        sources: These services are provided by external sources and
+                        are not managed by KubeBlocks. They can be Kubernetes-based
+                        or non-Kubernetes services. For external services, you need
+                        to provide an additional ServiceDescriptor object to establish
+                        the service binding. Service provided by other KubeBlocks
+                        clusters: These services are provided by other KubeBlocks
+                        clusters. You can bind to these services by specifying the
+                        name of the hosting cluster. Each type of service reference
+                        requires specific configurations and bindings to establish
+                        the connection and interaction with the respective services.
+                        It should be noted that the ServiceRef has cluster-level semantic
+                        consistency, meaning that within the same Cluster, service
+                        references with the same ServiceRef.Name are considered to
+                        be the same service. It is only allowed to bind to the same
+                        Cluster or ServiceDescriptor.'
+                      items:
+                        properties:
+                          cluster:
+                            description: 'When referencing a service provided by other
+                              KubeBlocks cluster, you need to provide the name of
+                              the Cluster being referenced. By default, when other
+                              KubeBlocks Cluster are referenced, the ClusterDefinition.spec.connectionCredential
+                              secret corresponding to the referenced Cluster will
+                              be used to bind to the current component. Currently,
+                              if a KubeBlocks cluster is to be referenced, the connection
+                              credential secret should include and correspond to the
+                              following fields: endpoint, port, username, and password.
+                              Under this referencing approach, the ServiceKind and
+                              ServiceVersion of service reference declaration defined
+                              in the ClusterDefinition will not be validated. If both
+                              Cluster and ServiceDescriptor are specified, the Cluster
+                              takes precedence.'
+                            type: string
+                          name:
+                            description: name of the service reference declaration.
+                              references the serviceRefDeclaration name defined in
+                              clusterDefinition.componentDefs[*].serviceRefDeclarations[*].name
+                            type: string
+                          namespace:
+                            description: namespace defines the namespace of the referenced
+                              Cluster or the namespace of the referenced ServiceDescriptor
+                              object. If not set, the referenced Cluster and ServiceDescriptor
+                              will be searched in the namespace of the current cluster
+                              by default.
+                            type: string
+                          serviceDescriptor:
+                            description: serviceDescriptor defines the service descriptor
+                              of the service provided by external sources. When referencing
+                              a service provided by external sources, you need to
+                              provide the ServiceDescriptor object name to establish
+                              the service binding. And serviceDescriptor is the name
+                              of the ServiceDescriptor object, furthermore, the ServiceDescriptor.spec.serviceKind
+                              and ServiceDescriptor.spec.serviceVersion should match
+                              clusterDefinition.componentDefs[*].serviceRefDeclarations[*].serviceRefDeclarationSpecs[*].serviceKind
+                              and the regular expression defines in clusterDefinition.componentDefs[*].serviceRefDeclarations[*].serviceRefDeclarationSpecs[*].serviceVersion.
+                              If both Cluster and ServiceDescriptor are specified,
+                              the Cluster takes precedence.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    services:
+                      description: Services expose endpoints that can be accessed
+                        by clients.
+                      items:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'If ServiceType is LoadBalancer, cloud provider
+                              related parameters can be put here More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer.'
+                            type: object
+                          name:
+                            description: Service name
+                            maxLength: 15
+                            type: string
+                          serviceType:
+                            default: ClusterIP
+                            description: 'serviceType determines how the Service is
+                              exposed. Valid options are ClusterIP, NodePort, and
+                              LoadBalancer. "ClusterIP" allocates a cluster-internal
+                              IP address for load-balancing to endpoints. Endpoints
+                              are determined by the selector or if that is not specified,
+                              they are determined by manual construction of an Endpoints
+                              object or EndpointSlice objects. If clusterIP is "None",
+                              no virtual IP is allocated and the endpoints are published
+                              as a set of endpoints rather than a virtual IP. "NodePort"
+                              builds on ClusterIP and allocates a port on every node
+                              which routes to the same endpoints as the clusterIP.
+                              "LoadBalancer" builds on NodePort and creates an external
+                              load-balancer (if supported in the current cloud) which
+                              routes to the same endpoints as the clusterIP. More
+                              info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.'
+                            enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    switchPolicy:
+                      description: switchPolicy defines the strategy for switchover
+                        and failover when workloadType is Replication.
+                      properties:
+                        type:
+                          default: Noop
+                          description: 'clusterSwitchPolicy defines type of the switchPolicy
+                            when workloadType is Replication. MaximumAvailability:
+                            [WIP] when the primary is active, do switch if the synchronization
+                            delay = 0 in the user-defined lagProbe data delay detection
+                            logic, otherwise do not switch. The primary is down, switch
+                            immediately. It will be available in future versions.
+                            MaximumDataProtection: [WIP] when the primary is active,
+                            do switch if synchronization delay = 0 in the user-defined
+                            lagProbe data lag detection logic, otherwise do not switch.
+                            If the primary is down, if it can be judged that the primary
+                            and secondary data are consistent, then do the switch,
+                            otherwise do not switch. It will be available in future
+                            versions. Noop: KubeBlocks will not perform high-availability
+                            switching on components. Users need to implement HA by
+                            themselves or integrate open source HA solution.'
+                          enum:
+                          - Noop
+                          type: string
+                      type: object
+                    tls:
+                      description: Enables or disables TLS certs.
+                      type: boolean
+                    tolerations:
+                      description: Component tolerations will override ClusterSpec.Tolerations
+                        if specified.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
+                    updateStrategy:
+                      description: updateStrategy defines the update strategy for
+                        the component. Not supported.
+                      enum:
+                      - Serial
+                      - BestEffortParallel
+                      - Parallel
+                      type: string
+                    userResourceRefs:
+                      description: userResourceRefs defines the user-defined volumes.
+                      properties:
+                        configMapRefs:
+                          description: configMapRefs defines the user-defined configmaps.
+                          items:
+                            properties:
+                              asVolumeFrom:
+                                description: asVolumeFrom defines the list of containers
+                                  where volumeMounts will be injected into.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              configMap:
+                                description: configMap defines the configmap volume
+                                  source.
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mountPoint:
+                                description: mountPath is the path at which to mount
+                                  the volume.
+                                maxLength: 256
+                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
+                                type: string
+                              name:
+                                description: name is the name of the referenced the
+                                  Configmap/Secret object.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                                type: string
+                              subPath:
+                                description: subPath is a relative file path within
+                                  the volume to mount.
+                                type: string
+                            required:
+                            - configMap
+                            - mountPoint
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        secretRefs:
+                          description: secretRefs defines the user-defined secrets.
+                          items:
+                            properties:
+                              asVolumeFrom:
+                                description: asVolumeFrom defines the list of containers
+                                  where volumeMounts will be injected into.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPoint:
+                                description: mountPath is the path at which to mount
+                                  the volume.
+                                maxLength: 256
+                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
+                                type: string
+                              name:
+                                description: name is the name of the referenced the
+                                  Configmap/Secret object.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                                type: string
+                              secret:
+                                description: secret defines the secret volume source.
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items If unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: 'secretName is the name of the secret
+                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    type: string
+                                type: object
+                              subPath:
+                                description: subPath is a relative file path within
+                                  the volume to mount.
+                                type: string
+                            required:
+                            - mountPoint
+                            - name
+                            - secret
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    volumeClaimTemplates:
+                      description: volumeClaimTemplates information for statefulset.spec.volumeClaimTemplates.
+                      items:
+                        properties:
+                          name:
+                            description: Reference `ClusterDefinition.spec.componentDefs.containers.volumeMounts.name`.
+                            type: string
+                          spec:
+                            description: spec defines the desired characteristics
+                              of a volume requested by a pod author.
+                            properties:
+                              accessModes:
+                                description: 'accessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1.'
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-preserve-unknown-fields: true
+                              resources:
+                                description: 'resources represents the minimum resources
+                                  the volume should have. If RecoverVolumeExpansionFailure
+                                  feature is enabled users are allowed to specify
+                                  resource requirements that are lower than previous
+                                  value but must still be higher than capacity recorded
+                                  in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources.'
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storageClassName:
+                                description: 'storageClassName is the name of the
+                                  StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1.'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim.
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - replicas
+                  type: object
+                  x-kubernetes-validations:
+                  - message: either componentDefRef or componentDef should be provided
+                    rule: has(self.componentDefRef) || has(self.componentDef)
+                maxItems: 128
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: duplicated component
+                  rule: self.all(x, size(self.filter(c, c.name == x.name)) == 1)
+                - message: two kinds of definition API can not be used simultaneously
+                  rule: self.all(x, size(self.filter(c, has(c.componentDef))) == 0)
+                    || self.all(x, size(self.filter(c, has(c.componentDef))) == size(self))
+              monitor:
+                description: monitor specifies the configuration of monitor
+                properties:
+                  monitoringInterval:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: monitoringInterval specifies interval of monitoring,
+                      no monitor if set to 0
+                    x-kubernetes-int-or-string: true
+                type: object
+              network:
+                description: network specifies the configuration of network
+                properties:
+                  hostNetworkAccessible:
+                    default: false
+                    description: hostNetworkAccessible specifies whether host network
+                      is accessible. It defaults to false
+                    type: boolean
+                  publiclyAccessible:
+                    default: false
+                    description: publiclyAccessible specifies whether it is publicly
+                      accessible. It defaults to false
+                    type: boolean
+                type: object
+              replicas:
+                description: replicas specifies the replicas of the first componentSpec,
+                  if the replicas of the first componentSpec is specified, this value
+                  will be ignored.
+                format: int32
+                type: integer
+              resources:
+                description: resources specifies the resources of the first componentSpec,
+                  if the resources of the first componentSpec is specified, this value
+                  will be ignored.
+                properties:
+                  cpu:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'cpu resource needed, more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'memory resource needed, more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              services:
+                description: services defines the services to access a cluster.
+                items:
+                  description: ClusterService defines the service of a cluster.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'If ServiceType is LoadBalancer, cloud provider
+                        related parameters can be put here More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer.'
+                      type: object
+                    componentSelector:
+                      description: ComponentSelector extends the ServiceSpec.Selector
+                        by allowing you to specify a component as selectors for the
+                        service. ComponentSelector and ShardingSelector cannot be
+                        set at the same time.
+                      type: string
+                    name:
+                      description: Name defines the name of the service. otherwise,
+                        it indicates the name of the service. Others can refer to
+                        this service by its name. (e.g., connection credential) Cannot
+                        be updated.
+                      type: string
+                    roleSelector:
+                      description: RoleSelector extends the ServiceSpec.Selector by
+                        allowing you to specify defined role as selector for the service.
+                        if GeneratePodOrdinalService sets to true, RoleSelector will
+                        be ignored.
+                      type: string
+                    serviceName:
+                      description: 'ServiceName defines the name of the underlying
+                        service object. If not specified, the default service name
+                        with different patterns will be used: - <CLUSTER_NAME>: for
+                        cluster-level services - <CLUSTER_NAME>-<COMPONENT_NAME>:
+                        for component-level services Only one default service name
+                        is allowed. Cannot be updated.'
+                      type: string
+                    shardingSelector:
+                      description: ShardingSelector extends the ServiceSpec.Selector
+                        by allowing you to specify a sharding name defined in Cluster.Spec.ShardingSpecs[x].Name
+                        as selectors for the service. ShardingSelector and ComponentSelector
+                        cannot be set at the same time.
+                      type: string
+                    spec:
+                      description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          description: allocateLoadBalancerNodePorts defines if NodePorts
+                            will be automatically allocated for services with type
+                            LoadBalancer.  Default is "true". It may be set to "false"
+                            if the cluster load-balancer does not rely on NodePorts.  If
+                            the caller requests specific NodePorts (by specifying
+                            a value), those requests will be respected, regardless
+                            of this field. This field may only be set for services
+                            with type LoadBalancer and will be cleared if the type
+                            is changed to any other type.
+                          type: boolean
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly. If an address is specified
+                            manually, is in-range (as per system configuration), and
+                            is not in use, it will be allocated to the service; otherwise
+                            creation of the service will fail. This field may not
+                            be changed through updates unless the type field is also
+                            being changed to ExternalName (which requires this field
+                            to be blank) or the type field is being changed from ExternalName
+                            (in which case this field may optionally be specified,
+                            as describe above).  Valid values are "None", empty string
+                            (""), or a valid IP address. Setting this to "None" makes
+                            a "headless service" (no virtual IP), which is useful
+                            when direct endpoint connections are preferred and proxying
+                            is not required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        clusterIPs:
+                          description: "ClusterIPs is a list of IP addresses assigned
+                            to this service, and are usually assigned randomly.  If
+                            an address is specified manually, is in-range (as per
+                            system configuration), and is not in use, it will be allocated
+                            to the service; otherwise creation of the service will
+                            fail. This field may not be changed through updates unless
+                            the type field is also being changed to ExternalName (which
+                            requires this field to be empty) or the type field is
+                            being changed from ExternalName (in which case this field
+                            may optionally be specified, as describe above).  Valid
+                            values are \"None\", empty string (\"\"), or a valid IP
+                            address.  Setting this to \"None\" makes a \"headless
+                            service\" (no virtual IP), which is useful when direct
+                            endpoint connections are preferred and proxying is not
+                            required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            \ If this field is not specified, it will be initialized
+                            from the clusterIP field.  If this field is specified,
+                            clients must ensure that clusterIPs[0] and clusterIP have
+                            the same value. \n This field may hold a maximum of two
+                            entries (dual-stack IPs, in either order). These IPs must
+                            correspond to the values of the ipFamilies field. Both
+                            clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            discovery mechanisms will return as an alias for this
+                            service (e.g. a DNS CNAME record). No proxying will be
+                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires `type` to be "ExternalName".
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy describes how nodes distribute
+                            service traffic they receive on one of the Service's "externally-facing"
+                            addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                            If set to "Local", the proxy will configure the service
+                            in a way that assumes that external load balancers will
+                            take care of balancing the service traffic between nodes,
+                            and so each node will deliver traffic only to the node-local
+                            endpoints of the service, without masquerading the client
+                            source IP. (Traffic mistakenly sent to a node with no
+                            endpoints will be dropped.) The default value, "Cluster",
+                            uses the standard behavior of routing to all endpoints
+                            evenly (possibly modified by topology and other features).
+                            Note that traffic sent to an External IP or LoadBalancer
+                            IP from within the cluster will always get "Cluster" semantics,
+                            but clients sending to a NodePort from within the cluster
+                            may need to take traffic policy into account when picking
+                            a node.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. This only applies when type
+                            is set to LoadBalancer and externalTrafficPolicy is set
+                            to Local. If a value is specified, is in-range, and is
+                            not in use, it will be used.  If not specified, a value
+                            will be automatically allocated.  External systems (e.g.
+                            load-balancers) can use this port to determine if a given
+                            node holds endpoints for this service or not.  If this
+                            field is specified when creating a Service which does
+                            not need it, creation will fail. This field will be wiped
+                            when updating a Service to no longer need it (e.g. changing
+                            type). This field cannot be updated once set.
+                          format: int32
+                          type: integer
+                        internalTrafficPolicy:
+                          description: InternalTrafficPolicy describes how nodes distribute
+                            service traffic they receive on the ClusterIP. If set
+                            to "Local", the proxy will assume that pods only want
+                            to talk to endpoints of the service on the same node as
+                            the pod, dropping the traffic if there are no local endpoints.
+                            The default value, "Cluster", uses the standard behavior
+                            of routing to all endpoints evenly (possibly modified
+                            by topology and other features).
+                          type: string
+                        ipFamilies:
+                          description: "IPFamilies is a list of IP families (e.g.
+                            IPv4, IPv6) assigned to this service. This field is usually
+                            assigned automatically based on cluster configuration
+                            and the ipFamilyPolicy field. If this field is specified
+                            manually, the requested family is available in the cluster,
+                            and ipFamilyPolicy allows it, it will be used; otherwise
+                            creation of the service will fail. This field is conditionally
+                            mutable: it allows for adding or removing a secondary
+                            IP family, but it does not allow changing the primary
+                            IP family of the Service. Valid values are \"IPv4\" and
+                            \"IPv6\".  This field only applies to Services of types
+                            ClusterIP, NodePort, and LoadBalancer, and does apply
+                            to \"headless\" services. This field will be wiped when
+                            updating a Service to type ExternalName. \n This field
+                            may hold a maximum of two entries (dual-stack families,
+                            in either order).  These families must correspond to the
+                            values of the clusterIPs field, if specified. Both clusterIPs
+                            and ipFamilies are governed by the ipFamilyPolicy field."
+                          items:
+                            description: IPFamily represents the IP Family (IPv4 or
+                              IPv6). This type is used to express the family of an
+                              IP expressed by a type (e.g. service.spec.ipFamilies).
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipFamilyPolicy:
+                          description: IPFamilyPolicy represents the dual-stack-ness
+                            requested or required by this Service. If there is no
+                            value provided, then this field will be set to SingleStack.
+                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
+                            (two IP families on dual-stack configured clusters or
+                            a single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise
+                            fail). The ipFamilies and clusterIPs fields depend on
+                            the value of this field. This field will be wiped when
+                            updating a service to type ExternalName.
+                          type: string
+                        loadBalancerClass:
+                          description: loadBalancerClass is the class of the load
+                            balancer implementation this Service belongs to. If specified,
+                            the value of this field must be a label-style identifier,
+                            with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                            Unprefixed names are reserved for end-users. This field
+                            can only be set when the Service type is 'LoadBalancer'.
+                            If not set, the default load balancer implementation is
+                            used, today this is typically done through the cloud provider
+                            integration, but should apply for any default implementation.
+                            If set, it is assumed that a load balancer implementation
+                            is watching for Services with a matching class. Any default
+                            load balancer implementation (e.g. cloud providers) should
+                            ignore Services that set this field. This field can only
+                            be set when creating or updating a Service to type 'LoadBalancer'.
+                            Once set, it can not be changed. This field will be wiped
+                            when a service is updated to a non 'LoadBalancer' type.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer.
+                            This feature depends on whether the underlying cloud-provider
+                            supports specifying the loadBalancerIP when a load balancer
+                            is created. This field will be ignored if the cloud-provider
+                            does not support the feature. Deprecated: This field was
+                            under-specified and its meaning varies across implementations.
+                            Using it is non-portable and it may not support dual-stack.
+                            Users are encouraged to use implementation-specific annotations
+                            when available.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          description: 'The list of ports that are exposed by this
+                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          items:
+                            description: ServicePort contains information on service's
+                              port.
+                            properties:
+                              appProtocol:
+                                description: "The application protocol for this port.
+                                  This is used as a hint for implementations to offer
+                                  richer behavior for protocols that they understand.
+                                  This field follows standard Kubernetes label syntax.
+                                  Valid values are either: \n * Un-prefixed protocol
+                                  names - reserved for IANA standard service names
+                                  (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+                                  \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
+                                  - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
+                                  * 'kubernetes.io/ws'  - WebSocket over cleartext
+                                  as described in https://www.rfc-editor.org/rfc/rfc6455
+                                  * 'kubernetes.io/wss' - WebSocket over TLS as described
+                                  in https://www.rfc-editor.org/rfc/rfc6455 \n * Other
+                                  protocols should use implementation-defined prefixed
+                                  names such as mycompany.com/my-custom-protocol."
+                                type: string
+                              name:
+                                description: The name of this port within the service.
+                                  This must be a DNS_LABEL. All ports within a ServiceSpec
+                                  must have unique names. When considering the endpoints
+                                  for a Service, this must match the 'name' field
+                                  in the EndpointPort. Optional if only one ServicePort
+                                  is defined on this service.
+                                type: string
+                              nodePort:
+                                description: 'The port on each node on which this
+                                  service is exposed when type is NodePort or LoadBalancer.  Usually
+                                  assigned by the system. If a value is specified,
+                                  in-range, and not in use it will be used, otherwise
+                                  the operation will fail.  If not specified, a port
+                                  will be allocated if this Service requires one.  If
+                                  this field is specified when creating a Service
+                                  which does not need it, creation will fail. This
+                                  field will be wiped when updating a Service to no
+                                  longer need it (e.g. changing type from NodePort
+                                  to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                format: int32
+                                type: integer
+                              port:
+                                description: The port that will be exposed by this
+                                  service.
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: The IP protocol for this port. Supports
+                                  "TCP", "UDP", and "SCTP". Default is TCP.
+                                type: string
+                              targetPort:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'Number or name of the port to access
+                                  on the pods targeted by the service. Number must
+                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named
+                                  port in the target Pod''s container ports. If this
+                                  is not specified, the value of the ''port'' field
+                                  is used (an identity map). This field is ignored
+                                  for services with clusterIP=None, and should be
+                                  omitted or set equal to the ''port'' field. More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - port
+                          - protocol
+                          x-kubernetes-list-type: map
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses indicates that any
+                            agent which deals with endpoints for this Service should
+                            disregard any indications of ready/not-ready. The primary
+                            use case for setting this field is for a StatefulSet's
+                            Headless Service to propagate SRV DNS records for its
+                            Pods for the purpose of peer discovery. The Kubernetes
+                            controllers that generate Endpoints and EndpointSlice
+                            resources for Services interpret this to mean that all
+                            endpoints are considered "ready" even if the Pods themselves
+                            are not. Agents which consume only Kubernetes generated
+                            endpoints through the Endpoints or EndpointSlice resources
+                            can safely assume this behavior.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object or EndpointSlice objects. If clusterIP is "None",
+                            no virtual IP is allocated and the endpoints are published
+                            as a set of endpoints rather than a virtual IP. "NodePort"
+                            builds on ClusterIP and allocates a port on every node
+                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
+                            builds on NodePort and creates an external load-balancer
+                            (if supported in the current cloud) which routes to the
+                            same endpoints as the clusterIP. "ExternalName" aliases
+                            this service to the specified externalName. Several other
+                            fields do not apply to ExternalName services. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-preserve-unknown-fields: true
+              shardingSpecs:
+                description: List of ShardingSpec which is used to define components
+                  with a sharding topology structure that make up a cluster. ShardingSpecs
+                  and ComponentSpecs cannot both be empty at the same time.
+                items:
+                  description: ShardingSpec defines the sharding spec.
+                  properties:
+                    name:
+                      description: name defines sharding name, this name is also part
+                        of Service DNS name, so this name will comply with IANA Service
+                        Naming rule. The name is also used to generate the name of
+                        the underlying components with the naming pattern <ShardingSpec.Name>-<ShardID>.
+                        At the same time, the name of component template defined in
+                        ShardingSpec.Template.Name will be ignored.
+                      maxLength: 15
+                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      type: string
+                      x-kubernetes-validations:
+                      - message: name is immutable
+                        rule: self == oldSelf
+                    shards:
+                      description: 'shards indicates the number of component, and
+                        these components have the same specifications and definitions.
+                        It should be noted that the number of replicas for each component
+                        should be defined by template.replicas. Moreover, the logical
+                        relationship between these components should be maintained
+                        by the components themselves, KubeBlocks only provides the
+                        following capabilities for managing the lifecycle of sharding:
+                        1. When the number of shards increases, the postProvision
+                        Action defined in the ComponentDefinition will be executed
+                        if the conditions are met. 2. When the number of shards decreases,
+                        the preTerminate Action defined in the ComponentDefinition
+                        will be executed if the conditions are met. Additionally,
+                        the resources and data associated with the corresponding Component
+                        will be deleted as well.'
+                      format: int32
+                      maximum: 2048
+                      minimum: 0
+                      type: integer
+                    template:
+                      description: template defines the component template. A ShardingSpec
+                        generates a set of components (also called shards) based on
+                        the component template, and this group of components or shards
+                        have the same specifications and definitions.
+                      properties:
+                        affinity:
+                          description: affinity describes affinities specified by
+                            users.
+                          properties:
+                            nodeLabels:
+                              additionalProperties:
+                                type: string
+                              description: nodeLabels describes that pods must be
+                                scheduled to the nodes with the specified node labels.
+                              type: object
+                            podAntiAffinity:
+                              default: Preferred
+                              description: podAntiAffinity describes the anti-affinity
+                                level of pods within a component. Preferred means
+                                try spread pods by `TopologyKeys`. Required means
+                                must spread pods by `TopologyKeys`.
+                              enum:
+                              - Preferred
+                              - Required
+                              type: string
+                            tenancy:
+                              default: SharedNode
+                              description: tenancy describes how pods are distributed
+                                across node. SharedNode means multiple pods may share
+                                the same node. DedicatedNode means each pod runs on
+                                their own dedicated node.
+                              enum:
+                              - SharedNode
+                              - DedicatedNode
+                              type: string
+                            topologyKeys:
+                              description: topologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                It's used as the topology domain for pod anti-affinity
+                                and pod spread constraint. Some well-known label keys,
+                                such as "kubernetes.io/hostname" and "topology.kubernetes.io/zone"
+                                are often used as TopologyKey, as well as any other
+                                custom label key.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          type: object
+                        classDefRef:
+                          description: classDefRef references the class defined in
+                            ComponentClassDefinition.
+                          properties:
+                            class:
+                              description: Class refers to the name of the class that
+                                is defined in the ComponentClassDefinition.
+                              type: string
+                            name:
+                              description: Name refers to the name of the ComponentClassDefinition.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                              type: string
+                          required:
+                          - class
+                          type: object
+                        componentDef:
+                          description: componentDef references the name of the ComponentDefinition.
+                            If both componentDefRef and componentDef are provided,
+                            the componentDef will take precedence over componentDefRef.
+                            //(TODO) +kubebuilder:validation:XValidation:rule="self
+                            == oldSelf",message="componentDef is immutable"
+                          maxLength: 22
+                          pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                          type: string
+                        componentDefRef:
+                          description: componentDefRef references componentDef defined
+                            in ClusterDefinition spec. Need to comply with IANA Service
+                            Naming rule. //(TODO) +kubebuilder:validation:XValidation:rule="self
+                            == oldSelf",message="componentDefRef is immutable"
+                          maxLength: 22
+                          pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                          type: string
+                        enabledLogs:
+                          description: enabledLogs indicates which log file takes
+                            effect in the database cluster. element is the log type
+                            which is defined in cluster definition logConfig.name,
+                            and will set relative variables about this log type in
+                            database kernel.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        instances:
+                          description: Instances defines the list of instance to be
+                            deleted priorly If the RsmTransformPolicy is specified
+                            as ToPod,the list of instances will be used.
+                          items:
+                            type: string
+                          type: array
+                        issuer:
+                          description: issuer defines provider context for TLS certs.
+                            required when TLS enabled
+                          properties:
+                            name:
+                              default: KubeBlocks
+                              description: 'Name of issuer. Options supported: - KubeBlocks
+                                - Certificates signed by KubeBlocks Operator. - UserProvided
+                                - User provided own CA-signed certificates.'
+                              enum:
+                              - KubeBlocks
+                              - UserProvided
+                              type: string
+                            secretRef:
+                              description: secretRef. TLS certs Secret reference required
+                                when from is UserProvided
+                              properties:
+                                ca:
+                                  description: CA cert key in Secret
+                                  type: string
+                                cert:
+                                  description: Cert key in Secret
+                                  type: string
+                                key:
+                                  description: Key of TLS private key in Secret
+                                  type: string
+                                name:
+                                  description: Name of the Secret
+                                  type: string
+                              required:
+                              - ca
+                              - cert
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        monitor:
+                          default: false
+                          description: monitor is a switch to enable monitoring and
+                            is set as false by default. KubeBlocks provides an extension
+                            mechanism to support component level monitoring, which
+                            will scrape metrics auto or manually from servers in component
+                            and export metrics to Time Series Database.
+                          type: boolean
+                        name:
+                          description: name defines cluster's component name, this
+                            name is also part of Service DNS name, so this name will
+                            comply with IANA Service Naming rule. When ClusterComponentSpec
+                            is referenced as a template, name is optional. Otherwise,
+                            it is required. //(TODO) +kubebuilder:validation:XValidation:rule="self
+                            == oldSelf",message="name is immutable"
+                          maxLength: 22
+                          pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                          type: string
+                        nodes:
+                          description: Nodes defines the list of nodes that pods can
+                            schedule If the RsmTransformPolicy is specified as ToPod,the
+                            list of nodes will be used. If the list of nodes is empty,
+                            no specific node will be assigned. However, if the list
+                            of node is filled, all pods will be evenly scheduled across
+                            the nodes in the list.
+                          items:
+                            description: "NodeName is a type that holds a api.Node's
+                              Name identifier. Being a type captures intent and helps
+                              make sure that the node name is not confused with similar
+                              concepts (the hostname, the cloud provider id, the cloud
+                              provider name etc) \n To clarify the various types:
+                              \n - Node.Name is the Name field of the Node in the
+                              API.  This should be stored in a NodeName. Unfortunately,
+                              because Name is part of ObjectMeta, we can't store it
+                              as a NodeName at the API level. \n - Hostname is the
+                              hostname of the local machine (from uname -n). However,
+                              some components allow the user to pass in a --hostname-override
+                              flag, which will override this in most places. In the
+                              absence of anything more meaningful, kubelet will use
+                              Hostname as the Node.Name when it creates the Node.
+                              \n * The cloudproviders have the own names: GCE has
+                              InstanceName, AWS has InstanceId. \n For GCE, InstanceName
+                              is the Name of an Instance object in the GCE API.  On
+                              GCE, Instance.Name becomes the Hostname, and thus it
+                              makes sense also to use it as the Node.Name.  But that
+                              is GCE specific, and it is up to the cloudprovider how
+                              to do this mapping. \n For AWS, the InstanceID is not
+                              yet suitable for use as a Node.Name, so we actually
+                              use the PrivateDnsName for the Node.Name.  And this
+                              is _not_ always the same as the hostname: if we are
+                              using a custom DHCP domain it won't be."
+                            type: string
+                          type: array
+                        replicas:
+                          default: 1
+                          description: Component replicas.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        resources:
+                          description: Resources requests and limits of workload.
+                          properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        rsmTransformPolicy:
+                          default: ToSts
+                          description: 'RsmTransformPolicy defines the policy generate
+                            sts using rsm. ToSts: rsm transforms to statefulSet ToPod:
+                            rsm transforms to pods'
+                          enum:
+                          - ToPod
+                          - ToSts
+                          type: string
+                        serviceAccountName:
+                          description: serviceAccountName is the name of the ServiceAccount
+                            that running component depends on.
+                          type: string
+                        serviceRefs:
+                          description: 'serviceRefs define service references for
+                            the current component. Based on the referenced services,
+                            they can be categorized into two types: Service provided
+                            by external sources: These services are provided by external
+                            sources and are not managed by KubeBlocks. They can be
+                            Kubernetes-based or non-Kubernetes services. For external
+                            services, you need to provide an additional ServiceDescriptor
+                            object to establish the service binding. Service provided
+                            by other KubeBlocks clusters: These services are provided
+                            by other KubeBlocks clusters. You can bind to these services
+                            by specifying the name of the hosting cluster. Each type
+                            of service reference requires specific configurations
+                            and bindings to establish the connection and interaction
+                            with the respective services. It should be noted that
+                            the ServiceRef has cluster-level semantic consistency,
+                            meaning that within the same Cluster, service references
+                            with the same ServiceRef.Name are considered to be the
+                            same service. It is only allowed to bind to the same Cluster
+                            or ServiceDescriptor.'
+                          items:
+                            properties:
+                              cluster:
+                                description: 'When referencing a service provided
+                                  by other KubeBlocks cluster, you need to provide
+                                  the name of the Cluster being referenced. By default,
+                                  when other KubeBlocks Cluster are referenced, the
+                                  ClusterDefinition.spec.connectionCredential secret
+                                  corresponding to the referenced Cluster will be
+                                  used to bind to the current component. Currently,
+                                  if a KubeBlocks cluster is to be referenced, the
+                                  connection credential secret should include and
+                                  correspond to the following fields: endpoint, port,
+                                  username, and password. Under this referencing approach,
+                                  the ServiceKind and ServiceVersion of service reference
+                                  declaration defined in the ClusterDefinition will
+                                  not be validated. If both Cluster and ServiceDescriptor
+                                  are specified, the Cluster takes precedence.'
+                                type: string
+                              name:
+                                description: name of the service reference declaration.
+                                  references the serviceRefDeclaration name defined
+                                  in clusterDefinition.componentDefs[*].serviceRefDeclarations[*].name
+                                type: string
+                              namespace:
+                                description: namespace defines the namespace of the
+                                  referenced Cluster or the namespace of the referenced
+                                  ServiceDescriptor object. If not set, the referenced
+                                  Cluster and ServiceDescriptor will be searched in
+                                  the namespace of the current cluster by default.
+                                type: string
+                              serviceDescriptor:
+                                description: serviceDescriptor defines the service
+                                  descriptor of the service provided by external sources.
+                                  When referencing a service provided by external
+                                  sources, you need to provide the ServiceDescriptor
+                                  object name to establish the service binding. And
+                                  serviceDescriptor is the name of the ServiceDescriptor
+                                  object, furthermore, the ServiceDescriptor.spec.serviceKind
+                                  and ServiceDescriptor.spec.serviceVersion should
+                                  match clusterDefinition.componentDefs[*].serviceRefDeclarations[*].serviceRefDeclarationSpecs[*].serviceKind
+                                  and the regular expression defines in clusterDefinition.componentDefs[*].serviceRefDeclarations[*].serviceRefDeclarationSpecs[*].serviceVersion.
+                                  If both Cluster and ServiceDescriptor are specified,
+                                  the Cluster takes precedence.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        services:
+                          description: Services expose endpoints that can be accessed
+                            by clients.
+                          items:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'If ServiceType is LoadBalancer, cloud
+                                  provider related parameters can be put here More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer.'
+                                type: object
+                              name:
+                                description: Service name
+                                maxLength: 15
+                                type: string
+                              serviceType:
+                                default: ClusterIP
+                                description: 'serviceType determines how the Service
+                                  is exposed. Valid options are ClusterIP, NodePort,
+                                  and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                                  IP address for load-balancing to endpoints. Endpoints
+                                  are determined by the selector or if that is not
+                                  specified, they are determined by manual construction
+                                  of an Endpoints object or EndpointSlice objects.
+                                  If clusterIP is "None", no virtual IP is allocated
+                                  and the endpoints are published as a set of endpoints
+                                  rather than a virtual IP. "NodePort" builds on ClusterIP
+                                  and allocates a port on every node which routes
+                                  to the same endpoints as the clusterIP. "LoadBalancer"
+                                  builds on NodePort and creates an external load-balancer
+                                  (if supported in the current cloud) which routes
+                                  to the same endpoints as the clusterIP. More info:
+                                  https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.'
+                                enum:
+                                - ClusterIP
+                                - NodePort
+                                - LoadBalancer
+                                type: string
+                                x-kubernetes-preserve-unknown-fields: true
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        switchPolicy:
+                          description: switchPolicy defines the strategy for switchover
+                            and failover when workloadType is Replication.
+                          properties:
+                            type:
+                              default: Noop
+                              description: 'clusterSwitchPolicy defines type of the
+                                switchPolicy when workloadType is Replication. MaximumAvailability:
+                                [WIP] when the primary is active, do switch if the
+                                synchronization delay = 0 in the user-defined lagProbe
+                                data delay detection logic, otherwise do not switch.
+                                The primary is down, switch immediately. It will be
+                                available in future versions. MaximumDataProtection:
+                                [WIP] when the primary is active, do switch if synchronization
+                                delay = 0 in the user-defined lagProbe data lag detection
+                                logic, otherwise do not switch. If the primary is
+                                down, if it can be judged that the primary and secondary
+                                data are consistent, then do the switch, otherwise
+                                do not switch. It will be available in future versions.
+                                Noop: KubeBlocks will not perform high-availability
+                                switching on components. Users need to implement HA
+                                by themselves or integrate open source HA solution.'
+                              enum:
+                              - Noop
+                              type: string
+                          type: object
+                        tls:
+                          description: Enables or disables TLS certs.
+                          type: boolean
+                        tolerations:
+                          description: Component tolerations will override ClusterSpec.Tolerations
+                            if specified.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                        updateStrategy:
+                          description: updateStrategy defines the update strategy
+                            for the component. Not supported.
+                          enum:
+                          - Serial
+                          - BestEffortParallel
+                          - Parallel
+                          type: string
+                        userResourceRefs:
+                          description: userResourceRefs defines the user-defined volumes.
+                          properties:
+                            configMapRefs:
+                              description: configMapRefs defines the user-defined
+                                configmaps.
+                              items:
+                                properties:
+                                  asVolumeFrom:
+                                    description: asVolumeFrom defines the list of
+                                      containers where volumeMounts will be injected
+                                      into.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  configMap:
+                                    description: configMap defines the configmap volume
+                                      source.
+                                    properties:
+                                      defaultMode:
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  mountPoint:
+                                    description: mountPath is the path at which to
+                                      mount the volume.
+                                    maxLength: 256
+                                    pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
+                                    type: string
+                                  name:
+                                    description: name is the name of the referenced
+                                      the Configmap/Secret object.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                                    type: string
+                                  subPath:
+                                    description: subPath is a relative file path within
+                                      the volume to mount.
+                                    type: string
+                                required:
+                                - configMap
+                                - mountPoint
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            secretRefs:
+                              description: secretRefs defines the user-defined secrets.
+                              items:
+                                properties:
+                                  asVolumeFrom:
+                                    description: asVolumeFrom defines the list of
+                                      containers where volumeMounts will be injected
+                                      into.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  mountPoint:
+                                    description: mountPath is the path at which to
+                                      mount the volume.
+                                    maxLength: 256
+                                    pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
+                                    type: string
+                                  name:
+                                    description: name is the name of the referenced
+                                      the Configmap/Secret object.
+                                    maxLength: 63
+                                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                                    type: string
+                                  secret:
+                                    description: secret defines the secret volume
+                                      source.
+                                    properties:
+                                      defaultMode:
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: items If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                  subPath:
+                                    description: subPath is a relative file path within
+                                      the volume to mount.
+                                    type: string
+                                required:
+                                - mountPoint
+                                - name
+                                - secret
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                          type: object
+                        volumeClaimTemplates:
+                          description: volumeClaimTemplates information for statefulset.spec.volumeClaimTemplates.
+                          items:
+                            properties:
+                              name:
+                                description: Reference `ClusterDefinition.spec.componentDefs.containers.volumeMounts.name`.
+                                type: string
+                              spec:
+                                description: spec defines the desired characteristics
+                                  of a volume requested by a pod author.
+                                properties:
+                                  accessModes:
+                                    description: 'accessModes contains the desired
+                                      access modes the volume should have. More info:
+                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1.'
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  resources:
+                                    description: 'resources represents the minimum
+                                      resources the volume should have. If RecoverVolumeExpansionFailure
+                                      feature is enabled users are allowed to specify
+                                      resource requirements that are lower than previous
+                                      value but must still be higher than capacity
+                                      recorded in the status field of the claim. More
+                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources.'
+                                    properties:
+                                      claims:
+                                        description: "Claims lists the names of resources,
+                                          defined in spec.resourceClaims, that are
+                                          used by this container. \n This is an alpha
+                                          field and requires enabling the DynamicResourceAllocation
+                                          feature gate. \n This field is immutable.
+                                          It can only be set for containers."
+                                        items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: Name must match the name
+                                                of one entry in pod.spec.resourceClaims
+                                                of the Pod where this field is used.
+                                                It makes that resource available inside
+                                                a container.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. Requests cannot exceed Limits. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  storageClassName:
+                                    description: 'storageClassName is the name of
+                                      the StorageClass required by the claim. More
+                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1.'
+                                    type: string
+                                  volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim.
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - replicas
+                      type: object
+                      x-kubernetes-validations:
+                      - message: either componentDefRef or componentDef should be
+                          provided
+                        rule: has(self.componentDefRef) || has(self.componentDef)
+                  required:
+                  - name
+                  - template
+                  type: object
+                maxItems: 128
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              storage:
+                description: storage specifies the storage of the first componentSpec,
+                  if the storage of the first componentSpec is specified, this value
+                  will be ignored.
+                properties:
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'storage size needed, more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              tenancy:
+                description: tenancy describes how pods are distributed across node.
+                  SharedNode means multiple pods may share the same node. DedicatedNode
+                  means each pod runs on their own dedicated node.
+                enum:
+                - SharedNode
+                - DedicatedNode
+                type: string
+              terminationPolicy:
+                description: Cluster termination policy. Valid values are DoNotTerminate,
+                  Halt, Delete, WipeOut. DoNotTerminate will block delete operation.
+                  Halt will delete workload resources such as statefulset, deployment
+                  workloads but keep PVCs. Delete is based on Halt and deletes PVCs.
+                  WipeOut is based on Delete and wipe out all volume snapshots and
+                  snapshot data from backup storage location.
+                enum:
+                - DoNotTerminate
+                - Halt
+                - Delete
+                - WipeOut
+                type: string
+              tolerations:
+                description: tolerations are attached to tolerate any taint that matches
+                  the triple `key,value,effect` using the matching operator `operator`.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - terminationPolicy
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              clusterDefGeneration:
+                description: clusterDefGeneration represents the generation number
+                  of ClusterDefinition referenced.
+                format: int64
+                type: integer
+              components:
+                additionalProperties:
+                  description: ClusterComponentStatus records components status.
+                  properties:
+                    membersStatus:
+                      description: members' status.
+                      items:
+                        properties:
+                          podName:
+                            default: Unknown
+                            description: PodName pod name.
+                            type: string
+                          readyWithoutPrimary:
+                            description: Is it required for rsm to have at least one
+                              primary pod to be ready.
+                            type: boolean
+                          role:
+                            properties:
+                              accessMode:
+                                default: ReadWrite
+                                description: AccessMode, what service this member
+                                  capable.
+                                enum:
+                                - None
+                                - Readonly
+                                - ReadWrite
+                                type: string
+                              canVote:
+                                default: true
+                                description: CanVote, whether this member has voting
+                                  rights
+                                type: boolean
+                              isLeader:
+                                default: false
+                                description: IsLeader, whether this member is the
+                                  leader
+                                type: boolean
+                              name:
+                                default: leader
+                                description: Name, role name.
+                                type: string
+                            required:
+                            - accessMode
+                            - name
+                            type: object
+                        required:
+                        - podName
+                        - role
+                        type: object
+                      type: array
+                    message:
+                      additionalProperties:
+                        type: string
+                      description: message records the component details message in
+                        current phase. Keys are podName or deployName or statefulSetName.
+                        The format is `ObjectKind/Name`.
+                      type: object
+                    phase:
+                      description: 'phase describes the phase of the component and
+                        the detail information of the phases are as following: Creating:
+                        `Creating` is a special `Updating` with previous phase `empty`(means
+                        "") or `Creating`. Running: component replicas > 0 and all
+                        pod specs are latest with a Running state. Updating: component
+                        replicas > 0 and has no failed pods. the component is being
+                        updated. Abnormal: component replicas > 0 but having some
+                        failed pods. the component basically works but in a fragile
+                        state. Failed: component replicas > 0 but having some failed
+                        pods. the component doesn''t work anymore. Stopping: component
+                        replicas = 0 and has terminating pods. Stopped: component
+                        replicas = 0 and all pods have been deleted. Deleting: the
+                        component is being deleted.'
+                      enum:
+                      - Creating
+                      - Running
+                      - Updating
+                      - Stopping
+                      - Stopped
+                      - Deleting
+                      - Failed
+                      - Abnormal
+                      type: string
+                    podsReady:
+                      description: podsReady checks if all pods of the component are
+                        ready.
+                      type: boolean
+                    podsReadyTime:
+                      description: podsReadyTime what time point of all component
+                        pods are ready, this time is the ready time of the last component
+                        pod.
+                      format: date-time
+                      type: string
+                  type: object
+                description: components record the current status information of all
+                  components of the cluster.
+                type: object
+              conditions:
+                description: Describe current state of cluster API Resource, like
+                  warning.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: message describes cluster details message in current
+                  phase.
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this Cluster. It corresponds to the Cluster's generation, which
+                  is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              phase:
+                description: 'phase describes the phase of the Cluster, the detail
+                  information of the phases are as following: Creating: all components
+                  are in `Creating` phase. Running: all components are in `Running`
+                  phase, means the cluster is working well. Updating: all components
+                  are in `Creating`, `Running` or `Updating` phase, and at least one
+                  component is in `Creating` or `Updating` phase, means the cluster
+                  is doing an update. Stopping: at least one component is in `Stopping`
+                  phase, means the cluster is in a stop progress. Stopped: all components
+                  are in ''Stopped` phase, means the cluster has stopped and didn''t
+                  provide any function anymore. Failed: all components are in `Failed`
+                  phase, means the cluster is unavailable. Abnormal: some components
+                  are in `Failed` or `Abnormal` phase, means the cluster in a fragile
+                  state. troubleshoot need to be done. Deleting: the cluster is being
+                  deleted.'
+                enum:
+                - Creating
+                - Running
+                - Updating
+                - Stopping
+                - Stopped
+                - Deleting
+                - Failed
+                - Abnormal
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/apecloud_kubeblocks-mysql/system_state.json
+++ b/operators/apecloud_kubeblocks-mysql/system_state.json
@@ -1,0 +1,20061 @@
+{
+    "cluster_role_binding": {
+        "cluster-admin": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "cluster-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "135",
+                "self_link": null,
+                "uid": "23a19dd7-3ce0-4205-9ef3-9f01c33477ad"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:masters",
+                    "namespace": null
+                }
+            ]
+        },
+        "kb-addon-snapshot-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kb-addon-snapshot-controller",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:41:27+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/managed-by": "Helm"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/managed-by": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "helm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:41:27+00:00"
+                    }
+                ],
+                "name": "kb-addon-snapshot-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "2023",
+                "self_link": null,
+                "uid": "72c1caa0-d3ed-4fd4-b923-e390c1929f2f"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kb-addon-snapshot-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kb-addon-snapshot-controller",
+                    "namespace": "kb-system"
+                }
+            ]
+        },
+        "kindnet": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:36+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:36+00:00"
+                    }
+                ],
+                "name": "kindnet",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "256",
+                "self_link": null,
+                "uid": "e90642fe-8b9f-483a-be56-a61bd5cb51a6"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kindnet"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kindnet",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "kubeadm:cluster-admins": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:34+00:00"
+                    }
+                ],
+                "name": "kubeadm:cluster-admins",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "198",
+                "self_link": null,
+                "uid": "3e8d8d8c-5489-4f09-a820-7811636fe1f2"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "kubeadm:cluster-admins",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:get-nodes": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "kubeadm:get-nodes",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "209",
+                "self_link": null,
+                "uid": "12fb0892-d784-4952-9daf-de55ba1f831c"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kubeadm:get-nodes"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:kubelet-bootstrap": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "kubeadm:kubelet-bootstrap",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "210",
+                "self_link": null,
+                "uid": "d7f30277-76a9-4e7c-bb2b-0f1919a5e6c4"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-bootstrapper"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-autoapprove-bootstrap": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-autoapprove-bootstrap",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "211",
+                "self_link": null,
+                "uid": "d8639463-7301-4528-ab1e-4d8dd1f7e936"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:certificates.k8s.io:certificatesigningrequests:nodeclient"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-autoapprove-certificate-rotation": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-autoapprove-certificate-rotation",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "212",
+                "self_link": null,
+                "uid": "56bd374f-e5ed-49f2-91f8-a7a800db9853"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:nodes",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-proxier": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "226",
+                "self_link": null,
+                "uid": "af92834b-b9a7-476e-a7de-11be6c66c357"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-proxier"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kube-proxy",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "kubeblocks": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1005",
+                "self_link": null,
+                "uid": "92525714-873e-44b5-a1e4-160d02e91746"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kubeblocks"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kubeblocks",
+                    "namespace": "kb-system"
+                }
+            ]
+        },
+        "kubeblocks-cluster-admin": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-cluster-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1006",
+                "self_link": null,
+                "uid": "318b053a-cc16-4d68-8006-55f05f750573"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kubeblocks-addon-installer",
+                    "namespace": "kb-system"
+                }
+            ]
+        },
+        "kubeblocks-proxy-rolebinding": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-proxy-rolebinding",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1004",
+                "self_link": null,
+                "uid": "03c2180a-e6f1-42e8-a297-b9c893e173f0"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kubeblocks-proxy-role"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kubeblocks",
+                    "namespace": "kb-system"
+                }
+            ]
+        },
+        "local-path-provisioner-bind": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-bind\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"local-path-provisioner-role\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"local-path-provisioner-service-account\",\"namespace\":\"local-path-storage\"}]}\n"
+                },
+                "creation_timestamp": "2024-02-06T04:35:37+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:37+00:00"
+                    }
+                ],
+                "name": "local-path-provisioner-bind",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "274",
+                "self_link": null,
+                "uid": "fce772c4-3197-45b8-9dfb-d50bdeaf61e1"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "local-path-provisioner-role"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "local-path-provisioner-service-account",
+                    "namespace": "local-path-storage"
+                }
+            ]
+        },
+        "system:basic-user": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:basic-user",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "138",
+                "self_link": null,
+                "uid": "2a756f62-6b30-40b9-9210-9facc3c10b7e"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:basic-user"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:controller:attachdetach-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:attachdetach-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "147",
+                "self_link": null,
+                "uid": "16924632-7db2-4a88-adfc-cecc6bde3484"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:attachdetach-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "attachdetach-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:certificate-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:certificate-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "173",
+                "self_link": null,
+                "uid": "145e88e7-299e-42e8-aeac-3baedc612ed8"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:certificate-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "certificate-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:clusterrole-aggregation-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:clusterrole-aggregation-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "148",
+                "self_link": null,
+                "uid": "fce45d8d-7510-4f0e-963d-19a562197e4b"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:clusterrole-aggregation-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "clusterrole-aggregation-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:cronjob-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:cronjob-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "149",
+                "self_link": null,
+                "uid": "74865ffc-aab2-4672-aaf7-14417f5f320f"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:cronjob-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "cronjob-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:daemon-set-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:daemon-set-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "150",
+                "self_link": null,
+                "uid": "25275949-f97e-4ec2-855f-24d9deef8c9f"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:daemon-set-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "daemon-set-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:deployment-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:deployment-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "151",
+                "self_link": null,
+                "uid": "831df700-13f7-43af-ac90-2adfa26dc43e"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:deployment-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "deployment-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:disruption-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:disruption-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "152",
+                "self_link": null,
+                "uid": "1a899008-d40a-47a3-87e1-48cbc5c82f68"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:disruption-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "disruption-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpoint-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:endpoint-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "153",
+                "self_link": null,
+                "uid": "e042933f-5f8d-41c2-ba23-79538ce6e095"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpoint-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpoint-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpointslice-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslice-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "154",
+                "self_link": null,
+                "uid": "eb64f017-0737-4223-89c5-ee7bf448c879"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpointslice-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpointslice-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpointslicemirroring-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslicemirroring-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "155",
+                "self_link": null,
+                "uid": "8335cf31-2db6-47b9-9364-9f104af235a6"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpointslicemirroring-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpointslicemirroring-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ephemeral-volume-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:ephemeral-volume-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "157",
+                "self_link": null,
+                "uid": "ba7ff8e3-f00d-4829-bfc0-3006c5b2a924"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ephemeral-volume-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ephemeral-volume-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:expand-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:expand-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "156",
+                "self_link": null,
+                "uid": "df08ebdc-f7f0-4a6d-8d9c-eef6bafb9473"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:expand-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "expand-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:generic-garbage-collector": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:generic-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "158",
+                "self_link": null,
+                "uid": "e31903a5-a6fb-477b-b3f9-f189e65ea368"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:generic-garbage-collector"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "generic-garbage-collector",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:horizontal-pod-autoscaler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:horizontal-pod-autoscaler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "159",
+                "self_link": null,
+                "uid": "2dfe5262-3d84-4397-9a27-db59d7de44db"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:horizontal-pod-autoscaler"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "horizontal-pod-autoscaler",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:job-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:job-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "160",
+                "self_link": null,
+                "uid": "213002c0-a7b8-49a4-bf42-a38d6fc7488e"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:job-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "job-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:legacy-service-account-token-cleaner": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:legacy-service-account-token-cleaner",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "178",
+                "self_link": null,
+                "uid": "8f20b013-45cc-4282-a412-6cb55040e3bc"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:legacy-service-account-token-cleaner"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "legacy-service-account-token-cleaner",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:namespace-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:namespace-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "161",
+                "self_link": null,
+                "uid": "8f944f93-0813-4fc5-986e-0689c6de01b4"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:namespace-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "namespace-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:node-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:node-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "162",
+                "self_link": null,
+                "uid": "7ea57b81-9d68-48eb-be24-7b84426e95e7"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:node-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "node-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:persistent-volume-binder": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:persistent-volume-binder",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "163",
+                "self_link": null,
+                "uid": "be89b905-b9b3-4455-9f4f-b00634ff58d6"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:persistent-volume-binder"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "persistent-volume-binder",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pod-garbage-collector": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:pod-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "164",
+                "self_link": null,
+                "uid": "e3dcdca3-a84e-4910-8da7-2ea40398ba42"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pod-garbage-collector"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pod-garbage-collector",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pv-protection-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:pv-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "175",
+                "self_link": null,
+                "uid": "b06cec5b-f724-40e8-8ea9-a8d0b4e4b198"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pv-protection-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pv-protection-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pvc-protection-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:pvc-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "174",
+                "self_link": null,
+                "uid": "83c17a8b-dcd0-420f-8442-9aee117a00f5"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pvc-protection-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pvc-protection-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:replicaset-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:replicaset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "165",
+                "self_link": null,
+                "uid": "3d969433-a4c6-4e31-8829-4c3c165d8d82"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:replicaset-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "replicaset-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:replication-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:replication-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "166",
+                "self_link": null,
+                "uid": "118c8191-44fb-44d4-a4c3-ba69ca6b1f27"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:replication-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "replication-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:resourcequota-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:resourcequota-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "167",
+                "self_link": null,
+                "uid": "5938fc6d-16f3-4ca8-8718-3dd564dbd9f1"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:resourcequota-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "resourcequota-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:root-ca-cert-publisher": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:root-ca-cert-publisher",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "177",
+                "self_link": null,
+                "uid": "014cb359-7e57-4c07-b755-5f7fad938e14"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:root-ca-cert-publisher"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "root-ca-cert-publisher",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:route-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:route-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "168",
+                "self_link": null,
+                "uid": "4da94da0-70de-4760-b064-3831895119f2"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:route-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "route-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:service-account-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:service-account-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "169",
+                "self_link": null,
+                "uid": "d45b635f-52dd-4a23-b38a-0d2aab1003a5"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:service-account-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "service-account-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:service-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:service-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "170",
+                "self_link": null,
+                "uid": "fcb49f29-ec04-4484-baf7-857e2ea4a979"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:service-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "service-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:statefulset-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:statefulset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "171",
+                "self_link": null,
+                "uid": "5087fed4-b4c9-4c8e-8e17-f09c0e4c4011"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:statefulset-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "statefulset-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ttl-after-finished-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-after-finished-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "176",
+                "self_link": null,
+                "uid": "a0d02d38-8dd4-4623-8786-d856b1f14125"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ttl-after-finished-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ttl-after-finished-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ttl-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "172",
+                "self_link": null,
+                "uid": "6438bf22-970f-48db-a8da-43fbd98ab185"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ttl-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ttl-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:coredns": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "system:coredns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "218",
+                "self_link": null,
+                "uid": "217831b3-8570-4853-97a2-b75294ab181b"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:coredns"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "coredns",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:discovery": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "137",
+                "self_link": null,
+                "uid": "07bf99b0-1808-40d0-8e99-f0917ad9d091"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:discovery"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:kube-controller-manager": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kube-controller-manager",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "141",
+                "self_link": null,
+                "uid": "4f018b3e-05c2-47f7-9d5a-bcd267092b91"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-controller-manager"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-controller-manager",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:kube-dns": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kube-dns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "142",
+                "self_link": null,
+                "uid": "4a7effff-785c-4824-b1f0-ead37082aedf"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-dns"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kube-dns",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:kube-scheduler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kube-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "143",
+                "self_link": null,
+                "uid": "1f5311d9-8eec-4ca4-b64e-4451b2a0dc8a"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-scheduler"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-scheduler",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:monitoring": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:monitoring",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "136",
+                "self_link": null,
+                "uid": "eace01ad-8427-4fb8-a291-e7dfdebe1f75"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:monitoring"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:monitoring",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:node": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:node",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "145",
+                "self_link": null,
+                "uid": "fbb900a5-3e9d-41ba-be6a-a974ed55d063"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node"
+            },
+            "subjects": null
+        },
+        "system:node-proxier": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "140",
+                "self_link": null,
+                "uid": "18aa6a81-8248-405f-bc70-429b47c36a38"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-proxier"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-proxy",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:public-info-viewer": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:public-info-viewer",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "139",
+                "self_link": null,
+                "uid": "28cc9bb7-e23b-4f3d-90a8-351ed30f8947"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:public-info-viewer"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                },
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:unauthenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:service-account-issuer-discovery": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:service-account-issuer-discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "146",
+                "self_link": null,
+                "uid": "160dd404-9875-4606-af41-637b0aa9dc20"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:service-account-issuer-discovery"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:serviceaccounts",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:volume-scheduler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:volume-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "144",
+                "self_link": null,
+                "uid": "abfdb4e5-5d68-4f93-95a7-d111c8ac8e58"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:volume-scheduler"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-scheduler",
+                    "namespace": null
+                }
+            ]
+        }
+    },
+    "cluster_role": {
+        "admin": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:50+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "342",
+                "self_link": null,
+                "uid": "6eb86e39-1b6f-4622-af66-3808e3ee38b6"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "cluster-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "cluster-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "72",
+                "self_link": null,
+                "uid": "c0b1285a-d7de-4410-a943-c6a5e638b88d"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "*"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "edit": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:50+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "341",
+                "self_link": null,
+                "uid": "57016f9b-f750-4dce-a4d0-afe1b07c23a5"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kb-addon-snapshot-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kb-addon-snapshot-controller",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:41:27+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/managed-by": "Helm"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/managed-by": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "helm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:41:27+00:00"
+                    }
+                ],
+                "name": "kb-addon-snapshot-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "2022",
+                "self_link": null,
+                "uid": "52dbe1ac-3d2d-41fe-80b6-51d472f8b63e"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch",
+                        "create",
+                        "update",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshotclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshotcontents"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch",
+                        "update",
+                        "patch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshotcontents/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshots"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch",
+                        "update",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshots/status"
+                    ],
+                    "verbs": [
+                        "update",
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "kindnet": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:36+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:36+00:00"
+                    }
+                ],
+                "name": "kindnet",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "255",
+                "self_link": null,
+                "uid": "74cdcef9-f21f-42dc-8a89-4915a8062a6c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kindnet"
+                    ],
+                    "resources": [
+                        "podsecuritypolicies"
+                    ],
+                    "verbs": [
+                        "use"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kubeadm:get-nodes": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "kubeadm:get-nodes",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "208",
+                "self_link": null,
+                "uid": "de6b84bc-d285-47be-8ff5-494eed533ae4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "app.kubernetes.io/instance": "kubeblocks",
+                            "app.kubernetes.io/name": "kubeblocks"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            }
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1072",
+                "self_link": null,
+                "uid": "b498a786-68ee-4e0d-a1da-604cc00c9cef"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuptools"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuptools/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuptools"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update",
+                        "create",
+                        "list",
+                        "watch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "nodes/stats"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentclassdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentclassdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentclassdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentresourceconstraints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "components"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "components/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "components/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configurations"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configurations/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configurations/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "servicedescriptors"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "servicedescriptors/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "servicedescriptors/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/finalizers"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmap"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmap/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/exec"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/log"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "actionsets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "actionsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "actionsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuprepos"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuprepos/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuprepos/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backupschedules"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backupschedules/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backupschedules/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshotclasses"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshotclasses/finalizers"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshots"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshots/finalizers"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageproviders"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageproviders/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageproviders/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/metrics"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backup-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backup-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "987",
+                "self_link": null,
+                "uid": "5ebb1148-975b-485b-bf66-3bf719d836c2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backup-pod-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/required-by": "pod",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/required-by": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backup-pod-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "984",
+                "self_link": null,
+                "uid": "2125faf5-5691-4735-9a9d-de8eee137d79"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backup-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backup-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "992",
+                "self_link": null,
+                "uid": "d38f5a76-c157-49b7-af0a-81f12727dc04"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backuppolicy-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backuppolicy-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "985",
+                "self_link": null,
+                "uid": "9b1e4518-0742-49c3-862e-83a1db1cf070"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backuppolicy-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backuppolicy-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "989",
+                "self_link": null,
+                "uid": "264b338e-4180-4da2-b6e8-dd46078b7114"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backuppolicytemplate-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backuppolicytemplate-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "974",
+                "self_link": null,
+                "uid": "d4862485-f90b-47d3-9490-820932701686"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backuppolicytemplate-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backuppolicytemplate-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "968",
+                "self_link": null,
+                "uid": "df8486b2-7af8-4af0-8f06-f94c3eca624a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backuptool-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backuptool-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "988",
+                "self_link": null,
+                "uid": "3d2cd692-2c54-406c-8ea6-3bdd8ce3bfad"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuptools"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuptools/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-backuptool-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-backuptool-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "998",
+                "self_link": null,
+                "uid": "1c6ee36a-e796-4be3-9e32-7f95b56f2305"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuptools"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuptools/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-cluster-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-cluster-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "979",
+                "self_link": null,
+                "uid": "63e28f51-c428-49f7-980c-fbe57f19b338"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-cluster-pod-role": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "app.kubernetes.io/instance": "kubeblocks",
+                            "app.kubernetes.io/name": "kubeblocks",
+                            "app.kubernetes.io/required-by": "pod"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            }
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-cluster-pod-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1007",
+                "self_link": null,
+                "uid": "6290625d-61d4-4a43-b8db-252e2f208b58"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update",
+                        "create",
+                        "list",
+                        "watch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "nodes/stats"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-cluster-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-cluster-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "969",
+                "self_link": null,
+                "uid": "b600b630-6c5e-4839-841d-1d532b8dce3f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-clusterdefinition-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-clusterdefinition-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "975",
+                "self_link": null,
+                "uid": "73ea1282-bb28-4650-8494-a5bde37ef440"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-clusterdefinition-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-clusterdefinition-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "978",
+                "self_link": null,
+                "uid": "776d2aad-78b4-4f1b-befd-919217bf478d"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-clusterversion-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-clusterversion-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "990",
+                "self_link": null,
+                "uid": "05b82d6b-b956-4093-9549-11ecf147a33f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-clusterversion-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-clusterversion-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "982",
+                "self_link": null,
+                "uid": "2e1c2c49-98f2-47b5-b738-b3ee8b380f2f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-configconstraint-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-configconstraint-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "995",
+                "self_link": null,
+                "uid": "ae433064-eb17-4ea7-95e1-2ea9d3e55e41"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-configconstraint-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-configconstraint-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "972",
+                "self_link": null,
+                "uid": "3e43b905-80c4-4540-91ed-b1981126e818"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "999",
+                "self_link": null,
+                "uid": "0ba40c6a-640e-4764-ba3c-b7376e46d7be"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-lorry-pod-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/required-by": "pod",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/required-by": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-lorry-pod-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "993",
+                "self_link": null,
+                "uid": "e7ab5fc3-d0a3-48c5-9d5e-fd1cf834860f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-manager-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-manager-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1001",
+                "self_link": null,
+                "uid": "420c1dfa-f1c5-4af8-982c-9f60c1e700b7"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicytemplates/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusters/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterversions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentclassdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentclassdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentclassdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "componentresourceconstraints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "components"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "components/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "components/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configconstraints/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configurations"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configurations/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configurations/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsdefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsdefinitions/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsdefinitions/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "servicedescriptors"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "servicedescriptors/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "servicedescriptors/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/finalizers"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmap"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmap/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/exec"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/log"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "actionsets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "actionsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "actionsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuppolicies/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuprepos"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuprepos/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backuprepos/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backups/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backupschedules"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backupschedules/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "backupschedules/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshotclasses"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshotclasses/finalizers"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshots"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "snapshot.storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumesnapshots/finalizers"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageproviders"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageproviders/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageproviders/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-metrics-reader": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-metrics-reader",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "970",
+                "self_link": null,
+                "uid": "74c280d8-7bde-4625-a351-f917494a6d04"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/metrics"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-opsrequest-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-opsrequest-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "983",
+                "self_link": null,
+                "uid": "c53ed5c9-2db4-416b-8ee9-71f44477d1db"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-opsrequest-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-opsrequest-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "997",
+                "self_link": null,
+                "uid": "f8718b90-7d71-4799-8db0-b831463c3049"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "opsrequests/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-patroni-pod-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/required-by": "pod",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/required-by": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-patroni-pod-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "981",
+                "self_link": null,
+                "uid": "f198f98b-663c-4352-ab14-33302db4437c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update",
+                        "create",
+                        "list",
+                        "watch",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-proxy-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-proxy-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "977",
+                "self_link": null,
+                "uid": "ba6e8688-b689-4dfa-a206-5259c4755db6"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-rbac-manager-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-rbac-manager-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "1000",
+                "self_link": null,
+                "uid": "1c62be44-d8db-4f71-b31f-12a498dcf41c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterrolebindings/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-restore-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-restore-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "994",
+                "self_link": null,
+                "uid": "574ae0f9-ab49-4229-a5e9-2dd85fe8df08"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-restore-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-restore-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "986",
+                "self_link": null,
+                "uid": "e238c920-f566-4e31-8869-1a7d0d177476"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "dataprotection.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "restores/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "996",
+                "self_link": null,
+                "uid": "afd5b750-21c3-45ea-9a8a-5991e6992aee"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "addons/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeblocks-volume-protection-pod-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kubeblocks",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "kubeblocks",
+                    "app.kubernetes.io/required-by": "pod",
+                    "app.kubernetes.io/version": "0.8.1",
+                    "helm.sh/chart": "kubeblocks-0.8.1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/required-by": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "kubeblocks-volume-protection-pod-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "976",
+                "self_link": null,
+                "uid": "f5d7f410-f426-47f0-82e2-dd16257fd781"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "nodes/stats"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "local-path-provisioner-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-role\"},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"nodes\",\"persistentvolumeclaims\",\"configmaps\"],\"verbs\":[\"get\",\"list\",\"watch\"]},{\"apiGroups\":[\"\"],\"resources\":[\"endpoints\",\"persistentvolumes\",\"pods\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"\"],\"resources\":[\"events\"],\"verbs\":[\"create\",\"patch\"]},{\"apiGroups\":[\"storage.k8s.io\"],\"resources\":[\"storageclasses\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-06T04:35:37+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:37+00:00"
+                    }
+                ],
+                "name": "local-path-provisioner-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "273",
+                "self_link": null,
+                "uid": "6b92d9cc-b8dc-41c7-9f10-7532862db454"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "persistentvolumeclaims",
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "persistentvolumes",
+                        "pods"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "replicatedstatemachine-editor-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "rbac",
+                    "app.kubernetes.io/created-by": "kubeblocks",
+                    "app.kubernetes.io/instance": "replicatedstatemachine-editor-role",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "clusterrole",
+                    "app.kubernetes.io/part-of": "kubeblocks"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "replicatedstatemachine-editor-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "991",
+                "self_link": null,
+                "uid": "c69fe323-fad2-4b46-95c6-8d35695d88cb"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "replicatedstatemachines-viewer-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "meta.helm.sh/release-name": "kubeblocks",
+                    "meta.helm.sh/release-namespace": "kb-system"
+                },
+                "creation_timestamp": "2024-02-06T04:39:00+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "rbac",
+                    "app.kubernetes.io/created-by": "kubeblocks",
+                    "app.kubernetes.io/instance": "replicatedstatemachine-viewer-role",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "clusterrole",
+                    "app.kubernetes.io/part-of": "kubeblocks"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:meta.helm.sh/release-name": {},
+                                    "f:meta.helm.sh/release-namespace": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/created-by": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/part-of": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kbcli",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:39:00+00:00"
+                    }
+                ],
+                "name": "replicatedstatemachines-viewer-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "973",
+                "self_link": null,
+                "uid": "ccc05fef-3ef0-4101-9cfa-6329d1e58006"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "workloads.kubeblocks.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicatedstatemachines/status"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "80",
+                "self_link": null,
+                "uid": "bd73aace-8a05-488e-9a22-7635004e26a7"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "81",
+                "self_link": null,
+                "uid": "bab39e97-8260-46e2-972e-1c80cc4de298"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "82",
+                "self_link": null,
+                "uid": "256ae3b0-6721-402f-a69e-2bedbd827b8b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:auth-delegator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:auth-delegator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "88",
+                "self_link": null,
+                "uid": "54dab24d-ee27-4495-836a-d4dcdd1a3999"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:basic-user": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:basic-user",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "75",
+                "self_link": null,
+                "uid": "2d920599-a85c-43e0-8ef5-b2b4e03fe2ec"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "selfsubjectaccessreviews",
+                        "selfsubjectrulesreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "selfsubjectreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:certificatesigningrequests:nodeclient": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "93",
+                "self_link": null,
+                "uid": "534885f0-e4c0-4d00-a312-55b3c42d5637"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/nodeclient"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "94",
+                "self_link": null,
+                "uid": "27147df7-121b-45ce-8ca4-b3ab39694f7b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/selfnodeclient"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kube-apiserver-client-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kube-apiserver-client-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "98",
+                "self_link": null,
+                "uid": "9ede0978-a433-42d9-881b-ab981fe9bf08"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kube-apiserver-client-kubelet-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kube-apiserver-client-kubelet-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "99",
+                "self_link": null,
+                "uid": "5542195e-e50c-4530-aac9-f517faef8328"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client-kubelet"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kubelet-serving-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kubelet-serving-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "97",
+                "self_link": null,
+                "uid": "b67fb282-6bb8-4299-a250-537a0382a495"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kubelet-serving"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:legacy-unknown-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:legacy-unknown-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "96",
+                "self_link": null,
+                "uid": "eb339c52-20a9-4905-943a-814606ea8865"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/legacy-unknown"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:controller:attachdetach-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:attachdetach-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "103",
+                "self_link": null,
+                "uid": "9cc1b6b3-5656-4b3a-a854-f11b5daf9098"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumeattachments"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:certificate-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:certificate-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "129",
+                "self_link": null,
+                "uid": "fb227a13-483d-4169-ae02-2c3fffd06453"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/approval",
+                        "certificatesigningrequests/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client-kubelet"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client",
+                        "kubernetes.io/kube-apiserver-client-kubelet",
+                        "kubernetes.io/kubelet-serving",
+                        "kubernetes.io/legacy-unknown"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "sign"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:clusterrole-aggregation-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:clusterrole-aggregation-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "104",
+                "self_link": null,
+                "uid": "4171bceb-1449-488e-8b4b-0f9b0a99a5cc"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterroles"
+                    ],
+                    "verbs": [
+                        "escalate",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:cronjob-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:cronjob-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "105",
+                "self_link": null,
+                "uid": "e729322d-d838-4f9e-b558-3b97f3b7e4e1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:daemon-set-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:daemon-set-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "106",
+                "self_link": null,
+                "uid": "1d500b75-ac17-4b6c-9601-1d70277707b9"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/binding"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:deployment-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:deployment-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "107",
+                "self_link": null,
+                "uid": "02cab70e-d349-418a-a083-d73af0d722ca"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:disruption-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:disruption-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "108",
+                "self_link": null,
+                "uid": "d3424ab3-febd-4acb-8a34-e29d551d2223"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*/scale"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpoint-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:endpoint-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "109",
+                "self_link": null,
+                "uid": "acd1e8b2-8052-4e6c-84eb-10f1b04c6bd9"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints/restricted"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpointslice-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslice-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "110",
+                "self_link": null,
+                "uid": "72013871-fb40-4856-98a5-967bee29d2d1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "pods",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpointslicemirroring-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslicemirroring-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "111",
+                "self_link": null,
+                "uid": "e0dc144f-12c3-43e2-9634-d32c4b32d9f4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ephemeral-volume-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:ephemeral-volume-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "113",
+                "self_link": null,
+                "uid": "db4b5ffe-98c4-45be-998c-a0ac21ea123b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:expand-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:expand-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "112",
+                "self_link": null,
+                "uid": "170dbb17-d37b-4b52-92f9-93740c9789e2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:generic-garbage-collector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:generic-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "114",
+                "self_link": null,
+                "uid": "4480f88e-71fb-415c-8739-f89238a045cf"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:horizontal-pod-autoscaler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:horizontal-pod-autoscaler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "115",
+                "self_link": null,
+                "uid": "214ce931-9063-417a-87bb-f515c1ff40cd"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "custom.metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "external.metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:job-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:job-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "116",
+                "self_link": null,
+                "uid": "50fbb6db-8040-45e0-b847-3e0f9161d17d"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:legacy-service-account-token-cleaner": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:legacy-service-account-token-cleaner",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "134",
+                "self_link": null,
+                "uid": "231e0cd2-ba70-48f3-9e44-a183e9d8650c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-apiserver-legacy-service-account-token-tracking"
+                    ],
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:namespace-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:namespace-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "117",
+                "self_link": null,
+                "uid": "6940c962-68c8-4a73-8183-828ff57ca9d0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces/finalize",
+                        "namespaces/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "system:controller:node-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:node-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "118",
+                "self_link": null,
+                "uid": "fe7cf963-407a-4551-b76b-5918a3a7774f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustercidrs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:controller:persistent-volume-binder": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:persistent-volume-binder",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "119",
+                "self_link": null,
+                "uid": "bdc94d27-62d6-455a-aa06-92bdb1e8d817"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pod-garbage-collector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:pod-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "120",
+                "self_link": null,
+                "uid": "32c39fd0-30ec-4b7f-88d9-2bb2869ae954"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pv-protection-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:pv-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "131",
+                "self_link": null,
+                "uid": "983c8d8e-9818-4751-8b67-da1393c87140"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pvc-protection-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:pvc-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "130",
+                "self_link": null,
+                "uid": "482b49b6-66c1-4350-8435-44fe93bf6b40"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:replicaset-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:replicaset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "121",
+                "self_link": null,
+                "uid": "d4690f4d-13c1-46d1-99d8-1f3a52049702"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:replication-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:replication-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "122",
+                "self_link": null,
+                "uid": "04723f2c-21b5-4dcb-9f2c-2f4823c96fba"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:resourcequota-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:resourcequota-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "123",
+                "self_link": null,
+                "uid": "22126b49-7c2d-44f1-90b0-35f1ac3e3d88"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:root-ca-cert-publisher": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:root-ca-cert-publisher",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "133",
+                "self_link": null,
+                "uid": "a4efe9bb-7df0-48c5-88f4-8142ded7d396"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:route-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:route-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "124",
+                "self_link": null,
+                "uid": "a4e66e05-1c37-494c-8065-ac515542d6bb"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:service-account-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:service-account-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "125",
+                "self_link": null,
+                "uid": "fde334ac-1adf-4080-a727-94be8325e2c1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:service-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:service-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "126",
+                "self_link": null,
+                "uid": "d87d24ef-edb7-4c8a-a7ba-22a26c6107dc"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:statefulset-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:statefulset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "127",
+                "self_link": null,
+                "uid": "f82092df-edb6-41ff-b01a-e317290bccef"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ttl-after-finished-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-after-finished-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "132",
+                "self_link": null,
+                "uid": "f7021246-89ef-464b-afeb-492ea0336dca"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ttl-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "128",
+                "self_link": null,
+                "uid": "56f66635-6310-4ffb-ab89-28aadc326a8a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:coredns": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:35+00:00"
+                    }
+                ],
+                "name": "system:coredns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "217",
+                "self_link": null,
+                "uid": "bb38f04a-ab76-4999-9bbc-3517f051c73c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services",
+                        "pods",
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:discovery": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "73",
+                "self_link": null,
+                "uid": "d4d2cb51-7d7e-456e-a335-727d05f06122"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/api",
+                        "/api/*",
+                        "/apis",
+                        "/apis/*",
+                        "/healthz",
+                        "/livez",
+                        "/openapi",
+                        "/openapi/*",
+                        "/readyz",
+                        "/version",
+                        "/version/"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:heapster": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:heapster",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "83",
+                "self_link": null,
+                "uid": "f2978c24-b8d5-47bf-8578-b959a22c1d31"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events",
+                        "namespaces",
+                        "nodes",
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-aggregator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kube-aggregator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "89",
+                "self_link": null,
+                "uid": "0a1bbff0-996d-41a3-9375-a630a155ff01"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-controller-manager": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kube-controller-manager",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "90",
+                "self_link": null,
+                "uid": "93491e1d-41f0-4cd6-a40d-0635dd1c3268"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-controller-manager"
+                    ],
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "namespaces",
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:kube-dns": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kube-dns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "91",
+                "self_link": null,
+                "uid": "448ab637-bce5-406e-8bbd-e66ef4eff6be"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-scheduler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kube-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "102",
+                "self_link": null,
+                "uid": "e7922d46-1209-4d93-a87e-f5de118d3653"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-scheduler"
+                    ],
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "pods/binding"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csistoragecapacities"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kubelet-api-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:kubelet-api-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "86",
+                "self_link": null,
+                "uid": "b30b3b6a-0812-4f65-ba99-28f9be48a836"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "proxy"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/log",
+                        "nodes/metrics",
+                        "nodes/proxy",
+                        "nodes/stats"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "system:monitoring": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:monitoring",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "74",
+                "self_link": null,
+                "uid": "4b009932-57cd-46a3-aea1-88d73b1ce626"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/healthz",
+                        "/healthz/*",
+                        "/livez",
+                        "/livez/*",
+                        "/metrics",
+                        "/metrics/slis",
+                        "/readyz",
+                        "/readyz/*"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:node": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:node",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "84",
+                "self_link": null,
+                "uid": "82104a08-7487-449c-a24d-24abd8c43dd0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews",
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumeattachments"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "node.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "runtimeclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:node-bootstrapper": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:node-bootstrapper",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "87",
+                "self_link": null,
+                "uid": "05b17898-3889-4ce4-b414-f3ddf4268b1f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:node-problem-detector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:node-problem-detector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "85",
+                "self_link": null,
+                "uid": "1181a362-ca4d-4f2a-8c30-07b68a1e14a0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:node-proxier": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "101",
+                "self_link": null,
+                "uid": "e86d3075-7084-4563-bc73-15cfcd18fa77"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:persistent-volume-provisioner": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:persistent-volume-provisioner",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "92",
+                "self_link": null,
+                "uid": "a4f0f10b-830b-4dd4-9bfc-b951561334d4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:public-info-viewer": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:public-info-viewer",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "76",
+                "self_link": null,
+                "uid": "61aabd2d-8938-4b47-8dab-4e33a76028fe"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/healthz",
+                        "/livez",
+                        "/readyz",
+                        "/version",
+                        "/version/"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:service-account-issuer-discovery": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:service-account-issuer-discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "100",
+                "self_link": null,
+                "uid": "c7391f91-956b-4477-8eb0-9cc44190b09b"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/.well-known/openid-configuration",
+                        "/.well-known/openid-configuration/",
+                        "/openid/v1/jwks",
+                        "/openid/v1/jwks/"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:volume-scheduler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "system:volume-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "95",
+                "self_link": null,
+                "uid": "04d9849c-6a4c-48c2-a3dc-ea12428e7aa0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "view": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:50+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "338",
+                "self_link": null,
+                "uid": "e81011f6-7db1-4611-b811-7759c894fa84"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        }
+    },
+    "config_map": {
+        "kube-root-ca.crt": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "ca.crt": "-----BEGIN CERTIFICATE-----\nMIIDBTCCAe2gAwIBAgIIPn6jvGGF0iAwDQYJKoZIhvcNAQELBQAwFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczAeFw0yNDAyMDYwNDMwMjFaFw0zNDAyMDMwNDM1MjFaMBUx\nEzARBgNVBAMTCmt1YmVybmV0ZXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\nAoIBAQDxFHC1A1FMpIZo2EtDI0vKKChf1kAKfo1G8PXWdtjlw9+chMryGFfTj2Bh\nsa+NTmZ6kNDAb5K5yRGHKvFxkXvalCGbMeo06xqsIc7lscwfz3keTXe2aNBFO/WO\nnRifaQIf71WSaHknzL2amfU6/hbqLZACMXjuvRWgghcgdZFtuZMsYMthW6EHxJVq\nBZUKMszs67T/jhZYfBq6qnpKhZJYixdNh9vNNMAj6iEz/9/UuXgGhUUVc4mgUEMg\nMWCKmXv9d3p9tdTge7ecJ/uJCv7qk7kppCl/vZlw7CWkSHHcBfNVN5mE+uIEobbW\nKUHwwyRtzbNKHAVJCs6SMAn6wwpBAgMBAAGjWTBXMA4GA1UdDwEB/wQEAwICpDAP\nBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQTQcZHUpah3We8E/wZAwhJ1AlgnTAV\nBgNVHREEDjAMggprdWJlcm5ldGVzMA0GCSqGSIb3DQEBCwUAA4IBAQB9otdQr4KS\nOJRviJWXEvlikuT0iTELleLsRLIVa+dMrhl9D9Uffa+Ef/MyLvEK6ZZalw4A/3vL\nUk0z8ivTjo/ZTiP5FNPMm2NShtzf+m+aNGbp6QAfcLbTcJ5UD1Db0ZVfvgFO3HFd\ndTXxeHNiJ2OzouOYm3tLLy76itrqSn8NL198NM4ZvQJ4R3RfUpXTLWXQdkPcIz7e\n3eECz+bBNG3IQVfDUTC/pt7Jeq46keUd12YU/8j+twU3eRfgm+e82481lQt2VGoa\nmnblxkCD9Qn6JYyBPQTKL1mkem4ODPHbAp07fLAmJV+SB08TrO0HkLopt1z+T+Sc\nvT8dDHiLR2QC\n-----END CERTIFICATE-----\n"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubernetes.io/description": "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. No other usage is guaranteed across distributions of Kubernetes clusters."
+                },
+                "creation_timestamp": "2024-02-06T05:46:14+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:ca.crt": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubernetes.io/description": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:14+00:00"
+                    }
+                ],
+                "name": "kube-root-ca.crt",
+                "namespace": "demo",
+                "owner_references": null,
+                "resource_version": "13101",
+                "self_link": null,
+                "uid": "a38f3fe7-7f3d-4579-8977-51b404c06a11"
+            }
+        }
+    },
+    "cron_job": {},
+    "daemon_set": {},
+    "deployment": {},
+    "endpoint": {},
+    "ingress": {},
+    "job": {},
+    "network_policy": {},
+    "persistent_volume_claim": {},
+    "persistent_volume": {
+        "pvc-edeac3ec-49fe-48d7-b87e-411e8f786207": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "pv.kubernetes.io/provisioned-by": "rancher.io/local-path"
+                },
+                "creation_timestamp": "2024-02-06T05:46:32+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "kubernetes.io/pv-protection"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:phase": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-06T05:46:32+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:pv.kubernetes.io/provisioned-by": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:accessModes": {},
+                                "f:capacity": {
+                                    ".": {},
+                                    "f:storage": {}
+                                },
+                                "f:claimRef": {
+                                    ".": {},
+                                    "f:apiVersion": {},
+                                    "f:kind": {},
+                                    "f:name": {},
+                                    "f:namespace": {},
+                                    "f:resourceVersion": {},
+                                    "f:uid": {}
+                                },
+                                "f:hostPath": {
+                                    ".": {},
+                                    "f:path": {},
+                                    "f:type": {}
+                                },
+                                "f:nodeAffinity": {
+                                    ".": {},
+                                    "f:required": {}
+                                },
+                                "f:persistentVolumeReclaimPolicy": {},
+                                "f:storageClassName": {},
+                                "f:volumeMode": {}
+                            }
+                        },
+                        "manager": "local-path-provisioner",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:32+00:00"
+                    }
+                ],
+                "name": "pvc-edeac3ec-49fe-48d7-b87e-411e8f786207",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "13244",
+                "self_link": null,
+                "uid": "aad30b0c-3949-413f-ba90-3a29fe6fc852"
+            },
+            "spec": {
+                "access_modes": [
+                    "ReadWriteOnce"
+                ],
+                "aws_elastic_block_store": null,
+                "azure_disk": null,
+                "azure_file": null,
+                "capacity": {
+                    "storage": "20Gi"
+                },
+                "cephfs": null,
+                "cinder": null,
+                "claim_ref": {
+                    "api_version": "v1",
+                    "field_path": null,
+                    "kind": "PersistentVolumeClaim",
+                    "name": "data-mycluster-mysql-0",
+                    "namespace": "default",
+                    "resource_version": "13209",
+                    "uid": "edeac3ec-49fe-48d7-b87e-411e8f786207"
+                },
+                "csi": null,
+                "fc": null,
+                "flex_volume": null,
+                "flocker": null,
+                "gce_persistent_disk": null,
+                "glusterfs": null,
+                "host_path": {
+                    "path": "/var/local-path-provisioner/pvc-edeac3ec-49fe-48d7-b87e-411e8f786207_default_data-mycluster-mysql-0",
+                    "type": "DirectoryOrCreate"
+                },
+                "iscsi": null,
+                "local": null,
+                "mount_options": null,
+                "nfs": null,
+                "node_affinity": {
+                    "required": {
+                        "node_selector_terms": [
+                            {
+                                "match_expressions": [
+                                    {
+                                        "key": "kubernetes.io/hostname",
+                                        "operator": "In",
+                                        "values": [
+                                            "kind-worker2"
+                                        ]
+                                    }
+                                ],
+                                "match_fields": null
+                            }
+                        ]
+                    }
+                },
+                "persistent_volume_reclaim_policy": "Delete",
+                "photon_persistent_disk": null,
+                "portworx_volume": null,
+                "quobyte": null,
+                "rbd": null,
+                "scale_io": null,
+                "storage_class_name": "standard",
+                "storageos": null,
+                "volume_mode": "Filesystem",
+                "vsphere_volume": null
+            },
+            "status": {
+                "message": null,
+                "phase": "Bound",
+                "reason": null
+            }
+        }
+    },
+    "pod": {},
+    "replica_set": {},
+    "role_binding": {},
+    "role": {},
+    "secret": {},
+    "service_account": {
+        "default": {
+            "api_version": null,
+            "automount_service_account_token": null,
+            "image_pull_secrets": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:14+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": null,
+                "name": "default",
+                "namespace": "demo",
+                "owner_references": null,
+                "resource_version": "13102",
+                "self_link": null,
+                "uid": "45801b70-6b44-4c36-a1d5-48a52b0b7eea"
+            },
+            "secrets": null
+        }
+    },
+    "service": {},
+    "stateful_set": {},
+    "storage_class": {
+        "standard": {
+            "allow_volume_expansion": null,
+            "allowed_topologies": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"storage.k8s.io/v1\",\"kind\":\"StorageClass\",\"metadata\":{\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"},\"name\":\"standard\"},\"provisioner\":\"rancher.io/local-path\",\"reclaimPolicy\":\"Delete\",\"volumeBindingMode\":\"WaitForFirstConsumer\"}\n",
+                    "storageclass.kubernetes.io/is-default-class": "true"
+                },
+                "creation_timestamp": "2024-02-06T04:35:37+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "storage.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:storageclass.kubernetes.io/is-default-class": {}
+                                }
+                            },
+                            "f:provisioner": {},
+                            "f:reclaimPolicy": {},
+                            "f:volumeBindingMode": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:37+00:00"
+                    }
+                ],
+                "name": "standard",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "276",
+                "self_link": null,
+                "uid": "8e8e02ac-5e60-4b24-8874-89afeebd0da7"
+            },
+            "mount_options": null,
+            "parameters": null,
+            "provisioner": "rancher.io/local-path",
+            "reclaim_policy": "Delete",
+            "volume_binding_mode": "WaitForFirstConsumer"
+        }
+    }
+}

--- a/operators/apecloud_kubeblocks-mysql/system_state.json
+++ b/operators/apecloud_kubeblocks-mysql/system_state.json
@@ -19771,7 +19771,7 @@
                 "annotations": {
                     "kubernetes.io/description": "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. No other usage is guaranteed across distributions of Kubernetes clusters."
                 },
-                "creation_timestamp": "2024-02-06T05:46:14+00:00",
+                "creation_timestamp": "2024-02-06T04:35:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -19797,26 +19797,1321 @@
                         "manager": "kube-controller-manager",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-06T05:46:14+00:00"
+                        "time": "2024-02-06T04:35:50+00:00"
                     }
                 ],
                 "name": "kube-root-ca.crt",
-                "namespace": "demo",
+                "namespace": "default",
                 "owner_references": null,
-                "resource_version": "13101",
+                "resource_version": "330",
                 "self_link": null,
-                "uid": "a38f3fe7-7f3d-4579-8977-51b404c06a11"
+                "uid": "c795f47a-7898-4564-8d1b-c376240b169e"
+            }
+        },
+        "mycluster-mysql-agamotto-configuration": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "agamotto-config-with-proxy.yaml": "exporters:\n  prometheus:\n    enable_open_metrics: false\n    endpoint: 0.0.0.0:9104\n    metric_expiration: 20s\n    resource_to_telemetry_conversion:\n      enabled: true\n    send_timestamps: false\nextensions:\n  memory_ballast:\n    size_mib: 32\nprocessors:\n  memory_limiter:\n    check_interval: 10s\n    limit_mib: 128\n    spike_limit_mib: 32\nreceivers:\n  apecloudmysql:\n    allow_native_passwords: true\n    collection_interval: 15s\n    database: null\n    endpoint: ${env:ENDPOINT}\n    password: ${env:MYSQL_PASSWORD}\n    transport: tcp\n    username: ${env:MYSQL_USER}\n  prometheus:\n    config:\n      scrape_configs:\n      - job_name: agamotto\n        scrape_interval: 15s\n        static_configs:\n        - targets:\n          - 127.0.0.1:15100\nservice:\n  extensions:\n  - memory_ballast\n  pipelines:\n    metrics:\n      exporters:\n      - prometheus\n      processors:\n      - memory_limiter\n      receivers:\n      - apecloudmysql\n      - prometheus\n  telemetry:\n    logs:\n      level: info",
+                "agamotto-config.yaml": "extensions:\n  memory_ballast:\n    size_mib: 32\n\nreceivers:\n  apecloudmysql:\n    endpoint: ${env:ENDPOINT}\n    username: ${env:MYSQL_USER}\n    password: ${env:MYSQL_PASSWORD}\n    allow_native_passwords: true\n    database:\n    collection_interval: 15s\n    transport: tcp\n\nprocessors:\n  memory_limiter:\n    limit_mib: 128\n    spike_limit_mib: 32\n    check_interval: 10s\n\nexporters:\n  prometheus:\n    endpoint: 0.0.0.0:9104\n    send_timestamps: false\n    metric_expiration: 20s\n    enable_open_metrics: false\n    resource_to_telemetry_conversion:\n      enabled: true\n\nservice:\n  telemetry:\n    logs:\n      level: info\n  extensions: [ memory_ballast ]\n  pipelines:\n    metrics:\n      receivers: [ apecloudmysql ]\n      processors: [ memory_limiter ]\n      exporters: [ prometheus ]"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "config.kubeblocks.io/config-applied-version": "{\"name\":\"agamotto-configuration\",\"payload\":null,\"configSpec\":{\"name\":\"agamotto-configuration\",\"templateRef\":\"apecloud-mysql8-agamotto-configuration\",\"namespace\":\"kb-system\",\"volumeName\":\"agamotto-configuration\",\"defaultMode\":292},\"importTemplateRef\":null}",
+                    "config.kubeblocks.io/config-template-version": "",
+                    "config.kubeblocks.io/configuration-revision": "1",
+                    "config.kubeblocks.io/disable-reconfigure": "false",
+                    "config.kubeblocks.io/last-applied-configuration": "{\"agamotto-config-with-proxy.yaml\":\"exporters:\\n  prometheus:\\n    enable_open_metrics: false\\n    endpoint: 0.0.0.0:9104\\n    metric_expiration: 20s\\n    resource_to_telemetry_conversion:\\n      enabled: true\\n    send_timestamps: false\\nextensions:\\n  memory_ballast:\\n    size_mib: 32\\nprocessors:\\n  memory_limiter:\\n    check_interval: 10s\\n    limit_mib: 128\\n    spike_limit_mib: 32\\nreceivers:\\n  apecloudmysql:\\n    allow_native_passwords: true\\n    collection_interval: 15s\\n    database: null\\n    endpoint: ${env:ENDPOINT}\\n    password: ${env:MYSQL_PASSWORD}\\n    transport: tcp\\n    username: ${env:MYSQL_USER}\\n  prometheus:\\n    config:\\n      scrape_configs:\\n      - job_name: agamotto\\n        scrape_interval: 15s\\n        static_configs:\\n        - targets:\\n          - 127.0.0.1:15100\\nservice:\\n  extensions:\\n  - memory_ballast\\n  pipelines:\\n    metrics:\\n      exporters:\\n      - prometheus\\n      processors:\\n      - memory_limiter\\n      receivers:\\n      - apecloudmysql\\n      - prometheus\\n  telemetry:\\n    logs:\\n      level: info\",\"agamotto-config.yaml\":\"extensions:\\n  memory_ballast:\\n    size_mib: 32\\n\\nreceivers:\\n  apecloudmysql:\\n    endpoint: ${env:ENDPOINT}\\n    username: ${env:MYSQL_USER}\\n    password: ${env:MYSQL_PASSWORD}\\n    allow_native_passwords: true\\n    database:\\n    collection_interval: 15s\\n    transport: tcp\\n\\nprocessors:\\n  memory_limiter:\\n    limit_mib: 128\\n    spike_limit_mib: 32\\n    check_interval: 10s\\n\\nexporters:\\n  prometheus:\\n    endpoint: 0.0.0.0:9104\\n    send_timestamps: false\\n    metric_expiration: 20s\\n    enable_open_metrics: false\\n    resource_to_telemetry_conversion:\\n      enabled: true\\n\\nservice:\\n  telemetry:\\n    logs:\\n      level: info\\n  extensions: [ memory_ballast ]\\n  pipelines:\\n    metrics:\\n      receivers: [ apecloudmysql ]\\n      processors: [ memory_limiter ]\\n      exporters: [ prometheus ]\"}",
+                    "config.kubeblocks.io/reconfigure-source": "manager",
+                    "config.kubeblocks.io/revision-reconcile-phase-1": "{\"phase\":\"Finished\",\"revision\":\"1\",\"policy\":\"\",\"execResult\":\"\",\"succeedCount\":0,\"expectedCount\":-1,\"retry\":false,\"failed\":false,\"message\":\"phase: created\"}",
+                    "config.kubeblocks.io/update-config-hash": "845b49b4c4"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "config.kubeblocks.io/config-hash": "845b49b4c4",
+                    "config.kubeblocks.io/config-spec": "agamotto-configuration",
+                    "config.kubeblocks.io/config-template-name": "apecloud-mysql8-agamotto-configuration",
+                    "config.kubeblocks.io/config-type": "instance",
+                    "config.kubeblocks.io/last-applied-reconfigure-phase": "created",
+                    "config.kubeblocks.io/template-name": "apecloud-mysql8-agamotto-configuration"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:agamotto-config-with-proxy.yaml": {},
+                                "f:agamotto-config.yaml": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:config.kubeblocks.io/config-applied-version": {},
+                                    "f:config.kubeblocks.io/config-template-version": {},
+                                    "f:config.kubeblocks.io/configuration-revision": {},
+                                    "f:config.kubeblocks.io/disable-reconfigure": {},
+                                    "f:config.kubeblocks.io/last-applied-configuration": {},
+                                    "f:config.kubeblocks.io/reconfigure-source": {},
+                                    "f:config.kubeblocks.io/revision-reconcile-phase-1": {},
+                                    "f:config.kubeblocks.io/update-config-hash": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:config.kubeblocks.io/config-hash": {},
+                                    "f:config.kubeblocks.io/config-spec": {},
+                                    "f:config.kubeblocks.io/config-template-name": {},
+                                    "f:config.kubeblocks.io/config-type": {},
+                                    "f:config.kubeblocks.io/last-applied-reconfigure-phase": {},
+                                    "f:config.kubeblocks.io/template-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"51757a9b-30e6-431e-85f8-8eb2431384ee\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-agamotto-configuration",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Configuration",
+                        "name": "mycluster-mysql",
+                        "uid": "51757a9b-30e6-431e-85f8-8eb2431384ee"
+                    }
+                ],
+                "resource_version": "13176",
+                "self_link": null,
+                "uid": "6cbac86b-683d-436c-af0e-945260bf3fb7"
+            }
+        },
+        "mycluster-mysql-apecloud-mysql-scripts": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "agamotto.sh": "#!/bin/sh\nif [ \"$KB_PROXY_ENABLED\" != \"on\" ]; then\n  /bin/agamotto --config=/opt/agamotto/agamotto-config.yaml\nelse\n  /bin/agamotto --config=/opt/agamotto/agamotto-config-with-proxy.yaml\nfi ",
+                "etcd-post-start.sh": "#!/bin/bash\netcd_port=${ETCD_PORT:-'2379'}\netcd_server=${ETCD_SERVER:-'127.0.0.1'}\n\ncell=${CELL:-'zone1'}\nexport ETCDCTL_API=2\n\netcdctl --endpoints \"http://127.0.0.1:${etcd_port}\" get \"/vitess/global\" >/dev/null 2>&1\nif [[ $? -eq 1 ]]; then\n  exit 0\nfi\n\necho \"add /vitess/global\"\netcdctl --endpoints \"http://127.0.0.1:${etcd_port}\" mkdir /vitess/global\n\necho \"add /vitess/$cell\"\netcdctl --endpoints \"http://127.0.0.1:${etcd_port}\" mkdir /vitess/$cell\n\n# And also add the CellInfo description for the cell.\n# If the node already exists, it's fine, means we used existing data.\necho \"add $cell CellInfo\"\nset +e\nvtctl --topo_implementation etcd2 \\\n  --topo_global_server_address \"127.0.0.1:${etcd_port}\" \\\n  --topo_global_root /vitess/global VtctldCommand AddCellInfo \\\n  --root /vitess/$cell \\\n  --server-address \"${etcd_server}:${etcd_port}\" \\\n  $cell",
+                "etcd.sh": "#!/bin/bash\necho \"staring etcd.\"\netcd_port=${ETCD_PORT:-'2379'}\netcd_server=${ETCD_SERVER:-'127.0.0.1'}\n\ncell=${CELL:-'zone1'}\nexport ETCDCTL_API=2\n\netcd --enable-v2=true --data-dir \"${VTDATAROOT}/etcd/\"  \\\n  --listen-client-urls \"http://0.0.0.0:${etcd_port}\" \\\n  --advertise-client-urls \"http://0.0.0.0:${etcd_port}\" 2>&1 | tee \"${VTDATAROOT}/etcd.log\"",
+                "pre-stop.sh": "#!/bin/bash\n\nset_my_weight_to_zero() {\n  if [ ! -z $MYSQL_ROOT_PASSWORD ]; then \n    password_flag=\"-p$MYSQL_ROOT_PASSWORD\"\n  fi\n\n  if [ \"$KB_POD_NAME\" = \"$leader\" ]; then\n    echo \"self is leader, before scale in, need to set my election weight to 0.\" >> /data/mysql/.kb_pre_stop.log\n    host=$(eval echo \\$KB_\"$idx\"_HOSTNAME)\n    echo \"set weight to 0. mysql -uroot $password_flag -e \\\"call dbms_consensus.configure_follower('$host:13306',0 ,false);\\\" 2>&1\" >> /data/mysql/.kb_pre_stop.log\n    mysql -uroot $password_flag -e \"call dbms_consensus.configure_follower('$host:13306',0 ,false);\" 2>&1\n  fi\n}\n\nswitchover() {\n  if [ ! -z $MYSQL_ROOT_PASSWORD ]; then \n    password_flag=\"-p$MYSQL_ROOT_PASSWORD\"\n  fi\n  #new_leader_host=$KB_0_HOSTNAME\n  if [ \"$KB_POD_NAME\" = \"$leader\" ]; then\n    echo \"self is leader, need to switchover\" >> /data/mysql/.kb_pre_stop.log\n    echo \"try to get global cluster info\" >> /data/mysql/.kb_pre_stop.log\n    global_info=`mysql -uroot $password_flag 2>/dev/null -e \"select IP_PORT from information_schema.wesql_cluster_global order by MATCH_INDEX desc;\"`\n    echo \"all nodes: $global_info\" >> /data/mysql/.kb_pre_stop.log\n    global_info_arr=($global_info)\n    echo \"all nodes array: ${global_info_arr[0]},${global_info_arr[1]},${global_info_arr[2]},${global_info_arr[3]}\"  >> /data/mysql/.kb_pre_stop.log\n    echo \"array size: ${#global_info_arr[@]}, the first one is not real address,just the field name IP_PORT\"  >> /data/mysql/.kb_pre_stop.log\n\n    host=$(eval echo \\$KB_\"$idx\"_HOSTNAME)\n    host_ip_port=$host:13306\n    try_times=10\n    for((i=1;i<${#global_info_arr[@]};i++)) do\n      if [ \"$host_ip_port\" == \"${global_info_arr[i]}\" ];then\n        echo \"do not transfer to leader, leader:${global_info_arr[i]}\"  >> /data/mysql/.kb_pre_stop.log;\n      else\n        echo \"try to transfer to:${global_info_arr[i]}\"  >> /data/mysql/.kb_pre_stop.log;\n        echo \"mysql -uroot $password_flag -e \\\"call dbms_consensus.change_leader('${global_info_arr[i]}');\\\" 2>&1\" >> /data/mysql/.kb_pre_stop.log\n        mysql -uroot $password_flag -e \"call dbms_consensus.change_leader('${global_info_arr[i]}');\" 2>&1\n        sleep 1\n        role_info=`mysql -uroot $password_flag 2>/dev/null -e \"select ROLE from information_schema.wesql_cluster_local;\"`\n        role_info_arr=($role_info)\n        real_role=${role_info_arr[1]}\n        echo \"this node's current role info:$real_role\"  >> /data/mysql/.kb_pre_stop.log\n        if [ \"$real_role\" == \"Follower\" ];then\n          echo \"transfer successfully\" >> /data/mysql/.kb_pre_stop.log\n          new_leader_host_and_port=${global_info_arr[i]}\n          # get rid of port\n          new_leader_host=${new_leader_host_and_port%%:*}\n          echo \"new_leader_host=$new_leader_host\" >> /data/mysql/.kb_pre_stop.log\n          leader=`echo \"$new_leader_host\" | cut -d \".\" -f 1`\n          echo \"leader_host: $leader\"  >> /data/mysql/.kb_pre_stop.log\n          idx=${KB_POD_NAME##*-}\n          break\n        fi\n      fi\n      ((try_times--))\n      if [ $try_times -le 0 ];then\n        echo \"try too many times\" >> /data/mysql/.kb_pre_stop.log\n        break\n      fi\n    done\n  fi\n}\nleader=`cat /etc/annotations/leader`\nidx=${KB_POD_NAME##*-}\ncurrent_component_replicas=`cat /etc/annotations/component-replicas`\necho \"current replicas: $current_component_replicas\" >> /data/mysql/.kb_pre_stop.log\nif [ ! $idx -lt $current_component_replicas ] && [ $current_component_replicas -ne 0 ]; then \n    # if idx greater than or equal to current_component_replicas means the cluster's scaling in\n    # put .restore on pvc for next scaling out, if pvc not deleted\n    touch /data/mysql/data/.restore; sync\n    # set wegiht to 0 and switch leader before leader scaling in itself\n    set_my_weight_to_zero\n    switchover\nelif [ $current_component_replicas -eq 0 ]; then\n    # stop, do nothing.\n    echo \"stop, do nothing\" >> /data/mysql/.kb_pre_stop.log\nelse \n    # restart, switchover first.\n    echo \"Also try to switchover just before restart\" >> /data/mysql/.kb_pre_stop.log\n    switchover\n    echo \"no need to drop followers\" >> /data/mysql/.kb_pre_stop.log\nfi",
+                "set_config_variables.sh": "#!/bin/bash\nfunction set_config_variables(){\n  echo \"set config variables [$1]\"\n  config_file=\"/conf/$1.cnf\"\n  config_content=$(sed -n '/\\['$1'\\]/,/\\[/ { /\\['$1'\\]/d; /\\[/q; p; }' $config_file)\n  while read line\n  do\n    if [[ $line =~ ^[a-zA-Z_][a-zA-Z0-9_]*=[a-zA-Z0-9_.]*$ ]]; then\n      echo $line\n      eval \"export $line\"\n    elif ! [[ -z $line  || $line =~ ^[[:space:]]*# ]]; then \n      echo \"bad format: $line\"\n    fi\n  done <<< \"$(echo -e \"$config_content\")\"\n}",
+                "setup.sh": "#!/bin/bash\nrmdir /docker-entrypoint-initdb.d && mkdir -p /data/mysql/auditlog && mkdir -p /data/mysql/binlog && mkdir -p /data/mysql/docker-entrypoint-initdb.d && ln -s /data/mysql/docker-entrypoint-initdb.d /docker-entrypoint-initdb.d;\nexec docker-entrypoint.sh",
+                "switchover-with-candidate.sh": "#!/bin/bash\nset -ex\n\nif [ ! -z $MYSQL_ROOT_PASSWORD ]; then\n  password_flag=\"-p$MYSQL_ROOT_PASSWORD\"\nfi\n\nleader_ip_port=$KB_CONSENSUS_LEADER_POD_FQDN:13306\ncandidate_ip_port=$KB_SWITCHOVER_CANDIDATE_FQDN:13306\n\n# get currently leader weight\nleader_weight_info=`mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag 2>/dev/null -e \"select ELECTION_WEIGHT from information_schema.wesql_cluster_global where IP_PORT='$leader_ip_port' limit 1;\"`\nleader_weight_arr=($leader_weight_info)\nleader_weight=${leader_weight_arr[1]}\necho \"leader_weight=$leader_weight\"\n\n# get candidate weight\ncandidate_weight_info=`mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag 2>/dev/null -e \"select ELECTION_WEIGHT from information_schema.wesql_cluster_global where IP_PORT='$candidate_ip_port' limit 1;\"`\ncandidate_weight_arr=($candidate_weight_info)\ncandidate_weight=${candidate_weight_arr[1]}\necho \"candidate_weight=$leader_weight\"\n\n# if candidate weight is less than leader weight, update leader weight to candidate weight\nif [ $candidate_weight -lt $leader_weight ];then\n   echo \"leader weight larger than follower weight, update leader weight to current follower weight! leader:$leader_ip_port, leader weight:$leader_weight, follower:$candidate_ip_port, follower weight:$candidate_weight\"\n   mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag -e \"call dbms_consensus.configure_follower('$leader_ip_port', $candidate_weight, 0);\" 2>&1\nfi\n\n# do switchover\nmysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag -e \"call dbms_consensus.change_leader('$KB_SWITCHOVER_CANDIDATE_FQDN:13306');\"\n\nsleep 5\n\n# check if switchover successfully\nrole_info=`mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag 2>/dev/null -e \"select ROLE from information_schema.wesql_cluster_local;\"`\nrole_info_arr=($role_info)\nreal_role=${role_info_arr[1]}\nif [ \"$real_role\" == \"Follower\" ];then\n  echo \"switchover successfully\"\nelse\n  echo \"switchover failed, please check!\"\n  exit 1\nfi",
+                "switchover-without-candidate.sh": "#!/bin/bash\nset -ex\n\nif [ ! -z $MYSQL_ROOT_PASSWORD ]; then\n  password_flag=\"-p$MYSQL_ROOT_PASSWORD\"\nfi\nglobal_info=`mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag 2>/dev/null -e \"select IP_PORT from information_schema.wesql_cluster_global order by MATCH_INDEX desc;\"`\nglobal_info_arr=($global_info)\nleader_ip_port=$KB_CONSENSUS_LEADER_POD_FQDN:13306\ntry_times=10\n\nfor((i=1;i<${#global_info_arr[@]};i++)) do\n  if [ \"$leader_ip_port\" == \"${global_info_arr[i]}\" ];then\n    echo \"do not transfer to leader, leader:${global_info_arr[i]}\"\n  else\n    # get currently leader weight\n    leader_weight_info=`mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag 2>/dev/null -e \"select ELECTION_WEIGHT from information_schema.wesql_cluster_global where IP_PORT='$leader_ip_port' limit 1;\"`\n    leader_weight_arr=($leader_weight_info)\n    leader_weight=${leader_weight_arr[1]}\n    echo \"leader_weight=$leader_weight\"\n\n    # get current follower weight\n    current_follower_weight_info=`mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag 2>/dev/null -e \"select ELECTION_WEIGHT from information_schema.wesql_cluster_global where IP_PORT='${global_info_arr[i]}' limit 1;\"`\n    current_follower_weight_arr=($current_follower_weight_info)\n    current_follower_weight=${current_follower_weight_arr[1]}\n    echo \"current_follower_weight=$current_follower_weight\"\n    if [ $current_follower_weight -lt $leader_weight ];then\n       echo \"leader weight larger than follower weight, update leader weight to current follower weight! leader:$leader_ip_port, leader weight:$leader_weight, follower:${global_info_arr[i]}, follower weight:$current_follower_weight\"\n       mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag -e \"call dbms_consensus.configure_follower('$leader_ip_port', $current_follower_weight, 0);\" 2>&1\n    fi\n    mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag -e \"call dbms_consensus.change_leader('${global_info_arr[i]}');\" 2>&1\n    sleep 5\n    role_info=`mysql -h$KB_CONSENSUS_LEADER_POD_FQDN -uroot $password_flag 2>/dev/null -e \"select ROLE from information_schema.wesql_cluster_local;\"`\n    role_info_arr=($role_info)\n    real_role=${role_info_arr[1]}\n    if [ \"$real_role\" == \"Follower\" ];then\n      echo \"transfer successfully\"\n      new_leader_host_and_port=${global_info_arr[i]}\n      new_leader_host=${new_leader_host_and_port%%:*}\n      echo \"new_leader_host=$new_leader_host\"\n      break\n    fi\n  fi\n  ((try_times--))\n  if [ $try_times -le 0 ];then\n    break\n  fi\ndone",
+                "vtconsensus.sh": "#!/bin/bash\n. /scripts/set_config_variables.sh\nset_config_variables vtconsensus\n\necho \"starting vtconsensus\"\ncell=${CELL:-'zone1'}\n\nvtconsensusport=${VTCONSENSUS_PORT:-'16000'}\ntopology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}\n\nVTDATAROOT=$VTDATAROOT/vtconsensus\nsu vitess <<EOF\nmkdir -p $VTDATAROOT\nexec vtconsensus \\\n  $topology_fags \\\n  --alsologtostderr \\\n  --refresh_interval $refresh_interval \\\n  --scan_repair_timeout $scan_repair_timeout \\\n  $(if [ \"$enable_logs\" == \"true\" ]; then echo \"--log_dir $VTDATAROOT\"; fi) \\\n  --db_username \"$MYSQL_ROOT_USER\" \\\n  --db_password \"$MYSQL_ROOT_PASSWORD\"\nEOF",
+                "vtctld.sh": "#!/bin/bash\necho \"starting vtctld\"\ncell=${CELL:-'zone1'}\ngrpc_port=${VTCTLD_GRPC_PORT:-'15999'}\nvtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}\ntopology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}\n\nVTDATAROOT=$VTDATAROOT/vtctld\nsu vitess <<EOF\nmkdir -p $VTDATAROOT\nexec vtctld \\\n$topology_fags \\\n--alsologtostderr \\\n--cell $cell \\\n--service_map 'grpc-vtctl,grpc-vtctld' \\\n--backup_storage_implementation file \\\n--file_backup_storage_root $VTDATAROOT/backups \\\n--log_dir $VTDATAROOT \\\n--port $vtctld_web_port \\\n--grpc_port $grpc_port \\\n--pid_file $VTDATAROOT/vtctld.pid\nEOF",
+                "vtgate.sh": "#!/bin/bash\n. /scripts/set_config_variables.sh\nset_config_variables vtgate\n\ncell=${CELL:-'zone1'}\nweb_port=${VTGATE_WEB_PORT:-'15001'}\ngrpc_port=${VTGATE_GRPC_PORT:-'15991'}\nmysql_server_port=${VTGATE_MYSQL_PORT:-'15306'}\nmysql_server_socket_path=\"/tmp/mysql.sock\"\n\necho \"starting vtgate.\"\nsu vitess <<EOF\nexec vtgate \\\n  $TOPOLOGY_FLAGS \\\n  --alsologtostderr \\\n  --gateway_initial_tablet_timeout $gateway_initial_tablet_timeout \\\n  --healthcheck_timeout $healthcheck_timeout \\\n  --srv_topo_timeout $srv_topo_timeout \\\n  --grpc_keepalive_time $grpc_keepalive_time \\\n  --grpc_keepalive_timeout $grpc_keepalive_timeout \\\n  $(if [ \"$enable_logs\" == \"true\" ]; then echo \"--log_dir $VTDATAROOT\"; fi) \\\n  $(if [ \"$enable_query_log\" == \"true\" ]; then echo \"--log_queries_to_file $VTDATAROOT/vtgate_querylog.txt\"; fi) \\\n  --port $web_port \\\n  --grpc_port $grpc_port \\\n  --mysql_server_port $mysql_server_port \\\n  --mysql_server_socket_path $mysql_server_socket_path \\\n  --cell $cell \\\n  --cells_to_watch $cell \\\n  --tablet_types_to_wait PRIMARY,REPLICA \\\n  --tablet_refresh_interval $tablet_refresh_interval \\\n  --service_map 'grpc-vtgateservice' \\\n  --pid_file $VTDATAROOT/vtgate.pid \\\n  --read_write_splitting_policy $read_write_splitting_policy  \\\n  --read_write_splitting_ratio $read_write_splitting_ratio  \\\n  --read_after_write_consistency $read_after_write_consistency \\\n  --read_after_write_timeout $read_after_write_timeout \\\n  --enable_buffer=$enable_buffer \\\n  --buffer_size $buffer_size \\\n  --buffer_window $buffer_window \\\n  --buffer_max_failover_duration $buffer_max_failover_duration \\\n  --buffer_min_time_between_failovers $buffer_min_time_between_failovers \\\n  $(if [ \"$mysql_server_require_secure_transport\" == \"true\" ]; then echo \"--mysql_server_require_secure_transport\"; fi) \\\n  $(if [ -n \"$mysql_server_ssl_cert\" ]; then echo \"--mysql_server_ssl_cert $mysql_server_ssl_cert\"; fi) \\\n  $(if [ -n \"$mysql_server_ssl_key\" ]; then echo \"--mysql_server_ssl_key $mysql_server_ssl_key\"; fi) \\\n  $(if [ -n \"$mysql_auth_server_static_file\" ]; then echo \"--mysql_auth_server_static_file $mysql_auth_server_static_file\"; fi) \\\n--mysql_auth_server_impl $mysql_auth_server_impl\nEOF",
+                "vttablet.sh": "#!/bin/bash\nwhile [ \"$KB_PROXY_ENABLED\" != \"on\" ]\ndo\n  sleep 60\ndone\n\n. /scripts/set_config_variables.sh\nset_config_variables vttablet\n\ncell=${CELL:-'zone1'}\nuid=\"${KB_POD_NAME##*-}\"\nmysql_root=${MYSQL_ROOT_USER:-'root'}\nmysql_root_passwd=${MYSQL_ROOT_PASSWORD:-'123456'}\nmysql_port=${MYSQL_PORT:-'3306'}\nport=${VTTABLET_PORT:-'15100'}\ngrpc_port=${VTTABLET_GRPC_PORT:-'16100'}\nvtctld_host=${VTCTLD_HOST:-'127.0.0.1'}\nvtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}\nprintf -v alias '%s-%010d' $cell $uid\nprintf -v tablet_dir 'vt_%010d' $uid\ntablet_hostname=$(eval echo \\$KB_\"$uid\"_HOSTNAME)\nprintf -v tablet_logfile 'vttablet_%010d_querylog.txt' $uid\n\ntablet_type=replica\ntopology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}\n\n/scripts/wait-for-service.sh vtctld $vtctld_host $vtctld_web_port\n\necho \"starting vttablet for $alias...\"\n\nVTDATAROOT=$VTDATAROOT/vttablet\nsu vitess <<EOF\nmkdir -p $VTDATAROOT\nexec vttablet \\\n$topology_fags \\\n--alsologtostderr \\\n$(if [ \"$enable_logs\" == \"true\" ]; then echo \"--log_dir $VTDATAROOT\"; fi) \\\n$(if [ \"$enable_query_log\" == \"true\" ]; then echo \"--log_queries_to_file $VTDATAROOT/$tablet_logfile\"; fi) \\\n--tablet-path $alias \\\n--tablet_hostname \"$tablet_hostname\" \\\n--init_tablet_type $tablet_type \\\n--health_check_interval $health_check_interval \\\n--shard_sync_retry_delay $shard_sync_retry_delay \\\n--remote_operation_timeout $remote_operation_timeout \\\n--db_connect_timeout_ms $db_connect_timeout_ms \\\n--enable_replication_reporter \\\n--backup_storage_implementation file \\\n--file_backup_storage_root $VTDATAROOT/backups \\\n--port $port \\\n--db_port $mysql_port \\\n--db_host $tablet_hostname \\\n--db_allprivs_user $mysql_root \\\n--db_allprivs_password $mysql_root_passwd \\\n--db_dba_user $mysql_root \\\n--db_dba_password $mysql_root_passwd \\\n--db_app_user $mysql_root \\\n--db_app_password $mysql_root_passwd \\\n--db_filtered_user $mysql_root \\\n--db_filtered_password $mysql_root_passwd \\\n--grpc_port $grpc_port \\\n--service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \\\n--pid_file $VTDATAROOT/vttablet.pid \\\n--vtctld_addr http://$vtctld_host:$vtctld_web_port/ \\\n--table-acl-config-mode=$table_acl_config_mode \\\n--disable_active_reparents \\\n$(if [ -n \"$table_acl_config\" ]; then echo \"--table-acl-config $table_acl_config\"; fi) \\\n$(if [ \"$queryserver_config_strict_table_acl\" == \"true\" ]; then echo \"--queryserver-config-strict-table-acl\"; fi) \\\n$(if [ \"$enforce_tableacl_config\" == \"true\" ]; then echo \"--enforce-tableacl-config\"; fi) \\\n--table-acl-config-reload-interval $table_acl_config_reload_interval\nEOF",
+                "wait-for-service.sh": "#!/bin/sh\necho \"wait for $1\"\nwhile ! nc -z $2 $3\ndo sleep 1\nprintf \"-\"\ndone\necho -e \"  >> $1 has started\""
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "config.kubeblocks.io/disable-reconfigure": "false",
+                    "config.kubeblocks.io/reconfigure-source": "manager"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "config.kubeblocks.io/config-type": "instance",
+                    "config.kubeblocks.io/template-name": "apecloud-mysql-scripts"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:agamotto.sh": {},
+                                "f:etcd-post-start.sh": {},
+                                "f:etcd.sh": {},
+                                "f:pre-stop.sh": {},
+                                "f:set_config_variables.sh": {},
+                                "f:setup.sh": {},
+                                "f:switchover-with-candidate.sh": {},
+                                "f:switchover-without-candidate.sh": {},
+                                "f:vtconsensus.sh": {},
+                                "f:vtctld.sh": {},
+                                "f:vtgate.sh": {},
+                                "f:vttablet.sh": {},
+                                "f:wait-for-service.sh": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:config.kubeblocks.io/disable-reconfigure": {},
+                                    "f:config.kubeblocks.io/reconfigure-source": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:config.kubeblocks.io/config-type": {},
+                                    "f:config.kubeblocks.io/template-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"626a1ffa-6ffe-48af-bfdc-815dbfe92773\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-apecloud-mysql-scripts",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": null,
+                        "controller": null,
+                        "kind": "Cluster",
+                        "name": "mycluster",
+                        "uid": "626a1ffa-6ffe-48af-bfdc-815dbfe92773"
+                    }
+                ],
+                "resource_version": "13168",
+                "self_link": null,
+                "uid": "0a7e5e7c-3bc8-4bce-8dbf-d26d2470ab7b"
+            }
+        },
+        "mycluster-mysql-env": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "KB_CLUSTER_COMP_NAME": "mycluster-mysql",
+                "KB_CLUSTER_NAME": "mycluster",
+                "KB_CLUSTER_UID": "626a1ffa-6ffe-48af-bfdc-815dbfe92773",
+                "KB_CLUSTER_UID_POSTFIX_8": "bfe92773",
+                "KB_COMP_NAME": "mysql",
+                "KB_COMP_REPLICAS": "1",
+                "KB_NAMESPACE": "default"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:KB_CLUSTER_COMP_NAME": {},
+                                "f:KB_CLUSTER_NAME": {},
+                                "f:KB_CLUSTER_UID": {},
+                                "f:KB_CLUSTER_UID_POSTFIX_8": {},
+                                "f:KB_COMP_NAME": {},
+                                "f:KB_COMP_REPLICAS": {},
+                                "f:KB_NAMESPACE": {}
+                            },
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-env",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13179",
+                "self_link": null,
+                "uid": "99a46402-287f-44a3-b053-e026785bf094"
+            }
+        },
+        "mycluster-mysql-haconfig": {
+            "api_version": null,
+            "binary_data": null,
+            "data": null,
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "MaxLagOnSwitchover": "10",
+                    "enable": "true",
+                    "ttl": "15"
+                },
+                "creation_timestamp": "2024-02-06T05:51:31+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:MaxLagOnSwitchover": {},
+                                    "f:enable": {},
+                                    "f:ttl": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"626a1ffa-6ffe-48af-bfdc-815dbfe92773\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "lorry",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:51:31+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-haconfig",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": null,
+                        "controller": null,
+                        "kind": "Cluster",
+                        "name": "mycluster",
+                        "uid": "626a1ffa-6ffe-48af-bfdc-815dbfe92773"
+                    }
+                ],
+                "resource_version": "14134",
+                "self_link": null,
+                "uid": "61914bf3-fa72-4cef-90da-26d01fce6d5c"
+            }
+        },
+        "mycluster-mysql-leader": {
+            "api_version": null,
+            "binary_data": null,
+            "data": null,
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "acquire-time": "1707198691",
+                    "dbstate": "{\"OpTimestamp\":1707201452,\"Extra\":{\"Binlog_File\":\"mysql-bin.000001\",\"Binlog_Pos\":\"\",\"gtid_executed\":\"3c9058f6-c4b3-11ee-894a-42213704aeef:1-831\",\"gtid_purged\":\"\",\"hostname\":\"mycluster-mysql-0\",\"read_only\":\"0\",\"server_uuid\":\"3c9058f6-c4b3-11ee-894a-42213704aeef\",\"super_read_only\":\"0\"}}",
+                    "extra": "",
+                    "leader": "mycluster-mysql-0",
+                    "renew-time": "1707201462",
+                    "ttl": "15"
+                },
+                "creation_timestamp": "2024-02-06T05:51:31+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:acquire-time": {},
+                                    "f:dbstate": {},
+                                    "f:extra": {},
+                                    "f:leader": {},
+                                    "f:renew-time": {},
+                                    "f:ttl": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"626a1ffa-6ffe-48af-bfdc-815dbfe92773\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "lorry",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T06:37:42+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-leader",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": null,
+                        "controller": null,
+                        "kind": "Cluster",
+                        "name": "mycluster",
+                        "uid": "626a1ffa-6ffe-48af-bfdc-815dbfe92773"
+                    }
+                ],
+                "resource_version": "22158",
+                "self_link": null,
+                "uid": "135259e6-2899-4d9c-869e-6d26e5f37643"
+            }
+        },
+        "mycluster-mysql-mysql-consensusset-config": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "my.cnf": "[mysqld]\n# aliyun buffer pool: https://help.aliyun.com/document_detail/162326.html?utm_content=g_1000230851&spm=5176.20966629.toubu.3.f2991ddcpxxvD1#title-rey-j7j-4dt\ninnodb_buffer_pool_size=128M\n\n# require port\n# Global_Buffer = innodb_buffer_pool_size = PhysicalMemory *3/4\n# max_connections = (PhysicalMemory  - Global_Buffer) / single_thread_memory\nmax_connections=83\n\n# if memory less than 8Gi, disable performance_schema\nperformance_schema=OFF\n\n# alias replica_exec_mode. Aliyun slave_exec_mode=STRICT\nslave_exec_mode=IDEMPOTENT\n\n# gtid\ngtid_mode=ON\nenforce_gtid_consistency=ON\n\n# consensus\nloose_consensus_enabled=ON\nloose_consensus_io_thread_cnt=8\nloose_consensus_worker_thread_cnt=8\nloose_consensus_election_timeout=1000\nloose_consensus_auto_leader_transfer=OFF\nloose_consensus_prefetch_window_size=100\nloose_consensus_auto_reset_match_index=ON\nloose_cluster_mts_recover_use_index=ON\n# loose_replicate_same_server_id=ON\nloose_consensus_large_trx=ON\nloose_consensuslog_revise=ON\n# loose_cluster_log_type_node=OFF\n\n#server & instances\nthread_stack=262144\nthread_cache_size=60\n# ulimit -n\nopen_files_limit=1048576\nlocal_infile=ON\npersisted_globals_load=OFF\nsql_mode=NO_ENGINE_SUBSTITUTION\n#Default 4000\ntable_open_cache=4000\n\n# under high number thread (such as 128 threads), this value will cause sysbench fails\n# if so, change it to 100000 or higher.\nmax_prepared_stmt_count=16382\n\nperformance_schema_digests_size=10000\nperformance_schema_events_stages_history_long_size=10000\nperformance_schema_events_transactions_history_long_size=10000\nread_buffer_size=262144\nread_rnd_buffer_size=524288\njoin_buffer_size=262144\nsort_buffer_size=262144\n\n#default_authentication_plugin=mysql_native_password    #From mysql8.0.23 is deprecated.\nauthentication_policy=mysql_native_password,\nback_log=5285\nhost_cache_size=867\nconnect_timeout=10\n\n# character-sets-dir=/usr/share/mysql-8.0/charsets\n\nport=3306\nmysqlx-port=33060\nmysqlx=0\n\ndatadir=/data/mysql/data\n\n\nlog_statements_unsafe_for_binlog=OFF\nlog_error_verbosity=2\nlog_output=FILE\nlog_error=/data/mysql/log/mysqld-error.log\nslow_query_log=ON\nlong_query_time=5\nslow_query_log_file=/data/mysql/log/mysqld-slowquery.log\n\n\n#innodb\ninnodb_doublewrite_batch_size=16\ninnodb_doublewrite_pages=32\ninnodb_flush_method=O_DIRECT\ninnodb_io_capacity=200\ninnodb_io_capacity_max=2000\ninnodb_log_buffer_size=8388608\n#innodb_log_file_size and innodb_log_files_in_group are deprecated in MySQL 8.0.30. These variables are superseded by innodb_redo_log_capacity.\n#innodb_log_file_size=134217728\n#innodb_log_files_in_group=2\ninnodb_redo_log_capacity=104857600\ninnodb_open_files=4000\ninnodb_purge_threads=1\ninnodb_read_io_threads=4\n# innodb_print_all_deadlocks=ON    # AWS not set\nkey_buffer_size=16777216\n\n# binlog\n# master_info_repository=TABLE\n# From mysql8.0.23 is deprecated.\nbinlog_cache_size=32768\n# AWS binlog_format=MIXED, Aliyun is ROW\nbinlog_format=MIXED\nbinlog_row_image=FULL\n# Aliyun AWS binlog_order_commits=ON\nbinlog_order_commits=ON\nlog-bin=/data/mysql/binlog/mysql-bin\nlog_bin_index=/data/mysql/binlog/mysql-bin.index\nbinlog_expire_logs_seconds=604800\nbinlog_purge_size=102400M\nmax_binlog_size=134217728\nlog_replica_updates=1\n# binlog_rows_query_log_events=ON #AWS not set\n# binlog_transaction_dependency_tracking=WRITESET    #Default Commit Order, Aws not set\n\n# replay log\n# relay_log_info_repository=TABLE\n# From mysql8.0.23 is deprecated.\nrelay_log_recovery=ON\nrelay_log=relay-bin\nrelay_log_index=relay-bin.index\n\npid-file=/var/run/mysqld/mysqld.pid\nsocket=/var/run/mysqld/mysqld.sock\n\n## smartengine base config\n#default_storage_engine=smartengine\ndefault_tmp_storage_engine=innodb\nloose_smartengine=0\n\n# log_error_verbosity=3\n# binlog_format=ROW\n\n## non classes config\n\nloose_smartengine_datadir=/data/mysql/smartengine\nloose_smartengine_wal_dir=/data/mysql/smartengine\nloose_smartengine_flush_log_at_trx_commit=1\nloose_smartengine_enable_2pc=1\nloose_smartengine_batch_group_slot_array_size=5\nloose_smartengine_batch_group_max_group_size=15\nloose_smartengine_batch_group_max_leader_wait_time_us=50\nloose_smartengine_block_size=16384\nloose_smartengine_disable_auto_compactions=0\nloose_smartengine_dump_memtable_limit_size=0\n\nloose_smartengine_min_write_buffer_number_to_merge=1\nloose_smartengine_level0_file_num_compaction_trigger=64\nloose_smartengine_level0_layer_num_compaction_trigger=2\nloose_smartengine_level1_extents_major_compaction_trigger=1000\nloose_smartengine_level2_usage_percent=70\nloose_smartengine_flush_delete_percent=70\nloose_smartengine_compaction_delete_percent=50\nloose_smartengine_flush_delete_percent_trigger=700000\nloose_smartengine_flush_delete_record_trigger=700000\nloose_smartengine_scan_add_blocks_limit=100\n\nloose_smartengine_compression_per_level=kZSTD:kZSTD:kZSTD\n\n\n## classes classes config\nloose_smartengine_write_buffer_size=33554432\nloose_smartengine_db_write_buffer_size=160432128\nloose_smartengine_db_total_write_buffer_size=160432128\nloose_smartengine_block_cache_size=160432128\nloose_smartengine_row_cache_size=53477376\nloose_smartengine_max_total_wal_size=160432128\nloose_smartengine_max_background_flushes=1\nloose_smartengine_base_background_compactions=1\nloose_smartengine_max_background_compactions=1\n\nskip_name_resolve=ON\n\n\n[client]\nport=3306\nsocket=/var/run/mysqld/mysqld.sock"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "config.kubeblocks.io/config-applied-version": "{\"name\":\"mysql-consensusset-config\",\"payload\":null,\"configSpec\":{\"name\":\"mysql-consensusset-config\",\"templateRef\":\"mysql8.0-config-template\",\"namespace\":\"kb-system\",\"volumeName\":\"mysql-config\",\"constraintRef\":\"mysql8.0-config-constraints\"},\"importTemplateRef\":null}",
+                    "config.kubeblocks.io/config-template-version": "",
+                    "config.kubeblocks.io/configuration-revision": "1",
+                    "config.kubeblocks.io/disable-reconfigure": "false",
+                    "config.kubeblocks.io/last-applied-configuration": "{\"my.cnf\":\"[mysqld]\\n# aliyun buffer pool: https://help.aliyun.com/document_detail/162326.html?utm_content=g_1000230851\\u0026spm=5176.20966629.toubu.3.f2991ddcpxxvD1#title-rey-j7j-4dt\\ninnodb_buffer_pool_size=128M\\n\\n# require port\\n# Global_Buffer = innodb_buffer_pool_size = PhysicalMemory *3/4\\n# max_connections = (PhysicalMemory  - Global_Buffer) / single_thread_memory\\nmax_connections=83\\n\\n# if memory less than 8Gi, disable performance_schema\\nperformance_schema=OFF\\n\\n# alias replica_exec_mode. Aliyun slave_exec_mode=STRICT\\nslave_exec_mode=IDEMPOTENT\\n\\n# gtid\\ngtid_mode=ON\\nenforce_gtid_consistency=ON\\n\\n# consensus\\nloose_consensus_enabled=ON\\nloose_consensus_io_thread_cnt=8\\nloose_consensus_worker_thread_cnt=8\\nloose_consensus_election_timeout=1000\\nloose_consensus_auto_leader_transfer=OFF\\nloose_consensus_prefetch_window_size=100\\nloose_consensus_auto_reset_match_index=ON\\nloose_cluster_mts_recover_use_index=ON\\n# loose_replicate_same_server_id=ON\\nloose_consensus_large_trx=ON\\nloose_consensuslog_revise=ON\\n# loose_cluster_log_type_node=OFF\\n\\n#server \\u0026 instances\\nthread_stack=262144\\nthread_cache_size=60\\n# ulimit -n\\nopen_files_limit=1048576\\nlocal_infile=ON\\npersisted_globals_load=OFF\\nsql_mode=NO_ENGINE_SUBSTITUTION\\n#Default 4000\\ntable_open_cache=4000\\n\\n# under high number thread (such as 128 threads), this value will cause sysbench fails\\n# if so, change it to 100000 or higher.\\nmax_prepared_stmt_count=16382\\n\\nperformance_schema_digests_size=10000\\nperformance_schema_events_stages_history_long_size=10000\\nperformance_schema_events_transactions_history_long_size=10000\\nread_buffer_size=262144\\nread_rnd_buffer_size=524288\\njoin_buffer_size=262144\\nsort_buffer_size=262144\\n\\n#default_authentication_plugin=mysql_native_password    #From mysql8.0.23 is deprecated.\\nauthentication_policy=mysql_native_password,\\nback_log=5285\\nhost_cache_size=867\\nconnect_timeout=10\\n\\n# character-sets-dir=/usr/share/mysql-8.0/charsets\\n\\nport=3306\\nmysqlx-port=33060\\nmysqlx=0\\n\\ndatadir=/data/mysql/data\\n\\n\\nlog_statements_unsafe_for_binlog=OFF\\nlog_error_verbosity=2\\nlog_output=FILE\\nlog_error=/data/mysql/log/mysqld-error.log\\nslow_query_log=ON\\nlong_query_time=5\\nslow_query_log_file=/data/mysql/log/mysqld-slowquery.log\\n\\n\\n#innodb\\ninnodb_doublewrite_batch_size=16\\ninnodb_doublewrite_pages=32\\ninnodb_flush_method=O_DIRECT\\ninnodb_io_capacity=200\\ninnodb_io_capacity_max=2000\\ninnodb_log_buffer_size=8388608\\n#innodb_log_file_size and innodb_log_files_in_group are deprecated in MySQL 8.0.30. These variables are superseded by innodb_redo_log_capacity.\\n#innodb_log_file_size=134217728\\n#innodb_log_files_in_group=2\\ninnodb_redo_log_capacity=104857600\\ninnodb_open_files=4000\\ninnodb_purge_threads=1\\ninnodb_read_io_threads=4\\n# innodb_print_all_deadlocks=ON    # AWS not set\\nkey_buffer_size=16777216\\n\\n# binlog\\n# master_info_repository=TABLE\\n# From mysql8.0.23 is deprecated.\\nbinlog_cache_size=32768\\n# AWS binlog_format=MIXED, Aliyun is ROW\\nbinlog_format=MIXED\\nbinlog_row_image=FULL\\n# Aliyun AWS binlog_order_commits=ON\\nbinlog_order_commits=ON\\nlog-bin=/data/mysql/binlog/mysql-bin\\nlog_bin_index=/data/mysql/binlog/mysql-bin.index\\nbinlog_expire_logs_seconds=604800\\nbinlog_purge_size=102400M\\nmax_binlog_size=134217728\\nlog_replica_updates=1\\n# binlog_rows_query_log_events=ON #AWS not set\\n# binlog_transaction_dependency_tracking=WRITESET    #Default Commit Order, Aws not set\\n\\n# replay log\\n# relay_log_info_repository=TABLE\\n# From mysql8.0.23 is deprecated.\\nrelay_log_recovery=ON\\nrelay_log=relay-bin\\nrelay_log_index=relay-bin.index\\n\\npid-file=/var/run/mysqld/mysqld.pid\\nsocket=/var/run/mysqld/mysqld.sock\\n\\n## smartengine base config\\n#default_storage_engine=smartengine\\ndefault_tmp_storage_engine=innodb\\nloose_smartengine=0\\n\\n# log_error_verbosity=3\\n# binlog_format=ROW\\n\\n## non classes config\\n\\nloose_smartengine_datadir=/data/mysql/smartengine\\nloose_smartengine_wal_dir=/data/mysql/smartengine\\nloose_smartengine_flush_log_at_trx_commit=1\\nloose_smartengine_enable_2pc=1\\nloose_smartengine_batch_group_slot_array_size=5\\nloose_smartengine_batch_group_max_group_size=15\\nloose_smartengine_batch_group_max_leader_wait_time_us=50\\nloose_smartengine_block_size=16384\\nloose_smartengine_disable_auto_compactions=0\\nloose_smartengine_dump_memtable_limit_size=0\\n\\nloose_smartengine_min_write_buffer_number_to_merge=1\\nloose_smartengine_level0_file_num_compaction_trigger=64\\nloose_smartengine_level0_layer_num_compaction_trigger=2\\nloose_smartengine_level1_extents_major_compaction_trigger=1000\\nloose_smartengine_level2_usage_percent=70\\nloose_smartengine_flush_delete_percent=70\\nloose_smartengine_compaction_delete_percent=50\\nloose_smartengine_flush_delete_percent_trigger=700000\\nloose_smartengine_flush_delete_record_trigger=700000\\nloose_smartengine_scan_add_blocks_limit=100\\n\\nloose_smartengine_compression_per_level=kZSTD:kZSTD:kZSTD\\n\\n\\n## classes classes config\\nloose_smartengine_write_buffer_size=33554432\\nloose_smartengine_db_write_buffer_size=160432128\\nloose_smartengine_db_total_write_buffer_size=160432128\\nloose_smartengine_block_cache_size=160432128\\nloose_smartengine_row_cache_size=53477376\\nloose_smartengine_max_total_wal_size=160432128\\nloose_smartengine_max_background_flushes=1\\nloose_smartengine_base_background_compactions=1\\nloose_smartengine_max_background_compactions=1\\n\\nskip_name_resolve=ON\\n\\n\\n[client]\\nport=3306\\nsocket=/var/run/mysqld/mysqld.sock\"}",
+                    "config.kubeblocks.io/reconfigure-source": "manager",
+                    "config.kubeblocks.io/revision-reconcile-phase-1": "{\"phase\":\"Finished\",\"revision\":\"1\",\"policy\":\"\",\"execResult\":\"\",\"succeedCount\":0,\"expectedCount\":-1,\"retry\":false,\"failed\":false,\"message\":\"phase: created\"}",
+                    "config.kubeblocks.io/update-config-hash": "5cd6ffc9b9"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "config.kubeblocks.io/config-constraints-name": "mysql8.0-config-constraints",
+                    "config.kubeblocks.io/config-hash": "5cd6ffc9b9",
+                    "config.kubeblocks.io/config-spec": "mysql-consensusset-config",
+                    "config.kubeblocks.io/config-template-name": "mysql8.0-config-template",
+                    "config.kubeblocks.io/config-type": "instance",
+                    "config.kubeblocks.io/last-applied-reconfigure-phase": "created",
+                    "config.kubeblocks.io/template-name": "mysql8.0-config-template"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:my.cnf": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:config.kubeblocks.io/config-applied-version": {},
+                                    "f:config.kubeblocks.io/config-template-version": {},
+                                    "f:config.kubeblocks.io/configuration-revision": {},
+                                    "f:config.kubeblocks.io/disable-reconfigure": {},
+                                    "f:config.kubeblocks.io/last-applied-configuration": {},
+                                    "f:config.kubeblocks.io/reconfigure-source": {},
+                                    "f:config.kubeblocks.io/revision-reconcile-phase-1": {},
+                                    "f:config.kubeblocks.io/update-config-hash": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:config.kubeblocks.io/config-constraints-name": {},
+                                    "f:config.kubeblocks.io/config-hash": {},
+                                    "f:config.kubeblocks.io/config-spec": {},
+                                    "f:config.kubeblocks.io/config-template-name": {},
+                                    "f:config.kubeblocks.io/config-type": {},
+                                    "f:config.kubeblocks.io/last-applied-reconfigure-phase": {},
+                                    "f:config.kubeblocks.io/template-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"51757a9b-30e6-431e-85f8-8eb2431384ee\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-mysql-consensusset-config",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Configuration",
+                        "name": "mycluster-mysql",
+                        "uid": "51757a9b-30e6-431e-85f8-8eb2431384ee"
+                    }
+                ],
+                "resource_version": "13172",
+                "self_link": null,
+                "uid": "98de348d-7e65-41f0-8d9b-25c0a1d647c9"
+            }
+        },
+        "mycluster-mysql-rsm-env": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "KB_0_HOSTNAME": "mycluster-mysql-0.mycluster-mysql-headless",
+                "KB_CLUSTER_UID": "000d0562-3128-4586-9cdc-2478ff147a51",
+                "KB_LEADER": "mycluster-mysql-0",
+                "KB_MYSQL_0_HOSTNAME": "mycluster-mysql-0.mycluster-mysql-headless",
+                "KB_MYSQL_CLUSTER_UID": "000d0562-3128-4586-9cdc-2478ff147a51",
+                "KB_MYSQL_LEADER": "mycluster-mysql-0",
+                "KB_MYSQL_N": "1",
+                "KB_REPLICA_COUNT": "1",
+                "KB_RSM_0_HOSTNAME": "mycluster-mysql-0.mycluster-mysql-headless",
+                "KB_RSM_LEADER": "mycluster-mysql-0",
+                "KB_RSM_N": "1",
+                "KB_RSM_OWNER_UID": "000d0562-3128-4586-9cdc-2478ff147a51",
+                "KB_RSM_OWNER_UID_SUFFIX8": "7a51",
+                "LORRY_HTTP_PORT": "3501"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "apps.kubeblocks.io/config-type": "kubeblocks-env"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:KB_0_HOSTNAME": {},
+                                "f:KB_CLUSTER_UID": {},
+                                "f:KB_LEADER": {},
+                                "f:KB_MYSQL_0_HOSTNAME": {},
+                                "f:KB_MYSQL_CLUSTER_UID": {},
+                                "f:KB_MYSQL_LEADER": {},
+                                "f:KB_MYSQL_N": {},
+                                "f:KB_REPLICA_COUNT": {},
+                                "f:KB_RSM_0_HOSTNAME": {},
+                                "f:KB_RSM_LEADER": {},
+                                "f:KB_RSM_N": {},
+                                "f:KB_RSM_OWNER_UID": {},
+                                "f:KB_RSM_OWNER_UID_SUFFIX8": {},
+                                "f:LORRY_HTTP_PORT": {}
+                            },
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:apps.kubeblocks.io/config-type": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"000d0562-3128-4586-9cdc-2478ff147a51\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:51:24+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-rsm-env",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "workloads.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicatedStateMachine",
+                        "name": "mycluster-mysql",
+                        "uid": "000d0562-3128-4586-9cdc-2478ff147a51"
+                    }
+                ],
+                "resource_version": "14106",
+                "self_link": null,
+                "uid": "3dc85633-c0d2-432d-bc65-41b83fcbb60b"
+            }
+        },
+        "mycluster-mysql-vttablet-config": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "vttablet.cnf": "[vttablet]\nhealth_check_interval=1s\nshard_sync_retry_delay=1s\nremote_operation_timeout=1s\ndb_connect_timeout_ms=500\ntable_acl_config_mode=simple\nenable_logs=true\nenable_query_log=true\ntable_acl_config=\nqueryserver_config_strict_table_acl=false\ntable_acl_config_reload_interval=30s\nenforce_tableacl_config=false\n\n# OltpReadPool\nqueryserver_config_pool_size=30\n\n# OlapReadPool\nqueryserver_config_stream_pool_size=30\n\n# TxPool\nqueryserver_config_transaction_cap=50"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "config.kubeblocks.io/config-applied-version": "{\"name\":\"vttablet-config\",\"payload\":null,\"configSpec\":{\"name\":\"vttablet-config\",\"templateRef\":\"vttablet-config-template\",\"namespace\":\"kb-system\",\"volumeName\":\"mysql-scale-config\",\"constraintRef\":\"mysql-scale-vttablet-config-constraints\"},\"importTemplateRef\":null}",
+                    "config.kubeblocks.io/config-template-version": "",
+                    "config.kubeblocks.io/configuration-revision": "1",
+                    "config.kubeblocks.io/disable-reconfigure": "false",
+                    "config.kubeblocks.io/last-applied-configuration": "{\"vttablet.cnf\":\"[vttablet]\\nhealth_check_interval=1s\\nshard_sync_retry_delay=1s\\nremote_operation_timeout=1s\\ndb_connect_timeout_ms=500\\ntable_acl_config_mode=simple\\nenable_logs=true\\nenable_query_log=true\\ntable_acl_config=\\nqueryserver_config_strict_table_acl=false\\ntable_acl_config_reload_interval=30s\\nenforce_tableacl_config=false\\n\\n# OltpReadPool\\nqueryserver_config_pool_size=30\\n\\n# OlapReadPool\\nqueryserver_config_stream_pool_size=30\\n\\n# TxPool\\nqueryserver_config_transaction_cap=50\"}",
+                    "config.kubeblocks.io/reconfigure-source": "manager",
+                    "config.kubeblocks.io/revision-reconcile-phase-1": "{\"phase\":\"Finished\",\"revision\":\"1\",\"policy\":\"\",\"execResult\":\"\",\"succeedCount\":0,\"expectedCount\":-1,\"retry\":false,\"failed\":false,\"message\":\"phase: created\"}",
+                    "config.kubeblocks.io/update-config-hash": "5fc598c9df"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "config.kubeblocks.io/config-constraints-name": "mysql-scale-vttablet-config-constraints",
+                    "config.kubeblocks.io/config-hash": "5fc598c9df",
+                    "config.kubeblocks.io/config-spec": "vttablet-config",
+                    "config.kubeblocks.io/config-template-name": "vttablet-config-template",
+                    "config.kubeblocks.io/config-type": "instance",
+                    "config.kubeblocks.io/last-applied-reconfigure-phase": "created",
+                    "config.kubeblocks.io/template-name": "vttablet-config-template"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:vttablet.cnf": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:config.kubeblocks.io/config-applied-version": {},
+                                    "f:config.kubeblocks.io/config-template-version": {},
+                                    "f:config.kubeblocks.io/configuration-revision": {},
+                                    "f:config.kubeblocks.io/disable-reconfigure": {},
+                                    "f:config.kubeblocks.io/last-applied-configuration": {},
+                                    "f:config.kubeblocks.io/reconfigure-source": {},
+                                    "f:config.kubeblocks.io/revision-reconcile-phase-1": {},
+                                    "f:config.kubeblocks.io/update-config-hash": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:config.kubeblocks.io/config-constraints-name": {},
+                                    "f:config.kubeblocks.io/config-hash": {},
+                                    "f:config.kubeblocks.io/config-spec": {},
+                                    "f:config.kubeblocks.io/config-template-name": {},
+                                    "f:config.kubeblocks.io/config-type": {},
+                                    "f:config.kubeblocks.io/last-applied-reconfigure-phase": {},
+                                    "f:config.kubeblocks.io/template-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"51757a9b-30e6-431e-85f8-8eb2431384ee\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-vttablet-config",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Configuration",
+                        "name": "mycluster-mysql",
+                        "uid": "51757a9b-30e6-431e-85f8-8eb2431384ee"
+                    }
+                ],
+                "resource_version": "13183",
+                "self_link": null,
+                "uid": "4d975f8b-da53-40da-88a6-fa1ce3ee352a"
+            }
+        },
+        "sidecar-mycluster-mysql-config-manager-config": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "config-manager.yaml": "- configSpec:\n    constraintRef: mysql8.0-config-constraints\n    name: mysql-consensusset-config\n    namespace: kb-system\n    templateRef: mysql8.0-config-template\n    volumeName: mysql-config\n  downwardAPIOptions: null\n  formatterConfig:\n    format: ini\n    iniConfig:\n      sectionName: mysqld\n  mountPoint: /opt/mysql\n  reloadType: tpl\n  tplConfig: /opt/kb-tools/reload/mysql-consensusset-config/reload.yaml\n  tplScriptTrigger:\n    namespace: kb-system\n    scriptConfigMapRef: mysql-reload-script\n    sync: true\n- configSpec:\n    constraintRef: mysql-scale-vttablet-config-constraints\n    name: vttablet-config\n    namespace: kb-system\n    templateRef: vttablet-config-template\n    volumeName: mysql-scale-config\n  downwardAPIOptions: null\n  formatterConfig:\n    format: ini\n    iniConfig:\n      sectionName: vttablet\n  mountPoint: /conf\n  reloadType: signal\n  tplConfig: \"\"\n  tplScriptTrigger: null\n  unixSignalTrigger:\n    processName: vttablet\n    signal: SIGHUP\n"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:config-manager.yaml": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"626a1ffa-6ffe-48af-bfdc-815dbfe92773\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "sidecar-mycluster-mysql-config-manager-config",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": null,
+                        "controller": null,
+                        "kind": "Cluster",
+                        "name": "mycluster",
+                        "uid": "626a1ffa-6ffe-48af-bfdc-815dbfe92773"
+                    }
+                ],
+                "resource_version": "13167",
+                "self_link": null,
+                "uid": "ea6e1961-d8d3-4577-9918-beed2ef117fe"
+            }
+        },
+        "sidecar-mysql-reload-script-mycluster": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "reload.tpl": "{{- /* mysql global variable update */}}\n{{- /* mysql using system variables reference docs: https://dev.mysql.com/doc/refman/8.0/en/using-system-variables.html */}}\n{{- /*  1. system variable names must be written using underscores, not dashes. */}}\n{{- /*  2. string variable 'xxx' */}}\n{{- /*  3. type convert to number */}}\n{{- range $pk, $pv := $.arg0 }}\n\t{{- $pk = trimPrefix \"loose_\" $pk }}\n\t{{- $pk = replace \"-\" \"_\" $pk }}\n\t{{- $var_int := -1 }}\n    {{- if $pv | regexMatch \"^\\\\d+$\" }}\n\t\t{{- $var_int = atoi $pv }}\n\t{{- end}}\n\t{{- if lt $var_int 0 }}\n\t\t{{- $tmp := $pv | regexStringSubmatch \"^(\\\\d+)K$\" }}\n\t\t{{- if $tmp }}\n\t\t{{- $var_int = last $tmp | atoi | mul 1024 }}\n\t\t{{- end }}\n\t{{- end }}\n\t{{- if lt $var_int 0 }}\n\t\t{{- $tmp := $pv | regexStringSubmatch \"^(\\\\d+)M$\" }}\n\t\t{{- if $tmp }}\n\t\t{{- $var_int =  last $tmp | atoi | mul 1024 1024 }}\n\t\t{{- end }}\n\t{{- end }}\n\t{{- if lt $var_int 0 }}\n\t\t{{- $tmp := $pv | regexStringSubmatch \"^(\\\\d+)G$\" }}\n\t\t{{- if $tmp }}\n\t\t{{- $var_int = last $tmp | atoi | mul 1024 1024 1024 }}\n\t\t{{- end }}\n\t{{- end }}\n\t{{- if ge $var_int 0 }}\n\t\t{{- execSql ( printf \"SET GLOBAL %s = %d\" $pk $var_int ) }}\n\t{{- else }}\n\t\t{{- execSql ( printf \"SET GLOBAL %s = '%s'\" $pk $pv ) }}\n\t{{- end }}\n{{- end }}",
+                "reload.yaml": "fileRegex: my.cnf\nformatterConfig:\n  format: ini\n  iniConfig:\n    sectionName: mysqld\nscripts: reload.tpl\n"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "kb-addon-apecloud-mysql",
+                    "app.kubernetes.io/managed-by": "Helm",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "app.kubernetes.io/version": "8.0.30",
+                    "helm.sh/chart": "apecloud-mysql-0.8.0-beta.5"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:reload.tpl": {},
+                                "f:reload.yaml": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:helm.sh/chart": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"626a1ffa-6ffe-48af-bfdc-815dbfe92773\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "sidecar-mysql-reload-script-mycluster",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": null,
+                        "controller": null,
+                        "kind": "Cluster",
+                        "name": "mycluster",
+                        "uid": "626a1ffa-6ffe-48af-bfdc-815dbfe92773"
+                    }
+                ],
+                "resource_version": "13166",
+                "self_link": null,
+                "uid": "f3d9ca02-e2ab-4591-8d11-e25241824c03"
             }
         }
     },
     "cron_job": {},
     "daemon_set": {},
     "deployment": {},
-    "endpoint": {},
+    "endpoint": {
+        "kubernetes": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "endpointslice.kubernetes.io/skip-mirror": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:endpointslice.kubernetes.io/skip-mirror": {}
+                                }
+                            },
+                            "f:subsets": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "kubernetes",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "196",
+                "self_link": null,
+                "uid": "de4222c2-a4e5-4280-8fcb-559d455aa92b"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": null,
+                            "ip": "172.18.0.2",
+                            "node_name": null,
+                            "target_ref": null
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": [
+                        {
+                            "app_protocol": null,
+                            "name": "https",
+                            "port": 6443,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
+        },
+        "mycluster-mysql": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2024-02-06T05:51:24Z"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:endpoints.kubernetes.io/last-change-trigger-time": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                }
+                            },
+                            "f:subsets": {}
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:51:24+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "14102",
+                "self_link": null,
+                "uid": "56c7a220-4f2b-42b8-b872-3a8c02a041f1"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": null,
+                            "ip": "10.244.3.8",
+                            "node_name": "kind-worker2",
+                            "target_ref": {
+                                "api_version": null,
+                                "field_path": null,
+                                "kind": "Pod",
+                                "name": "mycluster-mysql-0",
+                                "namespace": "default",
+                                "resource_version": null,
+                                "uid": "244f7a20-e661-4d7c-9126-34ac2042f004"
+                            }
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": [
+                        {
+                            "app_protocol": null,
+                            "name": "mysql",
+                            "port": 3306,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
+        },
+        "mycluster-mysql-headless": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2024-02-06T05:51:24Z"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "service.kubernetes.io/headless": ""
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:endpoints.kubernetes.io/last-change-trigger-time": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:service.kubernetes.io/headless": {}
+                                }
+                            },
+                            "f:subsets": {}
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:51:24+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-headless",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "14097",
+                "self_link": null,
+                "uid": "61ad382a-5f34-4c71-a4f9-1fc6f90953db"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": "mycluster-mysql-0",
+                            "ip": "10.244.3.8",
+                            "node_name": "kind-worker2",
+                            "target_ref": {
+                                "api_version": null,
+                                "field_path": null,
+                                "kind": "Pod",
+                                "name": "mycluster-mysql-0",
+                                "namespace": "default",
+                                "resource_version": null,
+                                "uid": "244f7a20-e661-4d7c-9126-34ac2042f004"
+                            }
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": [
+                        {
+                            "app_protocol": null,
+                            "name": "paxos",
+                            "port": 13306,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "vttabletgrpc",
+                            "port": 16100,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "lorry-grpc-port",
+                            "port": 50001,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "vttabletport",
+                            "port": 15100,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "mysql",
+                            "port": 3306,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "http-metrics",
+                            "port": 9104,
+                            "protocol": "TCP"
+                        },
+                        {
+                            "app_protocol": null,
+                            "name": "lorry-http-port",
+                            "port": 3501,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
     "ingress": {},
     "job": {},
     "network_policy": {},
-    "persistent_volume_claim": {},
+    "persistent_volume_claim": {
+        "data-mycluster-mysql-0": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "pv.kubernetes.io/bind-completed": "yes",
+                    "pv.kubernetes.io/bound-by-controller": "yes",
+                    "volume.beta.kubernetes.io/storage-provisioner": "rancher.io/local-path",
+                    "volume.kubernetes.io/selected-node": "kind-worker2",
+                    "volume.kubernetes.io/storage-provisioner": "rancher.io/local-path"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "kubernetes.io/pvc-protection"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "apps.kubeblocks.io/vct-name": "data",
+                    "kubeblocks.io/volume-type": "data"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:volume.kubernetes.io/selected-node": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-scheduler",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:pv.kubernetes.io/bind-completed": {},
+                                    "f:pv.kubernetes.io/bound-by-controller": {},
+                                    "f:volume.beta.kubernetes.io/storage-provisioner": {},
+                                    "f:volume.kubernetes.io/storage-provisioner": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:apps.kubeblocks.io/vct-name": {},
+                                    "f:kubeblocks.io/volume-type": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:accessModes": {},
+                                "f:resources": {
+                                    "f:requests": {
+                                        ".": {},
+                                        "f:storage": {}
+                                    }
+                                },
+                                "f:volumeMode": {},
+                                "f:volumeName": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:32+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:accessModes": {},
+                                "f:capacity": {
+                                    ".": {},
+                                    "f:storage": {}
+                                },
+                                "f:phase": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-06T05:46:32+00:00"
+                    }
+                ],
+                "name": "data-mycluster-mysql-0",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "13246",
+                "self_link": null,
+                "uid": "edeac3ec-49fe-48d7-b87e-411e8f786207"
+            },
+            "spec": {
+                "access_modes": [
+                    "ReadWriteOnce"
+                ],
+                "data_source": null,
+                "data_source_ref": null,
+                "resources": {
+                    "claims": null,
+                    "limits": null,
+                    "requests": {
+                        "storage": "20Gi"
+                    }
+                },
+                "selector": null,
+                "storage_class_name": "standard",
+                "volume_mode": "Filesystem",
+                "volume_name": "pvc-edeac3ec-49fe-48d7-b87e-411e8f786207"
+            },
+            "status": {
+                "access_modes": [
+                    "ReadWriteOnce"
+                ],
+                "allocated_resources": null,
+                "capacity": {
+                    "storage": "20Gi"
+                },
+                "conditions": null,
+                "phase": "Bound",
+                "resize_status": null
+            }
+        }
+    },
     "persistent_volume": {
         "pvc-edeac3ec-49fe-48d7-b87e-411e8f786207": {
             "api_version": null,
@@ -19971,11 +21266,4236 @@
             }
         }
     },
-    "pod": {},
+    "pod": {
+        "mycluster-mysql-0": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "apps.kubeblocks.io/component-replicas": "1",
+                    "apps.kubeblocks.io/last-role-snapshot-version": "2024-02-06T05:51:24.469889Z"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": "mycluster-mysql-",
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "app.kubernetes.io/version": "",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "apps.kubernetes.io/pod-index": "0",
+                    "controller-revision-hash": "mycluster-mysql-5ff7bd466b",
+                    "kubeblocks.io/role": "leader",
+                    "rsm.workloads.kubeblocks.io/access-mode": "ReadWrite",
+                    "statefulset.kubernetes.io/pod-name": "mycluster-mysql-0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:generateName": {},
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:app.kubernetes.io/version": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:apps.kubernetes.io/pod-index": {},
+                                    "f:controller-revision-hash": {},
+                                    "f:statefulset.kubernetes.io/pod-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"3d2e9e7c-b580-4ff5-835c-4aeb37e75d21\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:affinity": {
+                                    ".": {},
+                                    "f:nodeAffinity": {
+                                        ".": {},
+                                        "f:preferredDuringSchedulingIgnoredDuringExecution": {}
+                                    },
+                                    "f:podAntiAffinity": {
+                                        ".": {},
+                                        "f:requiredDuringSchedulingIgnoredDuringExecution": {}
+                                    }
+                                },
+                                "f:containers": {
+                                    "k:{\"name\":\"config-manager\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"CONFIG_MANAGER_POD_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"DATA_SOURCE_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"DB_TYPE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NODENAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_POD_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_UID\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_PASSWORD\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_USER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"TOOLS_PATH\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            }
+                                        },
+                                        "f:envFrom": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsUser": {}
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/conf\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/opt/config-manager\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/opt/kb-tools/reload/mysql-consensusset-config\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/opt/mysql\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"kb-checkrole\"}": {
+                                        ".": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"KB_BUILTIN_HANDLER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_CLUSTER_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_COMP_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_DATA_PATH\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NODENAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_POD_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_UID\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_RSM_ACTION_SVC_LIST\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_RSM_ROLE_PROBE_TIMEOUT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_RSM_ROLE_UPDATE_MECHANISM\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_SERVICE_CHARACTER_TYPE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_SERVICE_PASSWORD\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_SERVICE_PORT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_SERVICE_USER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            }
+                                        },
+                                        "f:envFrom": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":3501,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            },
+                                            "k:{\"containerPort\":50001,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:readinessProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:httpGet": {
+                                                ".": {},
+                                                "f:path": {},
+                                                "f:port": {},
+                                                "f:scheme": {}
+                                            },
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:startupProbe": {
+                                            ".": {},
+                                            "f:failureThreshold": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:tcpSocket": {
+                                                ".": {},
+                                                "f:port": {}
+                                            },
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/data/mysql\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"metrics\"}": {
+                                        ".": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"DB_TYPE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"ENDPOINT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NODENAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_POD_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_UID\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_PASSWORD\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_USER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            }
+                                        },
+                                        "f:envFrom": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":9104,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsNonRoot": {},
+                                            "f:runAsUser": {}
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/data/mysql\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/opt/agamotto\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/scripts\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"mysql\"}": {
+                                        ".": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"CLUSTER_ID\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"CLUSTER_START_INDEX\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_EMBEDDED_WESQL\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NODENAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_POD_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_UID\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_CUSTOM_CONFIG\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"MYSQL_DATABASE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"MYSQL_DYNAMIC_CONFIG\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"MYSQL_PASSWORD\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"MYSQL_ROOT_HOST\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"MYSQL_ROOT_PASSWORD\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_ROOT_USER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_TEMPLATE_CONFIG\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"MYSQL_USER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"REPLICATION_PASSWORD\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"REPLICATION_USER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"SERVICE_PORT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            }
+                                        },
+                                        "f:envFrom": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:lifecycle": {
+                                            ".": {},
+                                            "f:preStop": {
+                                                ".": {},
+                                                "f:exec": {
+                                                    ".": {},
+                                                    "f:command": {}
+                                                }
+                                            }
+                                        },
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":3306,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            },
+                                            "k:{\"containerPort\":13306,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/data/mysql\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/annotations\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/opt/mysql\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/scripts\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"vttablet\"}": {
+                                        ".": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"CELL\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"ETCD_PORT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"ETCD_SERVER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_NODENAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_PODIPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"KB_POD_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_POD_UID\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_ROOT_PASSWORD\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"MYSQL_ROOT_USER\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:secretKeyRef": {}
+                                                }
+                                            },
+                                            "k:{\"name\":\"SERVICE_PORT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"TOPOLOGY_FLAGS\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"VTCTLD_HOST\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"VTCTLD_WEB_PORT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"VTTABLET_GRPC_PORT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            },
+                                            "k:{\"name\":\"VTTABLET_PORT\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            }
+                                        },
+                                        "f:envFrom": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":15100,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            },
+                                            "k:{\"containerPort\":16100,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/conf\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/scripts\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/vtdataroot\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:hostname": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {},
+                                "f:serviceAccount": {},
+                                "f:serviceAccountName": {},
+                                "f:shareProcessNamespace": {},
+                                "f:subdomain": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:tolerations": {},
+                                "f:topologySpreadConstraints": {
+                                    ".": {},
+                                    "k:{\"topologyKey\":\"kubernetes.io/hostname\",\"whenUnsatisfiable\":\"DoNotSchedule\"}": {
+                                        ".": {},
+                                        "f:labelSelector": {},
+                                        "f:maxSkew": {},
+                                        "f:topologyKey": {},
+                                        "f:whenUnsatisfiable": {}
+                                    }
+                                },
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"agamotto-configuration\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"annotations\"}": {
+                                        ".": {},
+                                        "f:downwardAPI": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:items": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"cm-script-mysql-consensusset-config\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"config-manager-config\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"data\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:persistentVolumeClaim": {
+                                            ".": {},
+                                            "f:claimName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"mysql-config\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"mysql-scale-config\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"scripts\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"ContainersReady\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Initialized\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"PodReadyToStartContainers\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:containerStatuses": {},
+                                "f:hostIP": {},
+                                "f:hostIPs": {},
+                                "f:phase": {},
+                                "f:podIP": {},
+                                "f:podIPs": {
+                                    ".": {},
+                                    "k:{\"ip\":\"10.244.3.8\"}": {
+                                        ".": {},
+                                        "f:ip": {}
+                                    }
+                                },
+                                "f:startTime": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-06T05:51:24+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:apps.kubeblocks.io/component-replicas": {},
+                                    "f:apps.kubeblocks.io/last-role-snapshot-version": {}
+                                },
+                                "f:labels": {
+                                    "f:kubeblocks.io/role": {},
+                                    "f:rsm.workloads.kubeblocks.io/access-mode": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:51:24+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-0",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "StatefulSet",
+                        "name": "mycluster-mysql",
+                        "uid": "3d2e9e7c-b580-4ff5-835c-4aeb37e75d21"
+                    }
+                ],
+                "resource_version": "14101",
+                "self_link": null,
+                "uid": "244f7a20-e661-4d7c-9126-34ac2042f004"
+            },
+            "spec": {
+                "active_deadline_seconds": null,
+                "affinity": {
+                    "node_affinity": {
+                        "preferred_during_scheduling_ignored_during_execution": [
+                            {
+                                "preference": {
+                                    "match_expressions": [
+                                        {
+                                            "key": "kb-data",
+                                            "operator": "In",
+                                            "values": [
+                                                "true"
+                                            ]
+                                        }
+                                    ],
+                                    "match_fields": null
+                                },
+                                "weight": 100
+                            }
+                        ],
+                        "required_during_scheduling_ignored_during_execution": null
+                    },
+                    "pod_affinity": null,
+                    "pod_anti_affinity": {
+                        "preferred_during_scheduling_ignored_during_execution": null,
+                        "required_during_scheduling_ignored_during_execution": [
+                            {
+                                "label_selector": {
+                                    "match_expressions": null,
+                                    "match_labels": {
+                                        "app.kubernetes.io/instance": "mycluster",
+                                        "apps.kubeblocks.io/component-name": "mysql"
+                                    }
+                                },
+                                "namespace_selector": null,
+                                "namespaces": null,
+                                "topology_key": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automount_service_account_token": null,
+                "containers": [
+                    {
+                        "args": null,
+                        "command": [
+                            "/scripts/setup.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "KB_POD_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.name"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_UID",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.uid"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_SA_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.serviceAccountName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NODENAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.nodeName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOST_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOSTIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_FQDN",
+                                "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                "value_from": null
+                            },
+                            {
+                                "name": "SERVICE_PORT",
+                                "value": "3306",
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_ROOT_HOST",
+                                "value": "%",
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_ROOT_USER",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "username",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": false
+                                    }
+                                }
+                            },
+                            {
+                                "name": "MYSQL_ROOT_PASSWORD",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "password",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": false
+                                    }
+                                }
+                            },
+                            {
+                                "name": "MYSQL_DATABASE",
+                                "value": "mydb",
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_USER",
+                                "value": "u1",
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_PASSWORD",
+                                "value": "u1",
+                                "value_from": null
+                            },
+                            {
+                                "name": "CLUSTER_ID",
+                                "value": "1",
+                                "value_from": null
+                            },
+                            {
+                                "name": "CLUSTER_START_INDEX",
+                                "value": "1",
+                                "value_from": null
+                            },
+                            {
+                                "name": "REPLICATION_USER",
+                                "value": "replicator",
+                                "value_from": null
+                            },
+                            {
+                                "name": "REPLICATION_PASSWORD",
+                                "value": null,
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_TEMPLATE_CONFIG",
+                                "value": null,
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_CUSTOM_CONFIG",
+                                "value": null,
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_DYNAMIC_CONFIG",
+                                "value": null,
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_EMBEDDED_WESQL",
+                                "value": "1",
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": [
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            },
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-rsm-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            }
+                        ],
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-server:8.0.30-5.beta3.20231215.ge77d836.13",
+                        "image_pull_policy": "IfNotPresent",
+                        "lifecycle": {
+                            "post_start": null,
+                            "pre_stop": {
+                                "_exec": {
+                                    "command": [
+                                        "/scripts/pre-stop.sh"
+                                    ]
+                                },
+                                "http_get": null,
+                                "tcp_socket": null
+                            }
+                        },
+                        "liveness_probe": null,
+                        "name": "mysql",
+                        "ports": [
+                            {
+                                "container_port": 3306,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "mysql",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "container_port": 13306,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "paxos",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": null,
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "500m",
+                                "memory": "512Mi"
+                            },
+                            "requests": {
+                                "cpu": "500m",
+                                "memory": "512Mi"
+                            }
+                        },
+                        "security_context": null,
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/data/mysql",
+                                "mount_propagation": null,
+                                "name": "data",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/opt/mysql",
+                                "mount_propagation": null,
+                                "name": "mysql-config",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/scripts",
+                                "mount_propagation": null,
+                                "name": "scripts",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/etc/annotations",
+                                "mount_propagation": null,
+                                "name": "annotations",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-t5mf4",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    },
+                    {
+                        "args": null,
+                        "command": [
+                            "/scripts/agamotto.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "KB_POD_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.name"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_UID",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.uid"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_SA_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.serviceAccountName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NODENAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.nodeName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOST_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOSTIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_FQDN",
+                                "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                "value_from": null
+                            },
+                            {
+                                "name": "DB_TYPE",
+                                "value": "MySQL",
+                                "value_from": null
+                            },
+                            {
+                                "name": "ENDPOINT",
+                                "value": "localhost:3306",
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_USER",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "username",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": false
+                                    }
+                                }
+                            },
+                            {
+                                "name": "MYSQL_PASSWORD",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "password",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": false
+                                    }
+                                }
+                            }
+                        ],
+                        "env_from": [
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            },
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-rsm-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            }
+                        ],
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto:0.1.2-beta.1",
+                        "image_pull_policy": "IfNotPresent",
+                        "lifecycle": null,
+                        "liveness_probe": null,
+                        "name": "metrics",
+                        "ports": [
+                            {
+                                "container_port": 9104,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "http-metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": null,
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "0",
+                                "memory": "0"
+                            },
+                            "requests": {
+                                "cpu": "0",
+                                "memory": "0"
+                            }
+                        },
+                        "security_context": {
+                            "allow_privilege_escalation": null,
+                            "capabilities": null,
+                            "privileged": null,
+                            "proc_mount": null,
+                            "read_only_root_filesystem": null,
+                            "run_as_group": null,
+                            "run_as_non_root": false,
+                            "run_as_user": 0,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "windows_options": null
+                        },
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/opt/agamotto",
+                                "mount_propagation": null,
+                                "name": "agamotto-configuration",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/data/mysql",
+                                "mount_propagation": null,
+                                "name": "data",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/scripts",
+                                "mount_propagation": null,
+                                "name": "scripts",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-t5mf4",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    },
+                    {
+                        "args": null,
+                        "command": [
+                            "/scripts/vttablet.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "KB_POD_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.name"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_UID",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.uid"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_SA_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.serviceAccountName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NODENAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.nodeName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOST_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOSTIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_FQDN",
+                                "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                "value_from": null
+                            },
+                            {
+                                "name": "CELL",
+                                "value": "zone1",
+                                "value_from": null
+                            },
+                            {
+                                "name": "ETCD_SERVER",
+                                "value": "$(KB_CLUSTER_NAME)-vtcontroller-headless",
+                                "value_from": null
+                            },
+                            {
+                                "name": "ETCD_PORT",
+                                "value": "2379",
+                                "value_from": null
+                            },
+                            {
+                                "name": "TOPOLOGY_FLAGS",
+                                "value": "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global",
+                                "value_from": null
+                            },
+                            {
+                                "name": "VTTABLET_PORT",
+                                "value": "15100",
+                                "value_from": null
+                            },
+                            {
+                                "name": "VTTABLET_GRPC_PORT",
+                                "value": "16100",
+                                "value_from": null
+                            },
+                            {
+                                "name": "VTCTLD_HOST",
+                                "value": "$(KB_CLUSTER_NAME)-vtcontroller-headless",
+                                "value_from": null
+                            },
+                            {
+                                "name": "VTCTLD_WEB_PORT",
+                                "value": "15000",
+                                "value_from": null
+                            },
+                            {
+                                "name": "SERVICE_PORT",
+                                "value": "$(VTTABLET_PORT)",
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_ROOT_USER",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "username",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": false
+                                    }
+                                }
+                            },
+                            {
+                                "name": "MYSQL_ROOT_PASSWORD",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "password",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": false
+                                    }
+                                }
+                            }
+                        ],
+                        "env_from": [
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            },
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-rsm-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            }
+                        ],
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-scale:0.2.3",
+                        "image_pull_policy": "IfNotPresent",
+                        "lifecycle": null,
+                        "liveness_probe": null,
+                        "name": "vttablet",
+                        "ports": [
+                            {
+                                "container_port": 15100,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "vttabletport",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "container_port": 16100,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "vttabletgrpc",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": null,
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "0",
+                                "memory": "0"
+                            },
+                            "requests": {
+                                "cpu": "0",
+                                "memory": "0"
+                            }
+                        },
+                        "security_context": null,
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/scripts",
+                                "mount_propagation": null,
+                                "name": "scripts",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/conf",
+                                "mount_propagation": null,
+                                "name": "mysql-scale-config",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/vtdataroot",
+                                "mount_propagation": null,
+                                "name": "data",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-t5mf4",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    },
+                    {
+                        "args": null,
+                        "command": [
+                            "lorry",
+                            "--port",
+                            "3501",
+                            "--grpcport",
+                            "50001"
+                        ],
+                        "env": [
+                            {
+                                "name": "KB_POD_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.name"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_UID",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.uid"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_SA_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.serviceAccountName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NODENAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.nodeName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOST_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOSTIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_FQDN",
+                                "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_SERVICE_PORT",
+                                "value": "3306",
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_DATA_PATH",
+                                "value": "/data/mysql",
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_BUILTIN_HANDLER",
+                                "value": "wesql",
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_SERVICE_USER",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "username",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": null
+                                    }
+                                }
+                            },
+                            {
+                                "name": "KB_SERVICE_PASSWORD",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "password",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": null
+                                    }
+                                }
+                            },
+                            {
+                                "name": "KB_RSM_ACTION_SVC_LIST",
+                                "value": "null",
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_RSM_ROLE_UPDATE_MECHANISM",
+                                "value": "DirectAPIServerEventUpdate",
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_RSM_ROLE_PROBE_TIMEOUT",
+                                "value": "1",
+                                "value_from": null
+                            },
+                            {
+                                "name": "KB_CLUSTER_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.labels['app.kubernetes.io/instance']"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_COMP_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.labels['apps.kubeblocks.io/component-name']"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_SERVICE_CHARACTER_TYPE",
+                                "value": "wesql",
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": [
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            },
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-rsm-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            }
+                        ],
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1",
+                        "image_pull_policy": "IfNotPresent",
+                        "lifecycle": null,
+                        "liveness_probe": null,
+                        "name": "kb-checkrole",
+                        "ports": [
+                            {
+                                "container_port": 3501,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "lorry-http-port",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "container_port": 50001,
+                                "host_ip": null,
+                                "host_port": null,
+                                "name": "lorry-grpc-port",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readiness_probe": {
+                            "_exec": null,
+                            "failure_threshold": 2,
+                            "grpc": null,
+                            "http_get": {
+                                "host": null,
+                                "http_headers": null,
+                                "path": "/v1.0/checkrole",
+                                "port": 3501,
+                                "scheme": "HTTP"
+                            },
+                            "initial_delay_seconds": null,
+                            "period_seconds": 1,
+                            "success_threshold": 1,
+                            "tcp_socket": null,
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "0",
+                                "memory": "0"
+                            },
+                            "requests": {
+                                "cpu": "0",
+                                "memory": "0"
+                            }
+                        },
+                        "security_context": null,
+                        "startup_probe": {
+                            "_exec": null,
+                            "failure_threshold": 3,
+                            "grpc": null,
+                            "http_get": null,
+                            "initial_delay_seconds": null,
+                            "period_seconds": 10,
+                            "success_threshold": 1,
+                            "tcp_socket": {
+                                "host": null,
+                                "port": 3501
+                            },
+                            "termination_grace_period_seconds": null,
+                            "timeout_seconds": 1
+                        },
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/data/mysql",
+                                "mount_propagation": null,
+                                "name": "data",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-t5mf4",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    },
+                    {
+                        "args": [
+                            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(TOOLS_PATH)",
+                            "/bin/reloader",
+                            "--log-level",
+                            "info",
+                            "--volume-dir",
+                            "/conf",
+                            "--operator-update-enable",
+                            "--tcp",
+                            "9901",
+                            "--config",
+                            "/opt/config-manager/config-manager.yaml"
+                        ],
+                        "command": [
+                            "env"
+                        ],
+                        "env": [
+                            {
+                                "name": "KB_POD_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.name"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_UID",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.uid"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NAMESPACE",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.namespace"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_SA_NAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.serviceAccountName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_NODENAME",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "spec.nodeName"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOST_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_IPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_HOSTIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.hostIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_PODIPS",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIPs"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "KB_POD_FQDN",
+                                "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                "value_from": null
+                            },
+                            {
+                                "name": "CONFIG_MANAGER_POD_IP",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "status.podIP"
+                                    },
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": null
+                                }
+                            },
+                            {
+                                "name": "DB_TYPE",
+                                "value": "mysql",
+                                "value_from": null
+                            },
+                            {
+                                "name": "MYSQL_USER",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "username",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": null
+                                    }
+                                }
+                            },
+                            {
+                                "name": "MYSQL_PASSWORD",
+                                "value": null,
+                                "value_from": {
+                                    "config_map_key_ref": null,
+                                    "field_ref": null,
+                                    "resource_field_ref": null,
+                                    "secret_key_ref": {
+                                        "key": "password",
+                                        "name": "mycluster-conn-credential",
+                                        "optional": null
+                                    }
+                                }
+                            },
+                            {
+                                "name": "DATA_SOURCE_NAME",
+                                "value": "$(MYSQL_USER):$(MYSQL_PASSWORD)@(localhost:3306)/",
+                                "value_from": null
+                            },
+                            {
+                                "name": "TOOLS_PATH",
+                                "value": "/opt/kb-tools/reload/mysql-consensusset-config:/opt/config-manager",
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": [
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            },
+                            {
+                                "config_map_ref": {
+                                    "name": "mycluster-mysql-rsm-env",
+                                    "optional": false
+                                },
+                                "prefix": null,
+                                "secret_ref": null
+                            }
+                        ],
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1",
+                        "image_pull_policy": "IfNotPresent",
+                        "lifecycle": null,
+                        "liveness_probe": null,
+                        "name": "config-manager",
+                        "ports": null,
+                        "readiness_probe": null,
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "0",
+                                "memory": "0"
+                            },
+                            "requests": {
+                                "cpu": "0",
+                                "memory": "0"
+                            }
+                        },
+                        "security_context": {
+                            "allow_privilege_escalation": null,
+                            "capabilities": null,
+                            "privileged": null,
+                            "proc_mount": null,
+                            "read_only_root_filesystem": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": 0,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "windows_options": null
+                        },
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/opt/mysql",
+                                "mount_propagation": null,
+                                "name": "mysql-config",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/conf",
+                                "mount_propagation": null,
+                                "name": "mysql-scale-config",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/opt/kb-tools/reload/mysql-consensusset-config",
+                                "mount_propagation": null,
+                                "name": "cm-script-mysql-consensusset-config",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/opt/config-manager",
+                                "mount_propagation": null,
+                                "name": "config-manager-config",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-t5mf4",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    }
+                ],
+                "dns_config": null,
+                "dns_policy": "ClusterFirst",
+                "enable_service_links": true,
+                "ephemeral_containers": null,
+                "host_aliases": null,
+                "host_ipc": null,
+                "host_network": null,
+                "host_pid": null,
+                "host_users": null,
+                "hostname": "mycluster-mysql-0",
+                "image_pull_secrets": null,
+                "init_containers": null,
+                "node_name": "kind-worker2",
+                "node_selector": null,
+                "os": null,
+                "overhead": null,
+                "preemption_policy": "PreemptLowerPriority",
+                "priority": 0,
+                "priority_class_name": null,
+                "readiness_gates": null,
+                "resource_claims": null,
+                "restart_policy": "Always",
+                "runtime_class_name": null,
+                "scheduler_name": "default-scheduler",
+                "scheduling_gates": null,
+                "security_context": {
+                    "fs_group": null,
+                    "fs_group_change_policy": null,
+                    "run_as_group": null,
+                    "run_as_non_root": null,
+                    "run_as_user": null,
+                    "se_linux_options": null,
+                    "seccomp_profile": null,
+                    "supplemental_groups": null,
+                    "sysctls": null,
+                    "windows_options": null
+                },
+                "service_account": "kb-mycluster",
+                "service_account_name": "kb-mycluster",
+                "set_hostname_as_fqdn": null,
+                "share_process_namespace": true,
+                "subdomain": "mycluster-mysql-headless",
+                "termination_grace_period_seconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "kb-data",
+                        "operator": "Equal",
+                        "toleration_seconds": null,
+                        "value": "true"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    }
+                ],
+                "topology_spread_constraints": [
+                    {
+                        "label_selector": {
+                            "match_expressions": null,
+                            "match_labels": {
+                                "app.kubernetes.io/instance": "mycluster",
+                                "apps.kubeblocks.io/component-name": "mysql"
+                            }
+                        },
+                        "match_label_keys": null,
+                        "max_skew": 1,
+                        "min_domains": null,
+                        "node_affinity_policy": null,
+                        "node_taints_policy": null,
+                        "topology_key": "kubernetes.io/hostname",
+                        "when_unsatisfiable": "DoNotSchedule"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "data",
+                        "nfs": null,
+                        "persistent_volume_claim": {
+                            "claim_name": "data-mycluster-mysql-0",
+                            "read_only": null
+                        },
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": {
+                            "default_mode": 420,
+                            "items": [
+                                {
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.annotations['cs.apps.kubeblocks.io/leader']"
+                                    },
+                                    "mode": null,
+                                    "path": "leader",
+                                    "resource_field_ref": null
+                                },
+                                {
+                                    "field_ref": {
+                                        "api_version": "v1",
+                                        "field_path": "metadata.annotations['apps.kubeblocks.io/component-replicas']"
+                                    },
+                                    "mode": null,
+                                    "path": "component-replicas",
+                                    "resource_field_ref": null
+                                }
+                            ]
+                        },
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "annotations",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": {
+                            "default_mode": 292,
+                            "items": null,
+                            "name": "mycluster-mysql-agamotto-configuration",
+                            "optional": null
+                        },
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "agamotto-configuration",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": {
+                            "default_mode": 365,
+                            "items": null,
+                            "name": "mycluster-mysql-apecloud-mysql-scripts",
+                            "optional": null
+                        },
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "scripts",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": {
+                            "default_mode": 420,
+                            "items": null,
+                            "name": "mycluster-mysql-mysql-consensusset-config",
+                            "optional": null
+                        },
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "mysql-config",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": {
+                            "default_mode": 420,
+                            "items": null,
+                            "name": "mycluster-mysql-vttablet-config",
+                            "optional": null
+                        },
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "mysql-scale-config",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": {
+                            "default_mode": 493,
+                            "items": null,
+                            "name": "sidecar-mysql-reload-script-mycluster",
+                            "optional": null
+                        },
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "cm-script-mysql-consensusset-config",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": {
+                            "default_mode": 493,
+                            "items": null,
+                            "name": "sidecar-mycluster-mysql-config-manager-config",
+                            "optional": null
+                        },
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "config-manager-config",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-t5mf4",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": {
+                            "default_mode": 420,
+                            "sources": [
+                                {
+                                    "config_map": null,
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": {
+                                        "audience": null,
+                                        "expiration_seconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "config_map": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "mode": null,
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt",
+                                        "optional": null
+                                    },
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": null
+                                },
+                                {
+                                    "config_map": null,
+                                    "downward_api": {
+                                        "items": [
+                                            {
+                                                "field_ref": {
+                                                    "api_version": "v1",
+                                                    "field_path": "metadata.namespace"
+                                                },
+                                                "mode": null,
+                                                "path": "namespace",
+                                                "resource_field_ref": null
+                                            }
+                                        ]
+                                    },
+                                    "secret": null,
+                                    "service_account_token": null
+                                }
+                            ]
+                        },
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-06T05:51:23+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-06T05:46:33+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-06T05:51:24+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-06T05:51:24+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-06T05:46:33+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "container_statuses": [
+                    {
+                        "container_id": "containerd://270de614decba515ee8e4a1f7694ba7a44c631eed523aed337c0223aed2a857b",
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1",
+                        "image_id": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools@sha256:36e3a1205a06b6f935d6faa70fdaec91d9c6bc6ee69abeb80d4380cf381f82bd",
+                        "last_state": {
+                            "running": null,
+                            "terminated": null,
+                            "waiting": null
+                        },
+                        "name": "config-manager",
+                        "ready": true,
+                        "restart_count": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-06T05:51:22+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    },
+                    {
+                        "container_id": "containerd://8fc772a4ce2e0af1c6a586735ac54593a04fda89405e652f77bee59644da322f",
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1",
+                        "image_id": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools@sha256:36e3a1205a06b6f935d6faa70fdaec91d9c6bc6ee69abeb80d4380cf381f82bd",
+                        "last_state": {
+                            "running": null,
+                            "terminated": null,
+                            "waiting": null
+                        },
+                        "name": "kb-checkrole",
+                        "ready": true,
+                        "restart_count": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-06T05:51:22+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    },
+                    {
+                        "container_id": "containerd://58631a360bbe055bb7e65ac3fe6f14e1763bbc9381effdf778e818abe27eaf6b",
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto:0.1.2-beta.1",
+                        "image_id": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto@sha256:cbab349b90490807a8d5039bf01bc7e37334f20c98c7dd75bc7fc4cf9e5b10ee",
+                        "last_state": {
+                            "running": null,
+                            "terminated": null,
+                            "waiting": null
+                        },
+                        "name": "metrics",
+                        "ready": true,
+                        "restart_count": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-06T05:48:17+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    },
+                    {
+                        "container_id": "containerd://a54282c96816fce5ff2a0d46462af6a6240ed9876ee26943287c6ded2c64ff87",
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-server:8.0.30-5.beta3.20231215.ge77d836.13",
+                        "image_id": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-server@sha256:1b98d61f6f61e288dca34eb6ad53ecae2c113903e73a7e4ebb955a6ed19b9f33",
+                        "last_state": {
+                            "running": null,
+                            "terminated": null,
+                            "waiting": null
+                        },
+                        "name": "mysql",
+                        "ready": true,
+                        "restart_count": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-06T05:47:36+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    },
+                    {
+                        "container_id": "containerd://7db9d1872107f18885241ee06464b9b48e0b990f6686d606cae5c5b15e620815",
+                        "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-scale:0.2.3",
+                        "image_id": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-scale@sha256:d4ac8323dcaa50e24f07df68017cccdb9511e0deaf642a7f4755b2b4d448df4d",
+                        "last_state": {
+                            "running": null,
+                            "terminated": null,
+                            "waiting": null
+                        },
+                        "name": "vttablet",
+                        "ready": true,
+                        "restart_count": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-06T05:51:22+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    }
+                ],
+                "ephemeral_container_statuses": null,
+                "host_ip": "172.18.0.5",
+                "init_container_statuses": null,
+                "message": null,
+                "nominated_node_name": null,
+                "phase": "Running",
+                "pod_ip": "10.244.3.8",
+                "pod_i_ps": [
+                    {
+                        "ip": "10.244.3.8"
+                    }
+                ],
+                "qos_class": "Burstable",
+                "reason": null,
+                "start_time": "2024-02-06T05:46:33+00:00"
+            }
+        }
+    },
     "replica_set": {},
-    "role_binding": {},
+    "role_binding": {
+        "kb-mycluster": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": ""
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "kb-mycluster",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13186",
+                "self_link": null,
+                "uid": "6474b988-e45b-462c-92a4-fb4f8e1b80ea"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kubeblocks-cluster-pod-role"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kb-mycluster",
+                    "namespace": "default"
+                }
+            ]
+        }
+    },
     "role": {},
-    "secret": {},
+    "secret": {
+        "mycluster-conn-credential": {
+            "api_version": null,
+            "data": {
+                "endpoint": "bXljbHVzdGVyLW15c3FsOjMzMDY=",
+                "host": "bXljbHVzdGVyLW15c3Fs",
+                "password": "ZGdjZHc4a3g=",
+                "port": "MzMwNg==",
+                "username": "cm9vdA=="
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:28+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/cluster-type": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:endpoint": {},
+                                "f:host": {},
+                                "f:password": {},
+                                "f:port": {},
+                                "f:username": {}
+                            },
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/cluster-type": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"626a1ffa-6ffe-48af-bfdc-815dbfe92773\"}": {}
+                                }
+                            },
+                            "f:type": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:28+00:00"
+                    }
+                ],
+                "name": "mycluster-conn-credential",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Cluster",
+                        "name": "mycluster",
+                        "uid": "626a1ffa-6ffe-48af-bfdc-815dbfe92773"
+                    }
+                ],
+                "resource_version": "13146",
+                "self_link": null,
+                "uid": "e6141a88-d9de-44d8-be69-63780cf6b89f"
+            },
+            "string_data": null,
+            "type": "Opaque"
+        },
+        "mycluster-mysql-account-kbadmin": {
+            "api_version": null,
+            "data": {
+                "password": "NTk0UEtHb2s3Mw==",
+                "username": "a2JhZG1pbg=="
+            },
+            "immutable": true,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "account.kubeblocks.io/name": "kbadmin",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:password": {},
+                                "f:username": {}
+                            },
+                            "f:immutable": {},
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:account.kubeblocks.io/name": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            },
+                            "f:type": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-account-kbadmin",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13177",
+                "self_link": null,
+                "uid": "ff3e31f5-d1bf-4368-b63b-bd02c67c17aa"
+            },
+            "string_data": null,
+            "type": "Opaque"
+        },
+        "mycluster-mysql-account-kbdataprotection": {
+            "api_version": null,
+            "data": {
+                "password": "TDRLMDE4aUJTMg==",
+                "username": "a2JkYXRhcHJvdGVjdGlvbg=="
+            },
+            "immutable": true,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "account.kubeblocks.io/name": "kbdataprotection",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:password": {},
+                                "f:username": {}
+                            },
+                            "f:immutable": {},
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:account.kubeblocks.io/name": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            },
+                            "f:type": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-account-kbdataprotection",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13187",
+                "self_link": null,
+                "uid": "74b10932-4641-438f-895b-a204d97d89b8"
+            },
+            "string_data": null,
+            "type": "Opaque"
+        },
+        "mycluster-mysql-account-kbmonitoring": {
+            "api_version": null,
+            "data": {
+                "password": "Mzh2MFUxVmNNNg==",
+                "username": "a2Jtb25pdG9yaW5n"
+            },
+            "immutable": true,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "account.kubeblocks.io/name": "kbmonitoring",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:password": {},
+                                "f:username": {}
+                            },
+                            "f:immutable": {},
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:account.kubeblocks.io/name": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            },
+                            "f:type": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-account-kbmonitoring",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13190",
+                "self_link": null,
+                "uid": "67465b99-4c73-4fdd-8cb4-d6cd42e8fa2e"
+            },
+            "string_data": null,
+            "type": "Opaque"
+        },
+        "mycluster-mysql-account-kbprobe": {
+            "api_version": null,
+            "data": {
+                "password": "WnV3Qjk4TjE2NQ==",
+                "username": "a2Jwcm9iZQ=="
+            },
+            "immutable": true,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "account.kubeblocks.io/name": "kbprobe",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:password": {},
+                                "f:username": {}
+                            },
+                            "f:immutable": {},
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:account.kubeblocks.io/name": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            },
+                            "f:type": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-account-kbprobe",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13178",
+                "self_link": null,
+                "uid": "4524faa4-f9ba-4e72-9797-9f1156632bbf"
+            },
+            "string_data": null,
+            "type": "Opaque"
+        },
+        "mycluster-mysql-account-kbreplicator": {
+            "api_version": null,
+            "data": {
+                "password": "SkUwM2g3NmxDNQ==",
+                "username": "a2JyZXBsaWNhdG9y"
+            },
+            "immutable": true,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "account.kubeblocks.io/name": "kbreplicator",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:password": {},
+                                "f:username": {}
+                            },
+                            "f:immutable": {},
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:account.kubeblocks.io/name": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            },
+                            "f:type": {}
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-account-kbreplicator",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13188",
+                "self_link": null,
+                "uid": "aa0698f5-0e9a-4cc3-89e6-a17f2514f405"
+            },
+            "string_data": null,
+            "type": "Opaque"
+        }
+    },
     "service_account": {
         "default": {
             "api_version": null,
@@ -19984,7 +25504,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-06T05:46:14+00:00",
+                "creation_timestamp": "2024-02-06T04:35:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -19993,17 +25513,3958 @@
                 "labels": null,
                 "managed_fields": null,
                 "name": "default",
-                "namespace": "demo",
+                "namespace": "default",
                 "owner_references": null,
-                "resource_version": "13102",
+                "resource_version": "323",
                 "self_link": null,
-                "uid": "45801b70-6b44-4c36-a1d5-48a52b0b7eea"
+                "uid": "220e1026-d51e-4b15-9eb5-fe99628c7296"
+            },
+            "secrets": null
+        },
+        "kb-mycluster": {
+            "api_version": null,
+            "automount_service_account_token": null,
+            "image_pull_secrets": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": ""
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "kb-mycluster",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13182",
+                "self_link": null,
+                "uid": "e5885905-3379-4e18-b8b6-f6c80339cc5e"
             },
             "secrets": null
         }
     },
-    "service": {},
-    "stateful_set": {},
+    "service": {
+        "kubernetes": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T04:35:33+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "component": "apiserver",
+                    "provider": "kubernetes"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:component": {},
+                                    "f:provider": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:clusterIP": {},
+                                "f:internalTrafficPolicy": {},
+                                "f:ipFamilyPolicy": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"port\":443,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    }
+                                },
+                                "f:sessionAffinity": {},
+                                "f:type": {}
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T04:35:33+00:00"
+                    }
+                ],
+                "name": "kubernetes",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "194",
+                "self_link": null,
+                "uid": "83fd1d06-a23f-4b30-9017-c5d0f868ae19"
+            },
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "10.96.0.1",
+                "cluster_i_ps": [
+                    "10.96.0.1"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": [
+                    {
+                        "app_protocol": null,
+                        "name": "https",
+                        "node_port": null,
+                        "port": 443,
+                        "protocol": "TCP",
+                        "target_port": 6443
+                    }
+                ],
+                "publish_not_ready_addresses": null,
+                "selector": null,
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
+        },
+        "mycluster-mysql": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"d6b01dbd-aa8b-40ec-a611-382260fc2adb\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:internalTrafficPolicy": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"port\":3306,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    }
+                                },
+                                "f:selector": {},
+                                "f:sessionAffinity": {},
+                                "f:type": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "apps.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Component",
+                        "name": "mycluster-mysql",
+                        "uid": "d6b01dbd-aa8b-40ec-a611-382260fc2adb"
+                    }
+                ],
+                "resource_version": "13175",
+                "self_link": null,
+                "uid": "fa6b563b-9759-4d96-957c-e494735606c9"
+            },
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "10.96.101.50",
+                "cluster_i_ps": [
+                    "10.96.101.50"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": [
+                    {
+                        "app_protocol": null,
+                        "name": "mysql",
+                        "node_port": null,
+                        "port": 3306,
+                        "protocol": "TCP",
+                        "target_port": "mysql"
+                    }
+                ],
+                "publish_not_ready_addresses": null,
+                "selector": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "kubeblocks.io/role": "leader"
+                },
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
+        },
+        "mycluster-mysql-headless": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "monitor.kubeblocks.io/agamotto": "false",
+                    "monitor.kubeblocks.io/scrape": "false"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:monitor.kubeblocks.io/agamotto": {},
+                                    "f:monitor.kubeblocks.io/scrape": {}
+                                },
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"000d0562-3128-4586-9cdc-2478ff147a51\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:clusterIP": {},
+                                "f:internalTrafficPolicy": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"port\":3306,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":3501,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":9104,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":13306,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":15100,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":16100,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    },
+                                    "k:{\"port\":50001,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    }
+                                },
+                                "f:selector": {},
+                                "f:sessionAffinity": {},
+                                "f:type": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql-headless",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "workloads.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicatedStateMachine",
+                        "name": "mycluster-mysql",
+                        "uid": "000d0562-3128-4586-9cdc-2478ff147a51"
+                    }
+                ],
+                "resource_version": "13193",
+                "self_link": null,
+                "uid": "b616a865-f4be-421a-a0de-38d08d37bfb4"
+            },
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "None",
+                "cluster_i_ps": [
+                    "None"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": [
+                    {
+                        "app_protocol": null,
+                        "name": "mysql",
+                        "node_port": null,
+                        "port": 3306,
+                        "protocol": "TCP",
+                        "target_port": "mysql"
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "paxos",
+                        "node_port": null,
+                        "port": 13306,
+                        "protocol": "TCP",
+                        "target_port": "paxos"
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "http-metrics",
+                        "node_port": null,
+                        "port": 9104,
+                        "protocol": "TCP",
+                        "target_port": "http-metrics"
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "vttabletport",
+                        "node_port": null,
+                        "port": 15100,
+                        "protocol": "TCP",
+                        "target_port": "vttabletport"
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "vttabletgrpc",
+                        "node_port": null,
+                        "port": 16100,
+                        "protocol": "TCP",
+                        "target_port": "vttabletgrpc"
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "lorry-http-port",
+                        "node_port": null,
+                        "port": 3501,
+                        "protocol": "TCP",
+                        "target_port": "lorry-http-port"
+                    },
+                    {
+                        "app_protocol": null,
+                        "name": "lorry-grpc-port",
+                        "node_port": null,
+                        "port": 50001,
+                        "protocol": "TCP",
+                        "target_port": "lorry-grpc-port"
+                    }
+                ],
+                "publish_not_ready_addresses": null,
+                "selector": {
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "apps.kubeblocks.io/component-name": "mysql"
+                },
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
+        }
+    },
+    "stateful_set": {
+        "mycluster-mysql": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "config.kubeblocks.io/tpl-agamotto-configuration": "mycluster-mysql-agamotto-configuration",
+                    "config.kubeblocks.io/tpl-apecloud-mysql-scripts": "mycluster-mysql-apecloud-mysql-scripts",
+                    "config.kubeblocks.io/tpl-mysql-consensusset-config": "mycluster-mysql-mysql-consensusset-config",
+                    "config.kubeblocks.io/tpl-vttablet-config": "mycluster-mysql-vttablet-config",
+                    "kubeblocks.io/generation": "1"
+                },
+                "creation_timestamp": "2024-02-06T05:46:29+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": [
+                    "cluster.kubeblocks.io/finalizer"
+                ],
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app.kubernetes.io/component": "mysql",
+                    "app.kubernetes.io/instance": "mycluster",
+                    "app.kubernetes.io/managed-by": "kubeblocks",
+                    "app.kubernetes.io/name": "apecloud-mysql",
+                    "apps.kubeblocks.io/component-name": "mysql",
+                    "rsm.workloads.kubeblocks.io/controller-generation": "1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:config.kubeblocks.io/tpl-agamotto-configuration": {},
+                                    "f:config.kubeblocks.io/tpl-apecloud-mysql-scripts": {},
+                                    "f:config.kubeblocks.io/tpl-mysql-consensusset-config": {},
+                                    "f:config.kubeblocks.io/tpl-vttablet-config": {},
+                                    "f:kubeblocks.io/generation": {}
+                                },
+                                "f:finalizers": {
+                                    ".": {},
+                                    "v:\"cluster.kubeblocks.io/finalizer\"": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/instance": {},
+                                    "f:app.kubernetes.io/managed-by": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:apps.kubeblocks.io/component-name": {},
+                                    "f:rsm.workloads.kubeblocks.io/controller-generation": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"000d0562-3128-4586-9cdc-2478ff147a51\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:persistentVolumeClaimRetentionPolicy": {
+                                    ".": {},
+                                    "f:whenDeleted": {},
+                                    "f:whenScaled": {}
+                                },
+                                "f:podManagementPolicy": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {},
+                                "f:serviceName": {},
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/instance": {},
+                                            "f:app.kubernetes.io/managed-by": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:app.kubernetes.io/version": {},
+                                            "f:apps.kubeblocks.io/component-name": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:affinity": {
+                                            ".": {},
+                                            "f:nodeAffinity": {
+                                                ".": {},
+                                                "f:preferredDuringSchedulingIgnoredDuringExecution": {}
+                                            },
+                                            "f:podAntiAffinity": {
+                                                ".": {},
+                                                "f:requiredDuringSchedulingIgnoredDuringExecution": {}
+                                            }
+                                        },
+                                        "f:containers": {
+                                            "k:{\"name\":\"config-manager\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CONFIG_MANAGER_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"DATA_SOURCE_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"DB_TYPE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NODENAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_UID\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_PASSWORD\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_USER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"TOOLS_PATH\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    }
+                                                },
+                                                "f:envFrom": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:runAsUser": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/conf\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/opt/config-manager\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/opt/kb-tools/reload/mysql-consensusset-config\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/opt/mysql\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"kb-checkrole\"}": {
+                                                ".": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"KB_BUILTIN_HANDLER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_CLUSTER_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_COMP_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_DATA_PATH\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NODENAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_UID\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_RSM_ACTION_SVC_LIST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_RSM_ROLE_PROBE_TIMEOUT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_RSM_ROLE_UPDATE_MECHANISM\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_SERVICE_CHARACTER_TYPE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_SERVICE_PASSWORD\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_SERVICE_PORT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_SERVICE_USER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    }
+                                                },
+                                                "f:envFrom": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":3501,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    },
+                                                    "k:{\"containerPort\":50001,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:readinessProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:httpGet": {
+                                                        ".": {},
+                                                        "f:path": {},
+                                                        "f:port": {},
+                                                        "f:scheme": {}
+                                                    },
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:startupProbe": {
+                                                    ".": {},
+                                                    "f:failureThreshold": {},
+                                                    "f:periodSeconds": {},
+                                                    "f:successThreshold": {},
+                                                    "f:tcpSocket": {
+                                                        ".": {},
+                                                        "f:port": {}
+                                                    },
+                                                    "f:timeoutSeconds": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/data/mysql\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"metrics\"}": {
+                                                ".": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"DB_TYPE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"ENDPOINT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NODENAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_UID\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_PASSWORD\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_USER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    }
+                                                },
+                                                "f:envFrom": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":9104,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:securityContext": {
+                                                    ".": {},
+                                                    "f:runAsNonRoot": {},
+                                                    "f:runAsUser": {}
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/data/mysql\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/opt/agamotto\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/scripts\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"mysql\"}": {
+                                                ".": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CLUSTER_ID\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"CLUSTER_START_INDEX\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_EMBEDDED_WESQL\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NODENAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_UID\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_CUSTOM_CONFIG\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_DATABASE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_DYNAMIC_CONFIG\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_PASSWORD\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_ROOT_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_ROOT_PASSWORD\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_ROOT_USER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_TEMPLATE_CONFIG\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_USER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"REPLICATION_PASSWORD\"}": {
+                                                        ".": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"name\":\"REPLICATION_USER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"SERVICE_PORT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    }
+                                                },
+                                                "f:envFrom": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:lifecycle": {
+                                                    ".": {},
+                                                    "f:preStop": {
+                                                        ".": {},
+                                                        "f:exec": {
+                                                            ".": {},
+                                                            "f:command": {}
+                                                        }
+                                                    }
+                                                },
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":3306,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    },
+                                                    "k:{\"containerPort\":13306,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    },
+                                                    "f:requests": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/data/mysql\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/etc/annotations\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/opt/mysql\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/scripts\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            },
+                                            "k:{\"name\":\"vttablet\"}": {
+                                                ".": {},
+                                                "f:command": {},
+                                                "f:env": {
+                                                    ".": {},
+                                                    "k:{\"name\":\"CELL\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"ETCD_PORT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"ETCD_SERVER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_HOSTIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_HOST_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NAMESPACE\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_NODENAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_PODIPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_FQDN\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IP\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_IPS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_POD_UID\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"KB_SA_NAME\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:fieldRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_ROOT_PASSWORD\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"MYSQL_ROOT_USER\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:valueFrom": {
+                                                            ".": {},
+                                                            "f:secretKeyRef": {}
+                                                        }
+                                                    },
+                                                    "k:{\"name\":\"SERVICE_PORT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"TOPOLOGY_FLAGS\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"VTCTLD_HOST\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"VTCTLD_WEB_PORT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"VTTABLET_GRPC_PORT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    },
+                                                    "k:{\"name\":\"VTTABLET_PORT\"}": {
+                                                        ".": {},
+                                                        "f:name": {},
+                                                        "f:value": {}
+                                                    }
+                                                },
+                                                "f:envFrom": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:ports": {
+                                                    ".": {},
+                                                    "k:{\"containerPort\":15100,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    },
+                                                    "k:{\"containerPort\":16100,\"protocol\":\"TCP\"}": {
+                                                        ".": {},
+                                                        "f:containerPort": {},
+                                                        "f:name": {},
+                                                        "f:protocol": {}
+                                                    }
+                                                },
+                                                "f:resources": {
+                                                    ".": {},
+                                                    "f:limits": {
+                                                        ".": {},
+                                                        "f:cpu": {},
+                                                        "f:memory": {}
+                                                    }
+                                                },
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {},
+                                                "f:volumeMounts": {
+                                                    ".": {},
+                                                    "k:{\"mountPath\":\"/conf\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/scripts\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    },
+                                                    "k:{\"mountPath\":\"/vtdataroot\"}": {
+                                                        ".": {},
+                                                        "f:mountPath": {},
+                                                        "f:name": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:shareProcessNamespace": {},
+                                        "f:terminationGracePeriodSeconds": {},
+                                        "f:tolerations": {},
+                                        "f:topologySpreadConstraints": {
+                                            ".": {},
+                                            "k:{\"topologyKey\":\"kubernetes.io/hostname\",\"whenUnsatisfiable\":\"DoNotSchedule\"}": {
+                                                ".": {},
+                                                "f:labelSelector": {},
+                                                "f:maxSkew": {},
+                                                "f:topologyKey": {},
+                                                "f:whenUnsatisfiable": {}
+                                            }
+                                        },
+                                        "f:volumes": {
+                                            ".": {},
+                                            "k:{\"name\":\"agamotto-configuration\"}": {
+                                                ".": {},
+                                                "f:configMap": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:name": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"annotations\"}": {
+                                                ".": {},
+                                                "f:downwardAPI": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:items": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"cm-script-mysql-consensusset-config\"}": {
+                                                ".": {},
+                                                "f:configMap": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:name": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"config-manager-config\"}": {
+                                                ".": {},
+                                                "f:configMap": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:name": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"data\"}": {
+                                                ".": {},
+                                                "f:emptyDir": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"mysql-config\"}": {
+                                                ".": {},
+                                                "f:configMap": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:name": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"mysql-scale-config\"}": {
+                                                ".": {},
+                                                "f:configMap": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:name": {}
+                                                },
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"scripts\"}": {
+                                                ".": {},
+                                                "f:configMap": {
+                                                    ".": {},
+                                                    "f:defaultMode": {},
+                                                    "f:name": {}
+                                                },
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:updateStrategy": {
+                                    "f:type": {}
+                                },
+                                "f:volumeClaimTemplates": {}
+                            }
+                        },
+                        "manager": "manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-06T05:46:29+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:collisionCount": {},
+                                "f:currentReplicas": {},
+                                "f:currentRevision": {},
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updateRevision": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-06T05:51:24+00:00"
+                    }
+                ],
+                "name": "mycluster-mysql",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "workloads.kubeblocks.io/v1alpha1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicatedStateMachine",
+                        "name": "mycluster-mysql",
+                        "uid": "000d0562-3128-4586-9cdc-2478ff147a51"
+                    }
+                ],
+                "resource_version": "14100",
+                "self_link": null,
+                "uid": "3d2e9e7c-b580-4ff5-835c-4aeb37e75d21"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "ordinals": null,
+                "persistent_volume_claim_retention_policy": {
+                    "when_deleted": "Retain",
+                    "when_scaled": "Retain"
+                },
+                "pod_management_policy": "Parallel",
+                "replicas": 1,
+                "revision_history_limit": 10,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app.kubernetes.io/instance": "mycluster",
+                        "app.kubernetes.io/managed-by": "kubeblocks",
+                        "app.kubernetes.io/name": "apecloud-mysql",
+                        "apps.kubeblocks.io/component-name": "mysql"
+                    }
+                },
+                "service_name": "mycluster-mysql-headless",
+                "template": {
+                    "metadata": {
+                        "annotations": null,
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app.kubernetes.io/component": "mysql",
+                            "app.kubernetes.io/instance": "mycluster",
+                            "app.kubernetes.io/managed-by": "kubeblocks",
+                            "app.kubernetes.io/name": "apecloud-mysql",
+                            "app.kubernetes.io/version": "",
+                            "apps.kubeblocks.io/component-name": "mysql"
+                        },
+                        "managed_fields": null,
+                        "name": null,
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": {
+                            "node_affinity": {
+                                "preferred_during_scheduling_ignored_during_execution": [
+                                    {
+                                        "preference": {
+                                            "match_expressions": [
+                                                {
+                                                    "key": "kb-data",
+                                                    "operator": "In",
+                                                    "values": [
+                                                        "true"
+                                                    ]
+                                                }
+                                            ],
+                                            "match_fields": null
+                                        },
+                                        "weight": 100
+                                    }
+                                ],
+                                "required_during_scheduling_ignored_during_execution": null
+                            },
+                            "pod_affinity": null,
+                            "pod_anti_affinity": {
+                                "preferred_during_scheduling_ignored_during_execution": null,
+                                "required_during_scheduling_ignored_during_execution": [
+                                    {
+                                        "label_selector": {
+                                            "match_expressions": null,
+                                            "match_labels": {
+                                                "app.kubernetes.io/instance": "mycluster",
+                                                "apps.kubeblocks.io/component-name": "mysql"
+                                            }
+                                        },
+                                        "namespace_selector": null,
+                                        "namespaces": null,
+                                        "topology_key": "kubernetes.io/hostname"
+                                    }
+                                ]
+                            }
+                        },
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": null,
+                                "command": [
+                                    "/scripts/setup.sh"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KB_POD_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.name"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_UID",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.uid"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_SA_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.serviceAccountName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NODENAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.nodeName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOST_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOSTIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_FQDN",
+                                        "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "SERVICE_PORT",
+                                        "value": "3306",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_ROOT_HOST",
+                                        "value": "%",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_ROOT_USER",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "username",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": false
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "MYSQL_ROOT_PASSWORD",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "password",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": false
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "MYSQL_DATABASE",
+                                        "value": "mydb",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_USER",
+                                        "value": "u1",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_PASSWORD",
+                                        "value": "u1",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "CLUSTER_ID",
+                                        "value": "1",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "CLUSTER_START_INDEX",
+                                        "value": "1",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "REPLICATION_USER",
+                                        "value": "replicator",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "REPLICATION_PASSWORD",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_TEMPLATE_CONFIG",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_CUSTOM_CONFIG",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_DYNAMIC_CONFIG",
+                                        "value": null,
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_EMBEDDED_WESQL",
+                                        "value": "1",
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": [
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    },
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-rsm-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    }
+                                ],
+                                "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-server:8.0.30-5.beta3.20231215.ge77d836.13",
+                                "image_pull_policy": "IfNotPresent",
+                                "lifecycle": {
+                                    "post_start": null,
+                                    "pre_stop": {
+                                        "_exec": {
+                                            "command": [
+                                                "/scripts/pre-stop.sh"
+                                            ]
+                                        },
+                                        "http_get": null,
+                                        "tcp_socket": null
+                                    }
+                                },
+                                "liveness_probe": null,
+                                "name": "mysql",
+                                "ports": [
+                                    {
+                                        "container_port": 3306,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "mysql",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "container_port": 13306,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "paxos",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": null,
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "500m",
+                                        "memory": "512Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "500m",
+                                        "memory": "512Mi"
+                                    }
+                                },
+                                "security_context": null,
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/data/mysql",
+                                        "mount_propagation": null,
+                                        "name": "data",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/opt/mysql",
+                                        "mount_propagation": null,
+                                        "name": "mysql-config",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/scripts",
+                                        "mount_propagation": null,
+                                        "name": "scripts",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/etc/annotations",
+                                        "mount_propagation": null,
+                                        "name": "annotations",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            },
+                            {
+                                "args": null,
+                                "command": [
+                                    "/scripts/agamotto.sh"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KB_POD_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.name"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_UID",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.uid"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_SA_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.serviceAccountName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NODENAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.nodeName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOST_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOSTIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_FQDN",
+                                        "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "DB_TYPE",
+                                        "value": "MySQL",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "ENDPOINT",
+                                        "value": "localhost:3306",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_USER",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "username",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": false
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "MYSQL_PASSWORD",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "password",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": false
+                                            }
+                                        }
+                                    }
+                                ],
+                                "env_from": [
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    },
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-rsm-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    }
+                                ],
+                                "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto:0.1.2-beta.1",
+                                "image_pull_policy": "IfNotPresent",
+                                "lifecycle": null,
+                                "liveness_probe": null,
+                                "name": "metrics",
+                                "ports": [
+                                    {
+                                        "container_port": 9104,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "http-metrics",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": null,
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "0",
+                                        "memory": "0"
+                                    },
+                                    "requests": null
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": null,
+                                    "capabilities": null,
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": null,
+                                    "run_as_group": null,
+                                    "run_as_non_root": false,
+                                    "run_as_user": 0,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": null,
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/opt/agamotto",
+                                        "mount_propagation": null,
+                                        "name": "agamotto-configuration",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/data/mysql",
+                                        "mount_propagation": null,
+                                        "name": "data",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/scripts",
+                                        "mount_propagation": null,
+                                        "name": "scripts",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            },
+                            {
+                                "args": null,
+                                "command": [
+                                    "/scripts/vttablet.sh"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KB_POD_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.name"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_UID",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.uid"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_SA_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.serviceAccountName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NODENAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.nodeName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOST_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOSTIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_FQDN",
+                                        "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "CELL",
+                                        "value": "zone1",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "ETCD_SERVER",
+                                        "value": "$(KB_CLUSTER_NAME)-vtcontroller-headless",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "ETCD_PORT",
+                                        "value": "2379",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "TOPOLOGY_FLAGS",
+                                        "value": "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "VTTABLET_PORT",
+                                        "value": "15100",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "VTTABLET_GRPC_PORT",
+                                        "value": "16100",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "VTCTLD_HOST",
+                                        "value": "$(KB_CLUSTER_NAME)-vtcontroller-headless",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "VTCTLD_WEB_PORT",
+                                        "value": "15000",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "SERVICE_PORT",
+                                        "value": "$(VTTABLET_PORT)",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_ROOT_USER",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "username",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": false
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "MYSQL_ROOT_PASSWORD",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "password",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": false
+                                            }
+                                        }
+                                    }
+                                ],
+                                "env_from": [
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    },
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-rsm-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    }
+                                ],
+                                "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/apecloud-mysql-scale:0.2.3",
+                                "image_pull_policy": "IfNotPresent",
+                                "lifecycle": null,
+                                "liveness_probe": null,
+                                "name": "vttablet",
+                                "ports": [
+                                    {
+                                        "container_port": 15100,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "vttabletport",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "container_port": 16100,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "vttabletgrpc",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": null,
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "0",
+                                        "memory": "0"
+                                    },
+                                    "requests": null
+                                },
+                                "security_context": null,
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/scripts",
+                                        "mount_propagation": null,
+                                        "name": "scripts",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/conf",
+                                        "mount_propagation": null,
+                                        "name": "mysql-scale-config",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/vtdataroot",
+                                        "mount_propagation": null,
+                                        "name": "data",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            },
+                            {
+                                "args": null,
+                                "command": [
+                                    "lorry",
+                                    "--port",
+                                    "3501",
+                                    "--grpcport",
+                                    "50001"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KB_POD_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.name"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_UID",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.uid"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_SA_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.serviceAccountName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NODENAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.nodeName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOST_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOSTIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_FQDN",
+                                        "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_SERVICE_PORT",
+                                        "value": "3306",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_DATA_PATH",
+                                        "value": "/data/mysql",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_BUILTIN_HANDLER",
+                                        "value": "wesql",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_SERVICE_USER",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "username",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": null
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_SERVICE_PASSWORD",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "password",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": null
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_RSM_ACTION_SVC_LIST",
+                                        "value": "null",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_RSM_ROLE_UPDATE_MECHANISM",
+                                        "value": "DirectAPIServerEventUpdate",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_RSM_ROLE_PROBE_TIMEOUT",
+                                        "value": "1",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "KB_CLUSTER_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.labels['app.kubernetes.io/instance']"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_COMP_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.labels['apps.kubeblocks.io/component-name']"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_SERVICE_CHARACTER_TYPE",
+                                        "value": "wesql",
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": [
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    },
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-rsm-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    }
+                                ],
+                                "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1",
+                                "image_pull_policy": "IfNotPresent",
+                                "lifecycle": null,
+                                "liveness_probe": null,
+                                "name": "kb-checkrole",
+                                "ports": [
+                                    {
+                                        "container_port": 3501,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "lorry-http-port",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "container_port": 50001,
+                                        "host_ip": null,
+                                        "host_port": null,
+                                        "name": "lorry-grpc-port",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readiness_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 2,
+                                    "grpc": null,
+                                    "http_get": {
+                                        "host": null,
+                                        "http_headers": null,
+                                        "path": "/v1.0/checkrole",
+                                        "port": 3501,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initial_delay_seconds": null,
+                                    "period_seconds": 1,
+                                    "success_threshold": 1,
+                                    "tcp_socket": null,
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "0",
+                                        "memory": "0"
+                                    },
+                                    "requests": null
+                                },
+                                "security_context": null,
+                                "startup_probe": {
+                                    "_exec": null,
+                                    "failure_threshold": 3,
+                                    "grpc": null,
+                                    "http_get": null,
+                                    "initial_delay_seconds": null,
+                                    "period_seconds": 10,
+                                    "success_threshold": 1,
+                                    "tcp_socket": {
+                                        "host": null,
+                                        "port": 3501
+                                    },
+                                    "termination_grace_period_seconds": null,
+                                    "timeout_seconds": 1
+                                },
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/data/mysql",
+                                        "mount_propagation": null,
+                                        "name": "data",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            },
+                            {
+                                "args": [
+                                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(TOOLS_PATH)",
+                                    "/bin/reloader",
+                                    "--log-level",
+                                    "info",
+                                    "--volume-dir",
+                                    "/conf",
+                                    "--operator-update-enable",
+                                    "--tcp",
+                                    "9901",
+                                    "--config",
+                                    "/opt/config-manager/config-manager.yaml"
+                                ],
+                                "command": [
+                                    "env"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KB_POD_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.name"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_UID",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.uid"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NAMESPACE",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.namespace"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_SA_NAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.serviceAccountName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_NODENAME",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "spec.nodeName"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOST_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_IPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_HOSTIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.hostIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_PODIPS",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIPs"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "KB_POD_FQDN",
+                                        "value": "$(KB_POD_NAME).mycluster-mysql-headless.$(KB_NAMESPACE).svc",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "CONFIG_MANAGER_POD_IP",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "status.podIP"
+                                            },
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": null
+                                        }
+                                    },
+                                    {
+                                        "name": "DB_TYPE",
+                                        "value": "mysql",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "MYSQL_USER",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "username",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": null
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "MYSQL_PASSWORD",
+                                        "value": null,
+                                        "value_from": {
+                                            "config_map_key_ref": null,
+                                            "field_ref": null,
+                                            "resource_field_ref": null,
+                                            "secret_key_ref": {
+                                                "key": "password",
+                                                "name": "mycluster-conn-credential",
+                                                "optional": null
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "DATA_SOURCE_NAME",
+                                        "value": "$(MYSQL_USER):$(MYSQL_PASSWORD)@(localhost:3306)/",
+                                        "value_from": null
+                                    },
+                                    {
+                                        "name": "TOOLS_PATH",
+                                        "value": "/opt/kb-tools/reload/mysql-consensusset-config:/opt/config-manager",
+                                        "value_from": null
+                                    }
+                                ],
+                                "env_from": [
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    },
+                                    {
+                                        "config_map_ref": {
+                                            "name": "mycluster-mysql-rsm-env",
+                                            "optional": false
+                                        },
+                                        "prefix": null,
+                                        "secret_ref": null
+                                    }
+                                ],
+                                "image": "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1",
+                                "image_pull_policy": "IfNotPresent",
+                                "lifecycle": null,
+                                "liveness_probe": null,
+                                "name": "config-manager",
+                                "ports": null,
+                                "readiness_probe": null,
+                                "resources": {
+                                    "claims": null,
+                                    "limits": {
+                                        "cpu": "0",
+                                        "memory": "0"
+                                    },
+                                    "requests": null
+                                },
+                                "security_context": {
+                                    "allow_privilege_escalation": null,
+                                    "capabilities": null,
+                                    "privileged": null,
+                                    "proc_mount": null,
+                                    "read_only_root_filesystem": null,
+                                    "run_as_group": null,
+                                    "run_as_non_root": null,
+                                    "run_as_user": 0,
+                                    "se_linux_options": null,
+                                    "seccomp_profile": null,
+                                    "windows_options": null
+                                },
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": [
+                                    {
+                                        "mount_path": "/opt/mysql",
+                                        "mount_propagation": null,
+                                        "name": "mysql-config",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/conf",
+                                        "mount_propagation": null,
+                                        "name": "mysql-scale-config",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/opt/kb-tools/reload/mysql-consensusset-config",
+                                        "mount_propagation": null,
+                                        "name": "cm-script-mysql-consensusset-config",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    },
+                                    {
+                                        "mount_path": "/opt/config-manager",
+                                        "mount_propagation": null,
+                                        "name": "config-manager-config",
+                                        "read_only": null,
+                                        "sub_path": null,
+                                        "sub_path_expr": null
+                                    }
+                                ],
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": null,
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "kb-mycluster",
+                        "service_account_name": "kb-mycluster",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": true,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "kb-data",
+                                "operator": "Equal",
+                                "toleration_seconds": null,
+                                "value": "true"
+                            }
+                        ],
+                        "topology_spread_constraints": [
+                            {
+                                "label_selector": {
+                                    "match_expressions": null,
+                                    "match_labels": {
+                                        "app.kubernetes.io/instance": "mycluster",
+                                        "apps.kubeblocks.io/component-name": "mysql"
+                                    }
+                                },
+                                "match_label_keys": null,
+                                "max_skew": 1,
+                                "min_domains": null,
+                                "node_affinity_policy": null,
+                                "node_taints_policy": null,
+                                "topology_key": "kubernetes.io/hostname",
+                                "when_unsatisfiable": "DoNotSchedule"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": {
+                                    "default_mode": 420,
+                                    "items": [
+                                        {
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.annotations['cs.apps.kubeblocks.io/leader']"
+                                            },
+                                            "mode": null,
+                                            "path": "leader",
+                                            "resource_field_ref": null
+                                        },
+                                        {
+                                            "field_ref": {
+                                                "api_version": "v1",
+                                                "field_path": "metadata.annotations['apps.kubeblocks.io/component-replicas']"
+                                            },
+                                            "mode": null,
+                                            "path": "component-replicas",
+                                            "resource_field_ref": null
+                                        }
+                                    ]
+                                },
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "annotations",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": {
+                                    "default_mode": 292,
+                                    "items": null,
+                                    "name": "mycluster-mysql-agamotto-configuration",
+                                    "optional": null
+                                },
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "agamotto-configuration",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": {
+                                    "default_mode": 365,
+                                    "items": null,
+                                    "name": "mycluster-mysql-apecloud-mysql-scripts",
+                                    "optional": null
+                                },
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "scripts",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "name": "mycluster-mysql-mysql-consensusset-config",
+                                    "optional": null
+                                },
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "mysql-config",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": {
+                                    "default_mode": 420,
+                                    "items": null,
+                                    "name": "mycluster-mysql-vttablet-config",
+                                    "optional": null
+                                },
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "mysql-scale-config",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": {
+                                    "default_mode": 493,
+                                    "items": null,
+                                    "name": "sidecar-mysql-reload-script-mycluster",
+                                    "optional": null
+                                },
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "cm-script-mysql-consensusset-config",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": {
+                                    "default_mode": 493,
+                                    "items": null,
+                                    "name": "sidecar-mycluster-mysql-config-manager-config",
+                                    "optional": null
+                                },
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": null,
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "config-manager-config",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            },
+                            {
+                                "aws_elastic_block_store": null,
+                                "azure_disk": null,
+                                "azure_file": null,
+                                "cephfs": null,
+                                "cinder": null,
+                                "config_map": null,
+                                "csi": null,
+                                "downward_api": null,
+                                "empty_dir": {
+                                    "medium": null,
+                                    "size_limit": null
+                                },
+                                "ephemeral": null,
+                                "fc": null,
+                                "flex_volume": null,
+                                "flocker": null,
+                                "gce_persistent_disk": null,
+                                "git_repo": null,
+                                "glusterfs": null,
+                                "host_path": null,
+                                "iscsi": null,
+                                "name": "data",
+                                "nfs": null,
+                                "persistent_volume_claim": null,
+                                "photon_persistent_disk": null,
+                                "portworx_volume": null,
+                                "projected": null,
+                                "quobyte": null,
+                                "rbd": null,
+                                "scale_io": null,
+                                "secret": null,
+                                "storageos": null,
+                                "vsphere_volume": null
+                            }
+                        ]
+                    }
+                },
+                "update_strategy": {
+                    "rolling_update": null,
+                    "type": "OnDelete"
+                },
+                "volume_claim_templates": [
+                    {
+                        "api_version": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "annotations": null,
+                            "creation_timestamp": null,
+                            "deletion_grace_period_seconds": null,
+                            "deletion_timestamp": null,
+                            "finalizers": null,
+                            "generate_name": null,
+                            "generation": null,
+                            "labels": {
+                                "apps.kubeblocks.io/vct-name": "data",
+                                "kubeblocks.io/volume-type": "data"
+                            },
+                            "managed_fields": null,
+                            "name": "data",
+                            "namespace": null,
+                            "owner_references": null,
+                            "resource_version": null,
+                            "self_link": null,
+                            "uid": null
+                        },
+                        "spec": {
+                            "access_modes": [
+                                "ReadWriteOnce"
+                            ],
+                            "data_source": null,
+                            "data_source_ref": null,
+                            "resources": {
+                                "claims": null,
+                                "limits": null,
+                                "requests": {
+                                    "storage": "20Gi"
+                                }
+                            },
+                            "selector": null,
+                            "storage_class_name": null,
+                            "volume_mode": "Filesystem",
+                            "volume_name": null
+                        },
+                        "status": {
+                            "access_modes": null,
+                            "allocated_resources": null,
+                            "capacity": null,
+                            "conditions": null,
+                            "phase": "Pending",
+                            "resize_status": null
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "available_replicas": 1,
+                "collision_count": 0,
+                "conditions": null,
+                "current_replicas": 1,
+                "current_revision": "mycluster-mysql-5ff7bd466b",
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1,
+                "update_revision": "mycluster-mysql-5ff7bd466b",
+                "updated_replicas": 1
+            }
+        }
+    },
     "storage_class": {
         "standard": {
             "allow_volume_expansion": null,

--- a/operators/apecloud_kubeblocks-mysql/yaml-analyzer.py
+++ b/operators/apecloud_kubeblocks-mysql/yaml-analyzer.py
@@ -1,0 +1,35 @@
+import yaml
+
+stream = open('apps.kubeblocks.io_clusters.yaml', 'r')
+obj = yaml.safe_load(stream)
+
+target = obj['spec']['versions'][0]['schema']['openAPIV3Schema']['properties']['spec']['properties']
+print(target.keys())
+
+def find_depth(node, depths): 
+    if type(node) == dict: 
+        for child in node.values():
+            child_depths = []
+            find_depth(child, child_depths)
+            depths.append(max(child_depths) + 1)
+
+    elif type(node) == list:
+        for child in node:
+            child_depths = []
+            find_depth(child, child_depths)
+            depths.append(max(child_depths) + 1)
+
+    else:
+        depths.append(0)
+
+targetTest = []
+find_depth(target, targetTest)
+print(list(zip(target.keys(), targetTest)))
+
+compSpecsTest = []
+find_depth(target['componentSpecs'], compSpecsTest)
+print(list(zip(target['componentSpecs'].keys(), compSpecsTest)))
+
+shardingSpecsTest = []
+find_depth(target['shardingSpecs'], shardingSpecsTest)
+print(list(zip(target['shardingSpecs'].keys(), shardingSpecsTest)))


### PR DESCRIPTION
The analysis is in HW2-CRD-analysis.md
The yaml file is apps.kubeblocks.io_clusters.yaml.

Here is the HW2-CRD-analysis.md reproduced:

### Info

netid: qhng2  
name: Quan Hao Ng  
operator: kubeblocks for mysql  

### Chosen CRD

The chosen CRD is called `apps.kubeblocks.io_clusters.yaml`. It is taken from the `kubeblocks/config/crd/bases` directory of the kubeblocks project repo. I chose this CRD because it is the one that is used when I first installed and setup a simple cluster using the kubeblocks operator for MySQL. 

In the setup process, I has to write a simply yaml file for this Custom Resource and then use `kubectl apply -f` to apply this Custom Resource.

### The fields of the CRD 

In the CRD, I focused on the fields defined in `spec.versions.schema.openAPIV3Schema.properties.spec.properties`.

I initially considered splitting by what fields are required, as a measurement of how much effort it takes for a minimal setup. However, the only required field is `terminationPolicy`, which describes what happens when the cluster terminates.

These are the categorisations I now use:

Cluster description
- `componentSpecs`
- `clusterVersionRef`
- `clusterDefinitionRef`

Policies
- `tolerations`
- `terminationPolicy`
- `monitor`
- `availabilityPolicy`

Pods distribution
- `tenancy`
- `affinity`

Storage related
- `storage`
- `shardingSpecs`
- `resources`
- `replicas`
- `backup`

Networking
- `services`
- `network`

### Complexity metric

For complexity, I decided to analyze the `spec.versions.schema.openAPIV3Schema.properties.spec.properties.componentSpecs` and `spec.versions.schema.openAPIV3Schema.properties.spec.properties.shardingSpecs` in greater detail because this is the core portion that dictates how we want the cluster to eventually look like. One of the 2 has to be defined. 

The complexity metric that I'm using is the greatest depth. I think this is the one that causes the most confusion for me when I was analyzing through the CRD. The depth of these 2 fields is also interesting because they seem to have a recursive structure that mirror the parent (Something like components of components). 

I realised I could not find a simple utility to get the depths of a YAML file so I wrote a short python utility to help me get the depth of a particular node I'm interested in.

This is the depth for the primary fields listed above:  
`[('affinity', 5), ('availabilityPolicy', 3), ('backup', 4), ('clusterDefinitionRef', 4), ('clusterVersionRef', 2), ('componentSpecs', 15), ('monitor', 6), ('network', 4), ('replicas', 2), ('resources', 6), ('services', 12), ('shardingSpecs', 17), ('storage', 6), ('tenancy', 3), ('terminationPolicy', 3), ('tolerations', 5)]`

As expected, the componentSpecs and shardingSpecs have the greatest depth.

This is the depth for `componentSpecs`:  
`[('description', 1), ('items', 14), ('maxItems', 1), ('minItems', 1), ('type', 1), ('x-kubernetes-validations', 3)]`

This is the depth for `shardingSpecs`:  
`[('description', 1), ('items', 16), ('maxItems', 1), ('minItems', 1), ('type', 1), ('x-kubernetes-list-map-keys', 2), ('x-kubernetes-list-type', 1)]`

For both: `items` is the subtree with the highest depth and is the one that seems to mirror the parent structure.