### PR TITLE
HW2: Add the main grafana CRD.

### DIFF
--- a/operators/grafana_grafana-operator/grafana.integreatly.org_grafanas.yaml
+++ b/operators/grafana_grafana-operator/grafana.integreatly.org_grafanas.yaml
@@ -1,0 +1,4007 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  name: grafanas.grafana.integreatly.org
+spec:
+  group: grafana.integreatly.org
+  names:
+    kind: Grafana
+    listKind: GrafanaList
+    plural: grafanas
+    singular: grafana
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.stage
+      name: Stage
+      type: string
+    - jsonPath: .status.stageStatus
+      name: Stage status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              client:
+                properties:
+                  preferIngress:
+                    nullable: true
+                    type: boolean
+                  timeout:
+                    nullable: true
+                    type: integer
+                type: object
+              config:
+                additionalProperties:
+                  additionalProperties:
+                    type: string
+                  type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              deployment:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      minReadySeconds:
+                        format: int32
+                        type: integer
+                      paused:
+                        type: boolean
+                      progressDeadlineSeconds:
+                        format: int32
+                        type: integer
+                      replicas:
+                        format: int32
+                        type: integer
+                      revisionHistoryLimit:
+                        format: int32
+                        type: integer
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      strategy:
+                        properties:
+                          rollingUpdate:
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      template:
+                        properties:
+                          metadata:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          spec:
+                            properties:
+                              activeDeadlineSeconds:
+                                format: int64
+                                type: integer
+                              affinity:
+                                properties:
+                                  nodeAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            preference:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        properties:
+                                          nodeSelectorTerms:
+                                            items:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                type: boolean
+                              containers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              dnsConfig:
+                                properties:
+                                  nameservers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  options:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  searches:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              dnsPolicy:
+                                type: string
+                              enableServiceLinks:
+                                type: boolean
+                              ephemeralContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    targetContainerName:
+                                      type: string
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              hostAliases:
+                                items:
+                                  properties:
+                                    hostnames:
+                                      items:
+                                        type: string
+                                      type: array
+                                    ip:
+                                      type: string
+                                  type: object
+                                type: array
+                              hostIPC:
+                                type: boolean
+                              hostNetwork:
+                                type: boolean
+                              hostPID:
+                                type: boolean
+                              hostUsers:
+                                type: boolean
+                              hostname:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                              initContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              nodeName:
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              os:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              preemptionPolicy:
+                                type: string
+                              priority:
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                type: string
+                              readinessGates:
+                                items:
+                                  properties:
+                                    conditionType:
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                              restartPolicy:
+                                type: string
+                              runtimeClassName:
+                                type: string
+                              schedulerName:
+                                type: string
+                              securityContext:
+                                properties:
+                                  fsGroup:
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    type: string
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                  sysctls:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                type: string
+                              serviceAccountName:
+                                type: string
+                              setHostnameAsFQDN:
+                                type: boolean
+                              shareProcessNamespace:
+                                type: boolean
+                              subdomain:
+                                type: string
+                              terminationGracePeriodSeconds:
+                                format: int64
+                                type: integer
+                              tolerations:
+                                items:
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              topologySpreadConstraints:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      type: string
+                                    topologyKey:
+                                      type: string
+                                    whenUnsatisfiable:
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                items:
+                                  properties:
+                                    awsElasticBlockStore:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      properties:
+                                        cachingMode:
+                                          type: string
+                                        diskName:
+                                          type: string
+                                        diskURI:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      properties:
+                                        readOnly:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                        shareName:
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      properties:
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretFile:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        nodePublishSecretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      properties:
+                                        medium:
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      properties:
+                                        volumeClaimTemplate:
+                                          properties:
+                                            metadata:
+                                              type: object
+                                            spec:
+                                              properties:
+                                                accessModes:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  type: string
+                                                volumeAttributesClassName:
+                                                  type: string
+                                                volumeMode:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        targetWWNs:
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      properties:
+                                        datasetName:
+                                          type: string
+                                        datasetUUID:
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      properties:
+                                        directory:
+                                          type: string
+                                        repository:
+                                          type: string
+                                        revision:
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      properties:
+                                        endpoints:
+                                          type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      properties:
+                                        path:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    iscsi:
+                                      properties:
+                                        chapAuthDiscovery:
+                                          type: boolean
+                                        chapAuthSession:
+                                          type: boolean
+                                        fsType:
+                                          type: string
+                                        initiatorName:
+                                          type: string
+                                        iqn:
+                                          type: string
+                                        iscsiInterface:
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      type: string
+                                    nfs:
+                                      properties:
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        server:
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      properties:
+                                        claimName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        pdID:
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          items:
+                                            properties:
+                                              clusterTrustBundle:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  signerName:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              configMap:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                properties:
+                                                  audience:
+                                                    type: string
+                                                  expirationSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      properties:
+                                        group:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        registry:
+                                          type: string
+                                        tenant:
+                                          type: string
+                                        user:
+                                          type: string
+                                        volume:
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        image:
+                                          type: string
+                                        keyring:
+                                          type: string
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        gateway:
+                                          type: string
+                                        protectionDomain:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          type: boolean
+                                        storageMode:
+                                          type: string
+                                        storagePool:
+                                          type: string
+                                        system:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          type: string
+                                        volumeNamespace:
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        storagePolicyID:
+                                          type: string
+                                        storagePolicyName:
+                                          type: string
+                                        volumePath:
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              external:
+                properties:
+                  adminPassword:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  adminUser:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  apiKey:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  url:
+                    type: string
+                required:
+                - url
+                type: object
+              ingress:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      defaultBackend:
+                        properties:
+                          resource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              port:
+                                properties:
+                                  name:
+                                    type: string
+                                  number:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      ingressClassName:
+                        type: string
+                      rules:
+                        items:
+                          properties:
+                            host:
+                              type: string
+                            http:
+                              properties:
+                                paths:
+                                  items:
+                                    properties:
+                                      backend:
+                                        properties:
+                                          resource:
+                                            properties:
+                                              apiGroup:
+                                                type: string
+                                              kind:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          service:
+                                            properties:
+                                              name:
+                                                type: string
+                                              port:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  number:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                        type: object
+                                      path:
+                                        type: string
+                                      pathType:
+                                        type: string
+                                    required:
+                                    - backend
+                                    - pathType
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - paths
+                              type: object
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tls:
+                        items:
+                          properties:
+                            hosts:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            secretName:
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              jsonnet:
+                properties:
+                  libraryLabelSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              persistentVolumeClaim:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      accessModes:
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      resources:
+                        properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        type: string
+                      volumeMode:
+                        type: string
+                      volumeName:
+                        type: string
+                    type: object
+                type: object
+              preferences:
+                properties:
+                  homeDashboardUid:
+                    type: string
+                type: object
+              route:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      alternateBackends:
+                        items:
+                          properties:
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            weight:
+                              format: int32
+                              type: integer
+                          required:
+                          - kind
+                          - name
+                          - weight
+                          type: object
+                        type: array
+                      host:
+                        type: string
+                      path:
+                        type: string
+                      port:
+                        properties:
+                          targetPort:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - targetPort
+                        type: object
+                      tls:
+                        properties:
+                          caCertificate:
+                            type: string
+                          certificate:
+                            type: string
+                          destinationCACertificate:
+                            type: string
+                          insecureEdgeTerminationPolicy:
+                            type: string
+                          key:
+                            type: string
+                          termination:
+                            type: string
+                        required:
+                        - termination
+                        type: object
+                      to:
+                        properties:
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - kind
+                        - name
+                        - weight
+                        type: object
+                      wildcardPolicy:
+                        type: string
+                    type: object
+                type: object
+              service:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        type: boolean
+                      clusterIP:
+                        type: string
+                      clusterIPs:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        type: string
+                      externalTrafficPolicy:
+                        type: string
+                      healthCheckNodePort:
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        type: string
+                      ipFamilies:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        type: string
+                      loadBalancerClass:
+                        type: string
+                      loadBalancerIP:
+                        type: string
+                      loadBalancerSourceRanges:
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        items:
+                          properties:
+                            appProtocol:
+                              type: string
+                            name:
+                              type: string
+                            nodePort:
+                              format: int32
+                              type: integer
+                            port:
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        type: string
+                      sessionAffinityConfig:
+                        properties:
+                          clientIP:
+                            properties:
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                type: object
+              serviceAccount:
+                properties:
+                  automountServiceAccountToken:
+                    type: boolean
+                  imagePullSecrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  secrets:
+                    items:
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+            type: object
+          status:
+            properties:
+              adminUrl:
+                type: string
+              dashboards:
+                items:
+                  type: string
+                type: array
+              datasources:
+                items:
+                  type: string
+                type: array
+              folders:
+                items:
+                  type: string
+                type: array
+              lastMessage:
+                type: string
+              stage:
+                type: string
+              stageStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Per the HW2 steps:

1. The `grafana-operator` consists of  multiple CRDs. The one I have chosen to investigate appears to be the main operator responsible for managing/interfacing with the grafana server application (as opposed to the user dashboard, etc.)
2. The breakdown of the CRD fields into *app-specific*, *external*, and *k8s-native* fields can be seen below, in pseudo-yaml syntax. This is just the fields from the `spec.versions.schema.OpenAPIV3Schema.properties.spec.properties`. Thee relevant k8s-native and external APIs are:
    - [deployment](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#deploymentspec-v1-apps)
    - [ingress](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#ingressspec-v1-networking-k8s-io)
    - [jsonnet](https://jsonnet.org/articles/kubernetes.html)
    - [persistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#persistentvolumeclaimspec-v1-core)
    - [service](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#servicespec-v1-core)
    - [serviceAccount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#serviceaccount-v1-core)
    - [route](https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html)

    ```yaml
    client: app-specific
      preferIngress: boolean
      timeout: integer
    config: app-specific
      additionalProperties:
        additionalProperties: string
    deployment: k8s-native 
    external: app-specific
      adminPassword:
        key: string
        name: string
        optional: boolean
      adminUser:
        key: string
        name: string
        optional: boolean
      apiKey:
        key: string
        name: string
        optional: boolean
      url: string
    ingress: k8s-native 
    jsonnet: app-specific, but related to external jsonnet
      libraryLabelSelector:
        matchExpressions: array
          items:
            key: string
            operator: string
            values: array
              items: string
        matchLabels:
          additionalProperties: string
    persistentVolumeClaim: k8s-native
    preferences: app-specific
      homeDashboardUid: string
    route: external 
    service: k8s-native
    serviceAccount: standard
    ```
    
3. Like we were discussing in class, complexity is difficult to measure. I like to ask, "How many very large things do I have to learn in order to understand this?" We want to quantify both the size of the components in the system (a system of many small components may be complex, but a system of many large components is going to be worse), and we also want to quantify the number of those large components. To that effect, I propose using a modified form of the [h-index](https://en.wikipedia.org/wiki/H-index). We ask "what is the largest number `h`, such that there are `h` nodes in the configuration tree that each have at least `h` children?" For the CRD that I've chosen, `h = 11`.
    
    Other metrics that might be of interest:
    - Max depth of the YAML tree = 35
    - Number of nodes in the YAML tree (as parsed by PyYAML) = 4113
    - Number of leaf nodes in the YAML tree = 2027