### PR TITLE
Add CRD for kubeblocks postgresql cluster

### DIFF
--- a/operators/kubeblocks_postgresql-operator/clusters.apps.kubeblocks.io.yaml
+++ b/operators/kubeblocks_postgresql-operator/clusters.apps.kubeblocks.io.yaml
@@ -1,0 +1,1823 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.1
+  creationTimestamp: "2024-02-14T16:12:22Z"
+  generation: 1
+  labels:
+    app.kubernetes.io/name: kubeblocks
+  name: clusters.apps.kubeblocks.io
+  resourceVersion: "653"
+  uid: 38381779-be19-4ce5-a41e-4d448193cc51
+spec:
+  conversion:
+    strategy: None
+  group: apps.kubeblocks.io
+  names:
+    categories:
+    - kubeblocks
+    - all
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: ClusterDefinition referenced by cluster.
+      jsonPath: .spec.clusterDefinitionRef
+      name: CLUSTER-DEFINITION
+      type: string
+    - description: Cluster Application Version.
+      jsonPath: .spec.clusterVersionRef
+      name: VERSION
+      type: string
+    - description: Cluster termination policy.
+      jsonPath: .spec.terminationPolicy
+      name: TERMINATION-POLICY
+      type: string
+    - description: Cluster Status.
+      jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              affinity:
+                description: affinity is a group of affinity scheduling rules.
+                properties:
+                  nodeLabels:
+                    additionalProperties:
+                      type: string
+                    description: nodeLabels describes that pods must be scheduled
+                      to the nodes with the specified node labels.
+                    type: object
+                  podAntiAffinity:
+                    default: Preferred
+                    description: podAntiAffinity describes the anti-affinity level
+                      of pods within a component. Preferred means try spread pods
+                      by `TopologyKeys`. Required means must spread pods by `TopologyKeys`.
+                    enum:
+                    - Preferred
+                    - Required
+                    type: string
+                  tenancy:
+                    default: SharedNode
+                    description: tenancy describes how pods are distributed across
+                      node. SharedNode means multiple pods may share the same node.
+                      DedicatedNode means each pod runs on their own dedicated node.
+                    enum:
+                    - SharedNode
+                    - DedicatedNode
+                    type: string
+                  topologyKeys:
+                    description: topologyKey is the key of node labels. Nodes that
+                      have a label with this key and identical values are considered
+                      to be in the same topology. It's used as the topology domain
+                      for pod anti-affinity and pod spread constraint. Some well-known
+                      label keys, such as "kubernetes.io/hostname" and "topology.kubernetes.io/zone"
+                      are often used as TopologyKey, as well as any other custom label
+                      key.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              availabilityPolicy:
+                description: availabilityPolicy describes the availability policy,
+                  including zone, node, and none.
+                enum:
+                - zone
+                - node
+                - none
+                type: string
+              backup:
+                description: cluster backup configuration.
+                properties:
+                  cronExpression:
+                    description: the cron expression for schedule, the timezone is
+                      in UTC. see https://en.wikipedia.org/wiki/Cron.
+                    type: string
+                  enabled:
+                    default: false
+                    description: enabled defines whether to enable automated backup.
+                    type: boolean
+                  method:
+                    description: backup method name to use, that is defined in backupPolicy.
+                    type: string
+                  pitrEnabled:
+                    default: false
+                    description: pitrEnabled defines whether to enable point-in-time
+                      recovery.
+                    type: boolean
+                  repoName:
+                    description: repoName is the name of the backupRepo, if not set,
+                      will use the default backupRepo.
+                    type: string
+                  retentionPeriod:
+                    default: 7d
+                    description: "retentionPeriod determines a duration up to which
+                      the backup should be kept. controller will remove all backups
+                      that are older than the RetentionPeriod. For example, RetentionPeriod
+                      of `30d` will keep only the backups of last 30 days. Sample
+                      duration format: - years: \t2y - months: \t6mo - days: \t\t30d
+                      - hours: \t12h - minutes: \t30m You can also combine the above
+                      durations. For example: 30d12h30m"
+                    type: string
+                  startingDeadlineMinutes:
+                    description: startingDeadlineMinutes defines the deadline in minutes
+                      for starting the backup job if it misses scheduled time for
+                      any reason.
+                    format: int64
+                    maximum: 1440
+                    minimum: 0
+                    type: integer
+                type: object
+              clusterDefinitionRef:
+                description: Cluster referencing ClusterDefinition name. This is an
+                  immutable attribute. If ClusterDefRef is not specified, ComponentDef
+                  must be specified for each Component in ComponentSpecs.
+                maxLength: 63
+                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                type: string
+                x-kubernetes-validations:
+                - message: clusterDefinitionRef is immutable
+                  rule: self == oldSelf
+              clusterVersionRef:
+                description: Cluster referencing ClusterVersion name.
+                maxLength: 63
+                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                type: string
+              componentSpecs:
+                description: List of componentSpecs you want to replace in ClusterDefinition
+                  and ClusterVersion. It will replace the field in ClusterDefinition's
+                  and ClusterVersion's component if type is matching.
+                items:
+                  description: ClusterComponentSpec defines the cluster component
+                    spec.
+                  properties:
+                    affinity:
+                      description: affinity describes affinities specified by users.
+                      properties:
+                        nodeLabels:
+                          additionalProperties:
+                            type: string
+                          description: nodeLabels describes that pods must be scheduled
+                            to the nodes with the specified node labels.
+                          type: object
+                        podAntiAffinity:
+                          default: Preferred
+                          description: podAntiAffinity describes the anti-affinity
+                            level of pods within a component. Preferred means try
+                            spread pods by `TopologyKeys`. Required means must spread
+                            pods by `TopologyKeys`.
+                          enum:
+                          - Preferred
+                          - Required
+                          type: string
+                        tenancy:
+                          default: SharedNode
+                          description: tenancy describes how pods are distributed
+                            across node. SharedNode means multiple pods may share
+                            the same node. DedicatedNode means each pod runs on their
+                            own dedicated node.
+                          enum:
+                          - SharedNode
+                          - DedicatedNode
+                          type: string
+                        topologyKeys:
+                          description: topologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. It's used as the
+                            topology domain for pod anti-affinity and pod spread constraint.
+                            Some well-known label keys, such as "kubernetes.io/hostname"
+                            and "topology.kubernetes.io/zone" are often used as TopologyKey,
+                            as well as any other custom label key.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    classDefRef:
+                      description: classDefRef references the class defined in ComponentClassDefinition.
+                      properties:
+                        class:
+                          description: Class refers to the name of the class that
+                            is defined in the ComponentClassDefinition.
+                          type: string
+                        name:
+                          description: Name refers to the name of the ComponentClassDefinition.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - class
+                      type: object
+                    componentDef:
+                      description: componentDef references the name of the ComponentDefinition.
+                        If both componentDefRef and componentDef are provided, the
+                        componentDef will take precedence over componentDefRef.
+                      maxLength: 22
+                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      type: string
+                      x-kubernetes-validations:
+                      - message: componentDef is immutable
+                        rule: self == oldSelf
+                    componentDefRef:
+                      description: componentDefRef references componentDef defined
+                        in ClusterDefinition spec. Need to comply with IANA Service
+                        Naming rule.
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                      type: string
+                      x-kubernetes-validations:
+                      - message: componentDefRef is immutable
+                        rule: self == oldSelf
+                    enabledLogs:
+                      description: enabledLogs indicates which log file takes effect
+                        in the database cluster. element is the log type which is
+                        defined in cluster definition logConfig.name, and will set
+                        relative variables about this log type in database kernel.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    instances:
+                      description: Instances defines the list of instance to be deleted
+                        priorly If the RsmTransformPolicy is specified as ToPod,the
+                        list of instances will be used.
+                      items:
+                        type: string
+                      type: array
+                    issuer:
+                      description: issuer defines provider context for TLS certs.
+                        required when TLS enabled
+                      properties:
+                        name:
+                          default: KubeBlocks
+                          description: 'Name of issuer. Options supported: - KubeBlocks
+                            - Certificates signed by KubeBlocks Operator. - UserProvided
+                            - User provided own CA-signed certificates.'
+                          enum:
+                          - KubeBlocks
+                          - UserProvided
+                          type: string
+                        secretRef:
+                          description: secretRef. TLS certs Secret reference required
+                            when from is UserProvided
+                          properties:
+                            ca:
+                              description: CA cert key in Secret
+                              type: string
+                            cert:
+                              description: Cert key in Secret
+                              type: string
+                            key:
+                              description: Key of TLS private key in Secret
+                              type: string
+                            name:
+                              description: Name of the Secret
+                              type: string
+                          required:
+                          - ca
+                          - cert
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    monitor:
+                      default: false
+                      description: monitor is a switch to enable monitoring and is
+                        set as false by default. KubeBlocks provides an extension
+                        mechanism to support component level monitoring, which will
+                        scrape metrics auto or manually from servers in component
+                        and export metrics to Time Series Database.
+                      type: boolean
+                    name:
+                      description: name defines cluster's component name, this name
+                        is also part of Service DNS name, so this name will comply
+                        with IANA Service Naming rule.
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                      type: string
+                      x-kubernetes-validations:
+                      - message: name is immutable
+                        rule: self == oldSelf
+                    noCreatePDB:
+                      default: false
+                      description: noCreatePDB defines the PodDisruptionBudget creation
+                        behavior and is set to true if creation of PodDisruptionBudget
+                        for this component is not needed. It defaults to false.
+                      type: boolean
+                    nodes:
+                      description: Nodes defines the list of nodes that pods can schedule
+                        If the RsmTransformPolicy is specified as ToPod,the list of
+                        nodes will be used. If the list of nodes is empty, no specific
+                        node will be assigned. However, if the list of node is filled,
+                        all pods will be evenly scheduled across the nodes in the
+                        list.
+                      items:
+                        description: "NodeName is a type that holds a api.Node's Name
+                          identifier. Being a type captures intent and helps make
+                          sure that the node name is not confused with similar concepts
+                          (the hostname, the cloud provider id, the cloud provider
+                          name etc) \n To clarify the various types: \n - Node.Name
+                          is the Name field of the Node in the API.  This should be
+                          stored in a NodeName. Unfortunately, because Name is part
+                          of ObjectMeta, we can't store it as a NodeName at the API
+                          level. \n - Hostname is the hostname of the local machine
+                          (from uname -n). However, some components allow the user
+                          to pass in a --hostname-override flag, which will override
+                          this in most places. In the absence of anything more meaningful,
+                          kubelet will use Hostname as the Node.Name when it creates
+                          the Node. \n * The cloudproviders have the own names: GCE
+                          has InstanceName, AWS has InstanceId. \n For GCE, InstanceName
+                          is the Name of an Instance object in the GCE API.  On GCE,
+                          Instance.Name becomes the Hostname, and thus it makes sense
+                          also to use it as the Node.Name.  But that is GCE specific,
+                          and it is up to the cloudprovider how to do this mapping.
+                          \n For AWS, the InstanceID is not yet suitable for use as
+                          a Node.Name, so we actually use the PrivateDnsName for the
+                          Node.Name.  And this is _not_ always the same as the hostname:
+                          if we are using a custom DHCP domain it won't be."
+                        type: string
+                      type: array
+                    replicas:
+                      default: 1
+                      description: Component replicas.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: Resources requests and limits of workload.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                            in spec.resourceClaims, that are used by this container.
+                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                            feature gate. \n This field is immutable. It can only
+                            be set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry
+                                  in pod.spec.resourceClaims of the Pod where this
+                                  field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    rsmTransformPolicy:
+                      default: ToSts
+                      description: 'RsmTransformPolicy defines the policy generate
+                        sts using rsm. ToSts: rsm transforms to statefulSet ToPod:
+                        rsm transforms to pods'
+                      enum:
+                      - ToPod
+                      - ToSts
+                      type: string
+                    serviceAccountName:
+                      description: serviceAccountName is the name of the ServiceAccount
+                        that running component depends on.
+                      type: string
+                    serviceRefs:
+                      description: 'serviceRefs define service references for the
+                        current component. Based on the referenced services, they
+                        can be categorized into two types: Service provided by external
+                        sources: These services are provided by external sources and
+                        are not managed by KubeBlocks. They can be Kubernetes-based
+                        or non-Kubernetes services. For external services, you need
+                        to provide an additional ServiceDescriptor object to establish
+                        the service binding. Service provided by other KubeBlocks
+                        clusters: These services are provided by other KubeBlocks
+                        clusters. You can bind to these services by specifying the
+                        name of the hosting cluster. Each type of service reference
+                        requires specific configurations and bindings to establish
+                        the connection and interaction with the respective services.
+                        It should be noted that the ServiceRef has cluster-level semantic
+                        consistency, meaning that within the same Cluster, service
+                        references with the same ServiceRef.Name are considered to
+                        be the same service. It is only allowed to bind to the same
+                        Cluster or ServiceDescriptor.'
+                      items:
+                        properties:
+                          cluster:
+                            description: 'When referencing a service provided by other
+                              KubeBlocks cluster, you need to provide the name of
+                              the Cluster being referenced. By default, when other
+                              KubeBlocks Cluster are referenced, the ClusterDefinition.spec.connectionCredential
+                              secret corresponding to the referenced Cluster will
+                              be used to bind to the current component. Currently,
+                              if a KubeBlocks cluster is to be referenced, the connection
+                              credential secret should include and correspond to the
+                              following fields: endpoint, port, username, and password.
+                              Under this referencing approach, the ServiceKind and
+                              ServiceVersion of service reference declaration defined
+                              in the ClusterDefinition will not be validated. If both
+                              Cluster and ServiceDescriptor are specified, the Cluster
+                              takes precedence.'
+                            type: string
+                          name:
+                            description: name of the service reference declaration.
+                              references the serviceRefDeclaration name defined in
+                              clusterDefinition.componentDefs[*].serviceRefDeclarations[*].name
+                            type: string
+                          namespace:
+                            description: namespace defines the namespace of the referenced
+                              Cluster or the namespace of the referenced ServiceDescriptor
+                              object. If not set, the referenced Cluster and ServiceDescriptor
+                              will be searched in the namespace of the current cluster
+                              by default.
+                            type: string
+                          serviceDescriptor:
+                            description: serviceDescriptor defines the service descriptor
+                              of the service provided by external sources. When referencing
+                              a service provided by external sources, you need to
+                              provide the ServiceDescriptor object name to establish
+                              the service binding. And serviceDescriptor is the name
+                              of the ServiceDescriptor object, furthermore, the ServiceDescriptor.spec.serviceKind
+                              and ServiceDescriptor.spec.serviceVersion should match
+                              clusterDefinition.componentDefs[*].serviceRefDeclarations[*].serviceRefDeclarationSpecs[*].serviceKind
+                              and the regular expression defines in clusterDefinition.componentDefs[*].serviceRefDeclarations[*].serviceRefDeclarationSpecs[*].serviceVersion.
+                              If both Cluster and ServiceDescriptor are specified,
+                              the Cluster takes precedence.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    services:
+                      description: Services expose endpoints that can be accessed
+                        by clients.
+                      items:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'If ServiceType is LoadBalancer, cloud provider
+                              related parameters can be put here More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer.'
+                            type: object
+                          name:
+                            description: Service name
+                            maxLength: 15
+                            type: string
+                          serviceType:
+                            default: ClusterIP
+                            description: 'serviceType determines how the Service is
+                              exposed. Valid options are ClusterIP, NodePort, and
+                              LoadBalancer. "ClusterIP" allocates a cluster-internal
+                              IP address for load-balancing to endpoints. Endpoints
+                              are determined by the selector or if that is not specified,
+                              they are determined by manual construction of an Endpoints
+                              object or EndpointSlice objects. If clusterIP is "None",
+                              no virtual IP is allocated and the endpoints are published
+                              as a set of endpoints rather than a virtual IP. "NodePort"
+                              builds on ClusterIP and allocates a port on every node
+                              which routes to the same endpoints as the clusterIP.
+                              "LoadBalancer" builds on NodePort and creates an external
+                              load-balancer (if supported in the current cloud) which
+                              routes to the same endpoints as the clusterIP. More
+                              info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types.'
+                            enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    switchPolicy:
+                      description: switchPolicy defines the strategy for switchover
+                        and failover when workloadType is Replication.
+                      properties:
+                        type:
+                          default: Noop
+                          description: 'clusterSwitchPolicy defines type of the switchPolicy
+                            when workloadType is Replication. MaximumAvailability:
+                            [WIP] when the primary is active, do switch if the synchronization
+                            delay = 0 in the user-defined lagProbe data delay detection
+                            logic, otherwise do not switch. The primary is down, switch
+                            immediately. It will be available in future versions.
+                            MaximumDataProtection: [WIP] when the primary is active,
+                            do switch if synchronization delay = 0 in the user-defined
+                            lagProbe data lag detection logic, otherwise do not switch.
+                            If the primary is down, if it can be judged that the primary
+                            and secondary data are consistent, then do the switch,
+                            otherwise do not switch. It will be available in future
+                            versions. Noop: KubeBlocks will not perform high-availability
+                            switching on components. Users need to implement HA by
+                            themselves or integrate open source HA solution.'
+                          enum:
+                          - Noop
+                          type: string
+                      type: object
+                    tls:
+                      description: Enables or disables TLS certs.
+                      type: boolean
+                    tolerations:
+                      description: Component tolerations will override ClusterSpec.Tolerations
+                        if specified.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-preserve-unknown-fields: true
+                    updateStrategy:
+                      description: updateStrategy defines the update strategy for
+                        the component.
+                      enum:
+                      - Serial
+                      - BestEffortParallel
+                      - Parallel
+                      type: string
+                    userResourceRefs:
+                      description: userResourceRefs defines the user-defined volumes.
+                      properties:
+                        configMapRefs:
+                          description: configMapRefs defines the user-defined configmaps.
+                          items:
+                            properties:
+                              asVolumeFrom:
+                                description: asVolumeFrom defines the list of containers
+                                  where volumeMounts will be injected into.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              configMap:
+                                description: configMap defines the configmap volume
+                                  source.
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mountPoint:
+                                description: mountPath is the path at which to mount
+                                  the volume.
+                                maxLength: 256
+                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
+                                type: string
+                              name:
+                                description: name is the name of the referenced the
+                                  Configmap/Secret object.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                                type: string
+                              subPath:
+                                description: subPath is a relative file path within
+                                  the volume to mount.
+                                type: string
+                            required:
+                            - configMap
+                            - mountPoint
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        secretRefs:
+                          description: secretRefs defines the user-defined secrets.
+                          items:
+                            properties:
+                              asVolumeFrom:
+                                description: asVolumeFrom defines the list of containers
+                                  where volumeMounts will be injected into.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPoint:
+                                description: mountPath is the path at which to mount
+                                  the volume.
+                                maxLength: 256
+                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
+                                type: string
+                              name:
+                                description: name is the name of the referenced the
+                                  Configmap/Secret object.
+                                maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                                type: string
+                              secret:
+                                description: secret defines the secret volume source.
+                                properties:
+                                  defaultMode:
+                                    description: 'defaultMode is Optional: mode bits
+                                      used to set permissions on created files by
+                                      default. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values,
+                                      JSON requires decimal values for mode bits.
+                                      Defaults to 0644. Directories within the path
+                                      are not affected by this setting. This might
+                                      be in conflict with other options that affect
+                                      the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: items If unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: 'secretName is the name of the secret
+                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    type: string
+                                type: object
+                              subPath:
+                                description: subPath is a relative file path within
+                                  the volume to mount.
+                                type: string
+                            required:
+                            - mountPoint
+                            - name
+                            - secret
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    volumeClaimTemplates:
+                      description: volumeClaimTemplates information for statefulset.spec.volumeClaimTemplates.
+                      items:
+                        properties:
+                          name:
+                            description: Reference `ClusterDefinition.spec.componentDefs.containers.volumeMounts.name`.
+                            type: string
+                          spec:
+                            description: spec defines the desired characteristics
+                              of a volume requested by a pod author.
+                            properties:
+                              accessModes:
+                                description: 'accessModes contains the desired access
+                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1.'
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-preserve-unknown-fields: true
+                              resources:
+                                description: 'resources represents the minimum resources
+                                  the volume should have. If RecoverVolumeExpansionFailure
+                                  feature is enabled users are allowed to specify
+                                  resource requirements that are lower than previous
+                                  value but must still be higher than capacity recorded
+                                  in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources.'
+                                properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable. It
+                                      can only be set for containers."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. Requests cannot
+                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              storageClassName:
+                                description: 'storageClassName is the name of the
+                                  StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1.'
+                                type: string
+                              volumeMode:
+                                description: volumeMode defines what type of volume
+                                  is required by the claim.
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - replicas
+                  type: object
+                  x-kubernetes-validations:
+                  - message: either componentDefRef or componentDef should be provided
+                    rule: has(self.componentDefRef) || has(self.componentDef)
+                  - message: componentDefRef is required once set
+                    rule: '!has(oldSelf.componentDefRef) || has(self.componentDefRef)'
+                  - message: componentDef is required once set
+                    rule: '!has(oldSelf.componentDef) || has(self.componentDef)'
+                maxItems: 128
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: duplicated component
+                  rule: self.all(x, size(self.filter(c, c.name == x.name)) == 1)
+              monitor:
+                description: monitor specifies the configuration of monitor
+                properties:
+                  monitoringInterval:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: monitoringInterval specifies interval of monitoring,
+                      no monitor if set to 0
+                    x-kubernetes-int-or-string: true
+                type: object
+              network:
+                description: network specifies the configuration of network
+                properties:
+                  hostNetworkAccessible:
+                    default: false
+                    description: hostNetworkAccessible specifies whether host network
+                      is accessible. It defaults to false
+                    type: boolean
+                  publiclyAccessible:
+                    default: false
+                    description: publiclyAccessible specifies whether it is publicly
+                      accessible. It defaults to false
+                    type: boolean
+                type: object
+              replicas:
+                description: replicas specifies the replicas of the first componentSpec,
+                  if the replicas of the first componentSpec is specified, this value
+                  will be ignored.
+                format: int32
+                type: integer
+              resources:
+                description: resources specifies the resources of the first componentSpec,
+                  if the resources of the first componentSpec is specified, this value
+                  will be ignored.
+                properties:
+                  cpu:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'cpu resource needed, more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'memory resource needed, more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              services:
+                description: services defines the services to access a cluster.
+                items:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'If ServiceType is LoadBalancer, cloud provider
+                        related parameters can be put here More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer.'
+                      type: object
+                    componentSelector:
+                      description: ComponentSelector extends the ServiceSpec.Selector
+                        by allowing you to specify a component as selectors for the
+                        service.
+                      type: string
+                    name:
+                      description: Name defines the name of the service. otherwise,
+                        it indicates the name of the service. Others can refer to
+                        this service by its name. (e.g., connection credential) Cannot
+                        be updated.
+                      type: string
+                    roleSelector:
+                      description: RoleSelector extends the ServiceSpec.Selector by
+                        allowing you to specify defined role as selector for the service.
+                        if GeneratePodOrdinalService sets to true, RoleSelector will
+                        be ignored.
+                      type: string
+                    serviceName:
+                      description: 'ServiceName defines the name of the underlying
+                        service object. If not specified, the default service name
+                        with different patterns will be used: - <CLUSTER_NAME>: for
+                        cluster-level services - <CLUSTER_NAME>-<COMPONENT_NAME>:
+                        for component-level services Only one default service name
+                        is allowed. Cannot be updated.'
+                      type: string
+                    spec:
+                      description: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                      properties:
+                        allocateLoadBalancerNodePorts:
+                          description: allocateLoadBalancerNodePorts defines if NodePorts
+                            will be automatically allocated for services with type
+                            LoadBalancer.  Default is "true". It may be set to "false"
+                            if the cluster load-balancer does not rely on NodePorts.  If
+                            the caller requests specific NodePorts (by specifying
+                            a value), those requests will be respected, regardless
+                            of this field. This field may only be set for services
+                            with type LoadBalancer and will be cleared if the type
+                            is changed to any other type.
+                          type: boolean
+                        clusterIP:
+                          description: 'clusterIP is the IP address of the service
+                            and is usually assigned randomly. If an address is specified
+                            manually, is in-range (as per system configuration), and
+                            is not in use, it will be allocated to the service; otherwise
+                            creation of the service will fail. This field may not
+                            be changed through updates unless the type field is also
+                            being changed to ExternalName (which requires this field
+                            to be blank) or the type field is being changed from ExternalName
+                            (in which case this field may optionally be specified,
+                            as describe above).  Valid values are "None", empty string
+                            (""), or a valid IP address. Setting this to "None" makes
+                            a "headless service" (no virtual IP), which is useful
+                            when direct endpoint connections are preferred and proxying
+                            is not required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        clusterIPs:
+                          description: "ClusterIPs is a list of IP addresses assigned
+                            to this service, and are usually assigned randomly.  If
+                            an address is specified manually, is in-range (as per
+                            system configuration), and is not in use, it will be allocated
+                            to the service; otherwise creation of the service will
+                            fail. This field may not be changed through updates unless
+                            the type field is also being changed to ExternalName (which
+                            requires this field to be empty) or the type field is
+                            being changed from ExternalName (in which case this field
+                            may optionally be specified, as describe above).  Valid
+                            values are \"None\", empty string (\"\"), or a valid IP
+                            address.  Setting this to \"None\" makes a \"headless
+                            service\" (no virtual IP), which is useful when direct
+                            endpoint connections are preferred and proxying is not
+                            required.  Only applies to types ClusterIP, NodePort,
+                            and LoadBalancer. If this field is specified when creating
+                            a Service of type ExternalName, creation will fail. This
+                            field will be wiped when updating a Service to type ExternalName.
+                            \ If this field is not specified, it will be initialized
+                            from the clusterIP field.  If this field is specified,
+                            clients must ensure that clusterIPs[0] and clusterIP have
+                            the same value. \n This field may hold a maximum of two
+                            entries (dual-stack IPs, in either order). These IPs must
+                            correspond to the values of the ipFamilies field. Both
+                            clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        externalIPs:
+                          description: externalIPs is a list of IP addresses for which
+                            nodes in the cluster will also accept traffic for this
+                            service.  These IPs are not managed by Kubernetes.  The
+                            user is responsible for ensuring that traffic arrives
+                            at a node with this IP.  A common example is external
+                            load-balancers that are not part of the Kubernetes system.
+                          items:
+                            type: string
+                          type: array
+                        externalName:
+                          description: externalName is the external reference that
+                            discovery mechanisms will return as an alias for this
+                            service (e.g. a DNS CNAME record). No proxying will be
+                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                            and requires `type` to be "ExternalName".
+                          type: string
+                        externalTrafficPolicy:
+                          description: externalTrafficPolicy describes how nodes distribute
+                            service traffic they receive on one of the Service's "externally-facing"
+                            addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                            If set to "Local", the proxy will configure the service
+                            in a way that assumes that external load balancers will
+                            take care of balancing the service traffic between nodes,
+                            and so each node will deliver traffic only to the node-local
+                            endpoints of the service, without masquerading the client
+                            source IP. (Traffic mistakenly sent to a node with no
+                            endpoints will be dropped.) The default value, "Cluster",
+                            uses the standard behavior of routing to all endpoints
+                            evenly (possibly modified by topology and other features).
+                            Note that traffic sent to an External IP or LoadBalancer
+                            IP from within the cluster will always get "Cluster" semantics,
+                            but clients sending to a NodePort from within the cluster
+                            may need to take traffic policy into account when picking
+                            a node.
+                          type: string
+                        healthCheckNodePort:
+                          description: healthCheckNodePort specifies the healthcheck
+                            nodePort for the service. This only applies when type
+                            is set to LoadBalancer and externalTrafficPolicy is set
+                            to Local. If a value is specified, is in-range, and is
+                            not in use, it will be used.  If not specified, a value
+                            will be automatically allocated.  External systems (e.g.
+                            load-balancers) can use this port to determine if a given
+                            node holds endpoints for this service or not.  If this
+                            field is specified when creating a Service which does
+                            not need it, creation will fail. This field will be wiped
+                            when updating a Service to no longer need it (e.g. changing
+                            type). This field cannot be updated once set.
+                          format: int32
+                          type: integer
+                        internalTrafficPolicy:
+                          description: InternalTrafficPolicy describes how nodes distribute
+                            service traffic they receive on the ClusterIP. If set
+                            to "Local", the proxy will assume that pods only want
+                            to talk to endpoints of the service on the same node as
+                            the pod, dropping the traffic if there are no local endpoints.
+                            The default value, "Cluster", uses the standard behavior
+                            of routing to all endpoints evenly (possibly modified
+                            by topology and other features).
+                          type: string
+                        ipFamilies:
+                          description: "IPFamilies is a list of IP families (e.g.
+                            IPv4, IPv6) assigned to this service. This field is usually
+                            assigned automatically based on cluster configuration
+                            and the ipFamilyPolicy field. If this field is specified
+                            manually, the requested family is available in the cluster,
+                            and ipFamilyPolicy allows it, it will be used; otherwise
+                            creation of the service will fail. This field is conditionally
+                            mutable: it allows for adding or removing a secondary
+                            IP family, but it does not allow changing the primary
+                            IP family of the Service. Valid values are \"IPv4\" and
+                            \"IPv6\".  This field only applies to Services of types
+                            ClusterIP, NodePort, and LoadBalancer, and does apply
+                            to \"headless\" services. This field will be wiped when
+                            updating a Service to type ExternalName. \n This field
+                            may hold a maximum of two entries (dual-stack families,
+                            in either order).  These families must correspond to the
+                            values of the clusterIPs field, if specified. Both clusterIPs
+                            and ipFamilies are governed by the ipFamilyPolicy field."
+                          items:
+                            description: IPFamily represents the IP Family (IPv4 or
+                              IPv6). This type is used to express the family of an
+                              IP expressed by a type (e.g. service.spec.ipFamilies).
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        ipFamilyPolicy:
+                          description: IPFamilyPolicy represents the dual-stack-ness
+                            requested or required by this Service. If there is no
+                            value provided, then this field will be set to SingleStack.
+                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
+                            (two IP families on dual-stack configured clusters or
+                            a single IP family on single-stack clusters), or "RequireDualStack"
+                            (two IP families on dual-stack configured clusters, otherwise
+                            fail). The ipFamilies and clusterIPs fields depend on
+                            the value of this field. This field will be wiped when
+                            updating a service to type ExternalName.
+                          type: string
+                        loadBalancerClass:
+                          description: loadBalancerClass is the class of the load
+                            balancer implementation this Service belongs to. If specified,
+                            the value of this field must be a label-style identifier,
+                            with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                            Unprefixed names are reserved for end-users. This field
+                            can only be set when the Service type is 'LoadBalancer'.
+                            If not set, the default load balancer implementation is
+                            used, today this is typically done through the cloud provider
+                            integration, but should apply for any default implementation.
+                            If set, it is assumed that a load balancer implementation
+                            is watching for Services with a matching class. Any default
+                            load balancer implementation (e.g. cloud providers) should
+                            ignore Services that set this field. This field can only
+                            be set when creating or updating a Service to type 'LoadBalancer'.
+                            Once set, it can not be changed. This field will be wiped
+                            when a service is updated to a non 'LoadBalancer' type.
+                          type: string
+                        loadBalancerIP:
+                          description: 'Only applies to Service Type: LoadBalancer.
+                            This feature depends on whether the underlying cloud-provider
+                            supports specifying the loadBalancerIP when a load balancer
+                            is created. This field will be ignored if the cloud-provider
+                            does not support the feature. Deprecated: This field was
+                            under-specified and its meaning varies across implementations.
+                            Using it is non-portable and it may not support dual-stack.
+                            Users are encouraged to use implementation-specific annotations
+                            when available.'
+                          type: string
+                        loadBalancerSourceRanges:
+                          description: 'If specified and supported by the platform,
+                            this will restrict traffic through the cloud-provider
+                            load-balancer will be restricted to the specified client
+                            IPs. This field will be ignored if the cloud-provider
+                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                          items:
+                            type: string
+                          type: array
+                        ports:
+                          description: 'The list of ports that are exposed by this
+                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          items:
+                            description: ServicePort contains information on service's
+                              port.
+                            properties:
+                              appProtocol:
+                                description: "The application protocol for this port.
+                                  This is used as a hint for implementations to offer
+                                  richer behavior for protocols that they understand.
+                                  This field follows standard Kubernetes label syntax.
+                                  Valid values are either: \n * Un-prefixed protocol
+                                  names - reserved for IANA standard service names
+                                  (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+                                  \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
+                                  - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
+                                  * 'kubernetes.io/ws'  - WebSocket over cleartext
+                                  as described in https://www.rfc-editor.org/rfc/rfc6455
+                                  * 'kubernetes.io/wss' - WebSocket over TLS as described
+                                  in https://www.rfc-editor.org/rfc/rfc6455 \n * Other
+                                  protocols should use implementation-defined prefixed
+                                  names such as mycompany.com/my-custom-protocol."
+                                type: string
+                              name:
+                                description: The name of this port within the service.
+                                  This must be a DNS_LABEL. All ports within a ServiceSpec
+                                  must have unique names. When considering the endpoints
+                                  for a Service, this must match the 'name' field
+                                  in the EndpointPort. Optional if only one ServicePort
+                                  is defined on this service.
+                                type: string
+                              nodePort:
+                                description: 'The port on each node on which this
+                                  service is exposed when type is NodePort or LoadBalancer.  Usually
+                                  assigned by the system. If a value is specified,
+                                  in-range, and not in use it will be used, otherwise
+                                  the operation will fail.  If not specified, a port
+                                  will be allocated if this Service requires one.  If
+                                  this field is specified when creating a Service
+                                  which does not need it, creation will fail. This
+                                  field will be wiped when updating a Service to no
+                                  longer need it (e.g. changing type from NodePort
+                                  to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                                format: int32
+                                type: integer
+                              port:
+                                description: The port that will be exposed by this
+                                  service.
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: The IP protocol for this port. Supports
+                                  "TCP", "UDP", and "SCTP". Default is TCP.
+                                type: string
+                              targetPort:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'Number or name of the port to access
+                                  on the pods targeted by the service. Number must
+                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  If this is a string, it will be looked up as a named
+                                  port in the target Pod''s container ports. If this
+                                  is not specified, the value of the ''port'' field
+                                  is used (an identity map). This field is ignored
+                                  for services with clusterIP=None, and should be
+                                  omitted or set equal to the ''port'' field. More
+                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - port
+                          - protocol
+                          x-kubernetes-list-type: map
+                        publishNotReadyAddresses:
+                          description: publishNotReadyAddresses indicates that any
+                            agent which deals with endpoints for this Service should
+                            disregard any indications of ready/not-ready. The primary
+                            use case for setting this field is for a StatefulSet's
+                            Headless Service to propagate SRV DNS records for its
+                            Pods for the purpose of peer discovery. The Kubernetes
+                            controllers that generate Endpoints and EndpointSlice
+                            resources for Services interpret this to mean that all
+                            endpoints are considered "ready" even if the Pods themselves
+                            are not. Agents which consume only Kubernetes generated
+                            endpoints through the Endpoints or EndpointSlice resources
+                            can safely assume this behavior.
+                          type: boolean
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: 'Route service traffic to pods with label keys
+                            and values matching this selector. If empty or not present,
+                            the service is assumed to have an external process managing
+                            its endpoints, which Kubernetes will not modify. Only
+                            applies to types ClusterIP, NodePort, and LoadBalancer.
+                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sessionAffinity:
+                          description: 'Supports "ClientIP" and "None". Used to maintain
+                            session affinity. Enable client IP based session affinity.
+                            Must be ClientIP or None. Defaults to None. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                          type: string
+                        sessionAffinityConfig:
+                          description: sessionAffinityConfig contains the configurations
+                            of session affinity.
+                          properties:
+                            clientIP:
+                              description: clientIP contains the configurations of
+                                Client IP based session affinity.
+                              properties:
+                                timeoutSeconds:
+                                  description: timeoutSeconds specifies the seconds
+                                    of ClientIP type session sticky time. The value
+                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                    == "ClientIP". Default value is 10800(for 3 hours).
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        type:
+                          description: 'type determines how the Service is exposed.
+                            Defaults to ClusterIP. Valid options are ExternalName,
+                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
+                            a cluster-internal IP address for load-balancing to endpoints.
+                            Endpoints are determined by the selector or if that is
+                            not specified, by manual construction of an Endpoints
+                            object or EndpointSlice objects. If clusterIP is "None",
+                            no virtual IP is allocated and the endpoints are published
+                            as a set of endpoints rather than a virtual IP. "NodePort"
+                            builds on ClusterIP and allocates a port on every node
+                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
+                            builds on NodePort and creates an external load-balancer
+                            (if supported in the current cloud) which routes to the
+                            same endpoints as the clusterIP. "ExternalName" aliases
+                            this service to the specified externalName. Several other
+                            fields do not apply to ExternalName services. More info:
+                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-preserve-unknown-fields: true
+              storage:
+                description: storage specifies the storage of the first componentSpec,
+                  if the storage of the first componentSpec is specified, this value
+                  will be ignored.
+                properties:
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'storage size needed, more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              tenancy:
+                description: tenancy describes how pods are distributed across node.
+                  SharedNode means multiple pods may share the same node. DedicatedNode
+                  means each pod runs on their own dedicated node.
+                enum:
+                - SharedNode
+                - DedicatedNode
+                type: string
+              terminationPolicy:
+                description: Cluster termination policy. Valid values are DoNotTerminate,
+                  Halt, Delete, WipeOut. DoNotTerminate will block delete operation.
+                  Halt will delete workload resources such as statefulset, deployment
+                  workloads but keep PVCs. Delete is based on Halt and deletes PVCs.
+                  WipeOut is based on Delete and wipe out all volume snapshots and
+                  snapshot data from backup storage location.
+                enum:
+                - DoNotTerminate
+                - Halt
+                - Delete
+                - WipeOut
+                type: string
+              tolerations:
+                description: tolerations are attached to tolerate any taint that matches
+                  the triple `key,value,effect` using the matching operator `operator`.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - terminationPolicy
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              clusterDefGeneration:
+                description: clusterDefGeneration represents the generation number
+                  of ClusterDefinition referenced.
+                format: int64
+                type: integer
+              components:
+                additionalProperties:
+                  description: ClusterComponentStatus records components status.
+                  properties:
+                    consensusSetStatus:
+                      description: consensusSetStatus specifies the mapping of role
+                        and pod name.
+                      properties:
+                        followers:
+                          description: Followers status.
+                          items:
+                            properties:
+                              accessMode:
+                                default: ReadWrite
+                                description: accessMode defines what service this
+                                  pod provides.
+                                enum:
+                                - None
+                                - Readonly
+                                - ReadWrite
+                                type: string
+                              name:
+                                default: leader
+                                description: Defines the role name.
+                                type: string
+                              pod:
+                                default: Unknown
+                                description: Pod name.
+                                type: string
+                            required:
+                            - accessMode
+                            - name
+                            - pod
+                            type: object
+                          type: array
+                        leader:
+                          description: Leader status.
+                          properties:
+                            accessMode:
+                              default: ReadWrite
+                              description: accessMode defines what service this pod
+                                provides.
+                              enum:
+                              - None
+                              - Readonly
+                              - ReadWrite
+                              type: string
+                            name:
+                              default: leader
+                              description: Defines the role name.
+                              type: string
+                            pod:
+                              default: Unknown
+                              description: Pod name.
+                              type: string
+                          required:
+                          - accessMode
+                          - name
+                          - pod
+                          type: object
+                        learner:
+                          description: Learner status.
+                          properties:
+                            accessMode:
+                              default: ReadWrite
+                              description: accessMode defines what service this pod
+                                provides.
+                              enum:
+                              - None
+                              - Readonly
+                              - ReadWrite
+                              type: string
+                            name:
+                              default: leader
+                              description: Defines the role name.
+                              type: string
+                            pod:
+                              default: Unknown
+                              description: Pod name.
+                              type: string
+                          required:
+                          - accessMode
+                          - name
+                          - pod
+                          type: object
+                      required:
+                      - leader
+                      type: object
+                    membersStatus:
+                      description: members' status.
+                      items:
+                        properties:
+                          podName:
+                            default: Unknown
+                            description: PodName pod name.
+                            type: string
+                          readyWithoutPrimary:
+                            description: Is it required for rsm to have at least one
+                              primary pod to be ready.
+                            type: boolean
+                          role:
+                            properties:
+                              accessMode:
+                                default: ReadWrite
+                                description: AccessMode, what service this member
+                                  capable.
+                                enum:
+                                - None
+                                - Readonly
+                                - ReadWrite
+                                type: string
+                              canVote:
+                                default: true
+                                description: CanVote, whether this member has voting
+                                  rights
+                                type: boolean
+                              isLeader:
+                                default: false
+                                description: IsLeader, whether this member is the
+                                  leader
+                                type: boolean
+                              name:
+                                default: leader
+                                description: Name, role name.
+                                type: string
+                            required:
+                            - accessMode
+                            - name
+                            type: object
+                        required:
+                        - podName
+                        - role
+                        type: object
+                      type: array
+                    message:
+                      additionalProperties:
+                        type: string
+                      description: message records the component details message in
+                        current phase. Keys are podName or deployName or statefulSetName.
+                        The format is `ObjectKind/Name`.
+                      type: object
+                    phase:
+                      description: 'phase describes the phase of the component and
+                        the detail information of the phases are as following: Creating:
+                        `Creating` is a special `Updating` with previous phase `empty`(means
+                        "") or `Creating`. Running: component replicas > 0 and all
+                        pod specs are latest with a Running state. Updating: component
+                        replicas > 0 and has no failed pods. the component is being
+                        updated. Abnormal: component replicas > 0 but having some
+                        failed pods. the component basically works but in a fragile
+                        state. Failed: component replicas > 0 but having some failed
+                        pods. the component doesn''t work anymore. Stopping: component
+                        replicas = 0 and has terminating pods. Stopped: component
+                        replicas = 0 and all pods have been deleted. Deleting: the
+                        component is being deleted.'
+                      enum:
+                      - Creating
+                      - Running
+                      - Updating
+                      - Stopping
+                      - Stopped
+                      - Deleting
+                      - Failed
+                      - Abnormal
+                      type: string
+                    podsReady:
+                      description: podsReady checks if all pods of the component are
+                        ready.
+                      type: boolean
+                    podsReadyTime:
+                      description: podsReadyTime what time point of all component
+                        pods are ready, this time is the ready time of the last component
+                        pod.
+                      format: date-time
+                      type: string
+                    replicationSetStatus:
+                      description: replicationSetStatus specifies the mapping of role
+                        and pod name.
+                      properties:
+                        primary:
+                          description: Primary status.
+                          properties:
+                            pod:
+                              default: Unknown
+                              description: Pod name.
+                              type: string
+                          required:
+                          - pod
+                          type: object
+                        secondaries:
+                          description: Secondaries status.
+                          items:
+                            properties:
+                              pod:
+                                default: Unknown
+                                description: Pod name.
+                                type: string
+                            required:
+                            - pod
+                            type: object
+                          type: array
+                      required:
+                      - primary
+                      type: object
+                  type: object
+                description: components record the current status information of all
+                  components of the cluster.
+                type: object
+              conditions:
+                description: Describe current state of cluster API Resource, like
+                  warning.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: message describes cluster details message in current
+                  phase.
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this Cluster. It corresponds to the Cluster's generation, which
+                  is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              phase:
+                description: 'phase describes the phase of the Cluster, the detail
+                  information of the phases are as following: Creating: all components
+                  are in `Creating` phase. Running: all components are in `Running`
+                  phase, means the cluster is working well. Updating: all components
+                  are in `Creating`, `Running` or `Updating` phase, and at least one
+                  component is in `Creating` or `Updating` phase, means the cluster
+                  is doing an update. Stopping: at least one component is in `Stopping`
+                  phase, means the cluster is in a stop progress. Stopped: all components
+                  are in ''Stopped` phase, means the cluster has stopped and didn''t
+                  provide any function anymore. Failed: all components are in `Failed`
+                  phase, means the cluster is unavailable. Abnormal: some components
+                  are in `Failed` or `Abnormal` phase, means the cluster in a fragile
+                  state. troubleshoot need to be done. Deleting: the cluster is being
+                  deleted.'
+                enum:
+                - Creating
+                - Running
+                - Updating
+                - Stopping
+                - Stopped
+                - Deleting
+                - Failed
+                - Abnormal
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    categories:
+    - kubeblocks
+    - all
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  conditions:
+  - lastTransitionTime: "2024-02-14T16:12:22Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2024-02-14T16:12:22Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1alpha1


### PR DESCRIPTION
I used a CR to create an instance of this CRD when creating the postgresql cluster in kubeblocks. This also corresponds to the generated system state in the same folder.
To analyze this CRD, I looked into the `spec.versions[x].schema.openAPIV3Schema.properties.spec.properties` field in the CRD.

**Categorization**
There are 15 fields - `affinity`, `availabilityPolicy`, `backup`, `clusterDefinitionRef`, `clusterVersionRef`, `componentSpecs`, `monitor`, `network`, `replicas`, `resources`, `services`, `storage`, `tenancy`, `terminationPolicy`, and `tolerations`.

* Cluster related
`backup`, `clusterDefinitionRef`, `clusterVersionRef`, `services`, `terminationPolicy`

* Component Spec related details
`componentSpecs`, `replicas`, `resources`, `storage`

* General system configuration (kubernetes)
`affinity`, `monitor`, `network`, `availabilityPolicy`, `tenancy`, `tolerations`

**Complexity Metric**
There are several things which could be important.
Two dimensions could be the number of leaf nodes at the end of the yaml tree and the depth of each tree under each top level key. Both of these contribute to the amount of effort required in order to understand the yaml file
We would need a scaled, weighted metric that considers each of these - $\sum_i w_1 n_i {d_i}^{w_2}$ 
Here $w_1$ and $w_2$ would need to be tuned based on the use case. $n$ and $d$ represent the number of leaf nodes, and depth, respectively. 