### PR TITLE
submitting hw2

### DIFF
--- a/operators/kubeblocks-pulsar/operator_crd.yaml
+++ b/operators/kubeblocks-pulsar/operator_crd.yaml
@@ -1,0 +1,270 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2024-02-05T23:29:48Z"
+  generateName: kubeblocks-cf966665-
+  labels:
+    app.kubernetes.io/instance: kubeblocks
+    app.kubernetes.io/name: kubeblocks
+    pod-template-hash: cf966665
+  name: kubeblocks-cf966665-5tj58
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ReplicaSet
+    name: kubeblocks-cf966665
+    uid: b6573daf-4b8a-4a6f-a1d8-a6f03dbc3360
+  resourceVersion: "37234"
+  uid: b25e2554-329c-46bc-81dd-79a85148aea4
+spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: kb-controller
+            operator: In
+            values:
+            - "true"
+        weight: 100
+  containers:
+  - args:
+    - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8080
+    - --leader-elect
+    - --zap-devel=false
+    - --zap-time-encoding=iso8601
+    - --zap-encoder=console
+    - --extensions=true
+    - --apps=true
+    - --workloads=true
+    env:
+    - name: CM_NAMESPACE
+      value: default
+    - name: CM_AFFINITY
+      value: '{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"kb-controller","operator":"In","values":["true"]}]},"weight":100}]}}'
+    - name: CM_TOLERATIONS
+      value: '[{"effect":"NoSchedule","key":"kb-controller","operator":"Equal","value":"true"}]'
+    - name: KUBEBLOCKS_IMAGE_PULL_POLICY
+      value: IfNotPresent
+    - name: KUBEBLOCKS_TOOLS_IMAGE
+      value: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1
+    - name: KUBEBLOCKS_DATASCRIPT_CLIENTS_IMAGE
+      value: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.8.1
+    - name: KUBEBLOCKS_SERVICEACCOUNT_NAME
+      value: kubeblocks
+    - name: ENABLE_RBAC_MANAGER
+      value: "true"
+    - name: ADDON_JOB_TTL
+    - name: ADDON_JOB_IMAGE_PULL_POLICY
+      value: IfNotPresent
+    - name: KUBEBLOCKS_ADDON_SA_NAME
+      value: kubeblocks-addon-installer
+    - name: KUBEBLOCKS_ADDON_HELM_INSTALL_OPTIONS
+      value: --atomic --cleanup-on-fail --wait --insecure-skip-tls-verify
+    - name: DP_ENCRYPTION_KEY
+      valueFrom:
+        secretKeyRef:
+          key: dataProtectionEncryptionKey
+          name: kubeblocks-secret
+    - name: KUBE_PROVIDER
+    - name: HOST_PORT_INCLUDE_RANGES
+      value: 1025-65536
+    - name: HOST_PORT_EXCLUDE_RANGES
+      value: 6443,10250,10257,10259,2379-2380,30000-32767
+    - name: HOST_PORT_CM_NAME
+      value: kubeblocks-host-ports
+    image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.8.1
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /healthz
+        port: health
+        scheme: HTTP
+      initialDelaySeconds: 15
+      periodSeconds: 20
+      successThreshold: 1
+      timeoutSeconds: 1
+    name: manager
+    ports:
+    - containerPort: 9443
+      name: webhook-server
+      protocol: TCP
+    - containerPort: 8081
+      name: health
+      protocol: TCP
+    - containerPort: 8080
+      name: metrics
+      protocol: TCP
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /readyz
+        port: health
+        scheme: HTTP
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /etc/kubeblocks
+      name: manager-config
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-955zr
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  initContainers:
+  - command:
+    - /bin/true
+    image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1
+    imagePullPolicy: IfNotPresent
+    name: tools
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-955zr
+      readOnly: true
+  - command:
+    - /bin/true
+    image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.8.1
+    imagePullPolicy: IfNotPresent
+    name: datascript
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: kube-api-access-955zr
+      readOnly: true
+  nodeName: kind-worker3
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext:
+    runAsNonRoot: true
+  serviceAccount: kubeblocks
+  serviceAccountName: kubeblocks
+  terminationGracePeriodSeconds: 10
+  tolerations:
+  - effect: NoSchedule
+    key: kb-controller
+    operator: Equal
+    value: "true"
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - configMap:
+      defaultMode: 420
+      name: kubeblocks-manager-config
+    name: manager-config
+  - name: kube-api-access-955zr
+    projected:
+      defaultMode: 420
+      sources:
+      - serviceAccountToken:
+          expirationSeconds: 3607
+          path: token
+      - configMap:
+          items:
+          - key: ca.crt
+            path: ca.crt
+          name: kube-root-ca.crt
+      - downwardAPI:
+          items:
+          - fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+            path: namespace
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2024-02-15T00:52:27Z"
+    status: "True"
+    type: Initialized
+  - lastProbeTime: null
+    lastTransitionTime: "2024-02-15T00:52:34Z"
+    status: "True"
+    type: Ready
+  - lastProbeTime: null
+    lastTransitionTime: "2024-02-15T00:52:34Z"
+    status: "True"
+    type: ContainersReady
+  - lastProbeTime: null
+    lastTransitionTime: "2024-02-05T23:29:48Z"
+    status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - containerID: containerd://3f178f40c39cf203100da56f56ce93aaaa41b614159efccc27006c21c07cbaee
+    image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.8.1
+    imageID: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks@sha256:cd67e689401c18fadb38cefc94a39ac4052b99fa9a3e0330eca0512a3bac7e5b
+    lastState:
+      terminated:
+        containerID: containerd://71cfda1fee74e72adb43a4a949648e0b92e8fe1950b1425be55270de129bdd0b
+        exitCode: 255
+        finishedAt: "2024-02-15T00:52:18Z"
+        reason: Unknown
+        startedAt: "2024-02-14T20:20:27Z"
+    name: manager
+    ready: true
+    restartCount: 9
+    started: true
+    state:
+      running:
+        startedAt: "2024-02-15T00:52:29Z"
+  hostIP: 172.18.0.5
+  initContainerStatuses:
+  - containerID: containerd://6b1fe6738a85bb861426590504c3cc06761bf9e05370438d724b1c8c66e271d3
+    image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.1
+    imageID: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools@sha256:36e3a1205a06b6f935d6faa70fdaec91d9c6bc6ee69abeb80d4380cf381f82bd
+    lastState: {}
+    name: tools
+    ready: true
+    restartCount: 7
+    state:
+      terminated:
+        containerID: containerd://6b1fe6738a85bb861426590504c3cc06761bf9e05370438d724b1c8c66e271d3
+        exitCode: 0
+        finishedAt: "2024-02-15T00:52:26Z"
+        reason: Completed
+        startedAt: "2024-02-15T00:52:26Z"
+  - containerID: containerd://0b55d4f1f571f7bcfb5ad19ff98d3b12f0ae484c5de05dd050c13d57cb0b3949
+    image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.8.1
+    imageID: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript@sha256:7efba78a791cd28d4cf864f28201e196e14f77f9fd01950407c5c4f3faf9a938
+    lastState: {}
+    name: datascript
+    ready: true
+    restartCount: 0
+    state:
+      terminated:
+        containerID: containerd://0b55d4f1f571f7bcfb5ad19ff98d3b12f0ae484c5de05dd050c13d57cb0b3949
+        exitCode: 0
+        finishedAt: "2024-02-15T00:52:28Z"
+        reason: Completed
+        startedAt: "2024-02-15T00:52:28Z"
+  phase: Running
+  podIP: 10.244.2.2
+  podIPs:
+  - ip: 10.244.2.2
+  qosClass: BestEffort
+  startTime: "2024-02-05T23:29:48Z"

--- a/operators/kubeblocks-pulsar/pulsar_crd.yaml
+++ b/operators/kubeblocks-pulsar/pulsar_crd.yaml
@@ -1,0 +1,195 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  creationTimestamp: "2024-02-05T23:39:32Z"
+  finalizers:
+  - cluster.kubeblocks.io/finalizer
+  generation: 1
+  labels:
+    clusterdefinition.kubeblocks.io/name: pulsar
+    clusterversion.kubeblocks.io/name: pulsar-2.11.2
+  name: rose90
+  namespace: default
+  resourceVersion: "37411"
+  uid: 632e7cc5-496a-4014-b008-d291070074e6
+spec:
+  affinity:
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+  clusterDefinitionRef: pulsar
+  clusterVersionRef: pulsar-2.11.2
+  componentSpecs:
+  - componentDefRef: pulsar-broker
+    monitor: false
+    name: pulsar-broker
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: pulsar-proxy
+    monitor: false
+    name: pulsar-proxy
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: bookies
+    monitor: false
+    name: bookies
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: journal
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+    - name: ledgers
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: bookies-recovery
+    monitor: false
+    name: bookies-recovery
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: zookeeper
+    monitor: false
+    name: zookeeper
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  monitor: {}
+  resources:
+    cpu: "0"
+    memory: "0"
+  storage:
+    size: "0"
+  terminationPolicy: Delete
+status:
+  clusterDefGeneration: 2
+  components:
+    bookies:
+      phase: Updating
+      podsReady: false
+      podsReadyTime: "2024-02-14T20:20:47Z"
+    bookies-recovery:
+      phase: Running
+      podsReady: true
+      podsReadyTime: "2024-02-15T00:53:07Z"
+    pulsar-broker:
+      phase: Updating
+      podsReady: false
+      podsReadyTime: "2024-02-14T20:21:28Z"
+    pulsar-proxy:
+      phase: Updating
+      podsReady: false
+      podsReadyTime: "2024-02-14T20:21:59Z"
+    zookeeper:
+      phase: Running
+      podsReady: true
+      podsReadyTime: "2024-02-05T23:40:50Z"
+  conditions:
+  - lastTransitionTime: "2024-02-05T23:39:32Z"
+    message: 'The operator has started the provisioning of Cluster: rose90'
+    observedGeneration: 1
+    reason: PreCheckSucceed
+    status: "True"
+    type: ProvisioningStarted
+  - lastTransitionTime: "2024-02-05T23:39:32Z"
+    message: Successfully applied for resources
+    observedGeneration: 1
+    reason: ApplyResourcesSucceed
+    status: "True"
+    type: ApplyResources
+  - lastTransitionTime: "2024-02-15T00:52:58Z"
+    message: 'pods are not ready in Components: [bookies pulsar-broker pulsar-proxy],
+      refer to related component message in Cluster.status.components'
+    reason: ReplicasNotReady
+    status: "False"
+    type: ReplicasReady
+  - lastTransitionTime: "2024-02-15T00:52:58Z"
+    message: 'pods are unavailable in Components: [bookies pulsar-broker pulsar-proxy],
+      refer to related component message in Cluster.status.components'
+    reason: ComponentsNotReady
+    status: "False"
+    type: Ready
+  observedGeneration: 1
+  phase: Updating

--- a/operators/kubeblocks-pulsar/pulsar_crd_analysis.yaml
+++ b/operators/kubeblocks-pulsar/pulsar_crd_analysis.yaml
@@ -1,0 +1,213 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+# Cluster metadata
+metadata:
+  creationTimestamp: "2024-02-05T23:39:32Z"
+  finalizers:
+  - cluster.kubeblocks.io/finalizer
+  generation: 1
+  labels:
+    clusterdefinition.kubeblocks.io/name: pulsar
+    clusterversion.kubeblocks.io/name: pulsar-2.11.2
+  name: rose90
+  namespace: default
+  resourceVersion: "37411"
+  uid: 632e7cc5-496a-4014-b008-d291070074e6
+# Detailed cluster specification
+spec:
+  affinity:
+    # denotes the affinity of nodes to be spread out as preferred
+    podAntiAffinity: Preferred
+    tenancy: SharedNode
+  # Refers to the template cluster definition used for this cluster
+  clusterDefinitionRef: pulsar
+  clusterVersionRef: pulsar-2.11.2
+  # List of component specifications given in the base cluster specification that the user wants to replace
+  componentSpecs:
+    # To define changes on a component we first define a base definition reference
+  - componentDefRef: pulsar-broker
+    # Whether or not to turn on component level monitoring, off by default
+    monitor: false
+    name: pulsar-broker
+    # defines the pod disruption budget creation behavior, false means this component needs a PodDisruptionBudget
+    noCreatePDB: false
+    # basically replicas from k8s api
+    replicas: 1
+    resources:
+      # resource limits in terms of cpu and memory
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      # resource requests in terms of cpu and memory
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    # name of service account the component depends on
+    serviceAccountName: kb-rose90
+    # defines and makes changes to the PVC claims of base component
+    volumeClaimTemplates:
+      # name of PVC
+    - name: data
+      # specifications of PVC
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: pulsar-proxy
+    monitor: false
+    name: pulsar-proxy
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: bookies
+    monitor: false
+    name: bookies
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: journal
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+    - name: ledgers
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: bookies-recovery
+    monitor: false
+    name: bookies-recovery
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  - componentDefRef: zookeeper
+    monitor: false
+    name: zookeeper
+    noCreatePDB: false
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    rsmTransformPolicy: ToSts
+    serviceAccountName: kb-rose90
+    volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  monitor: {}
+  resources:
+    cpu: "0"
+    memory: "0"
+  storage:
+    size: "0"
+  # what to do when cluster is terminated, delete will get rid of the deployment workloads and the underlying PVC
+  terminationPolicy: Delete
+# Current status of cluster
+status:
+  clusterDefGeneration: 2
+  components:
+    bookies:
+      phase: Updating
+      podsReady: false
+      podsReadyTime: "2024-02-14T20:20:47Z"
+    bookies-recovery:
+      phase: Running
+      podsReady: true
+      podsReadyTime: "2024-02-15T00:53:07Z"
+    pulsar-broker:
+      phase: Updating
+      podsReady: false
+      podsReadyTime: "2024-02-14T20:21:28Z"
+    pulsar-proxy:
+      phase: Updating
+      podsReady: false
+      podsReadyTime: "2024-02-14T20:21:59Z"
+    zookeeper:
+      phase: Running
+      podsReady: true
+      podsReadyTime: "2024-02-05T23:40:50Z"
+  # describes a log of the latest state transitions, with why and when a transition happened
+  conditions:
+  - lastTransitionTime: "2024-02-05T23:39:32Z"
+    message: 'The operator has started the provisioning of Cluster: rose90'
+    observedGeneration: 1
+    reason: PreCheckSucceed
+    status: "True"
+    type: ProvisioningStarted
+  - lastTransitionTime: "2024-02-05T23:39:32Z"
+    message: Successfully applied for resources
+    observedGeneration: 1
+    reason: ApplyResourcesSucceed
+    status: "True"
+    type: ApplyResources
+  - lastTransitionTime: "2024-02-15T00:52:58Z"
+    message: 'pods are not ready in Components: [bookies pulsar-broker pulsar-proxy],
+      refer to related component message in Cluster.status.components'
+    reason: ReplicasNotReady
+    status: "False"
+    type: ReplicasReady
+  - lastTransitionTime: "2024-02-15T00:52:58Z"
+    message: 'pods are unavailable in Components: [bookies pulsar-broker pulsar-proxy],
+      refer to related component message in Cluster.status.components'
+    reason: ComponentsNotReady
+    status: "False"
+    type: Ready
+  observedGeneration: 1
+  phase: Updating


### PR DESCRIPTION
While choosing a CRD to analyze, I had trouble understanding and deciding whether I was supposed to choose my operators Pod definition, since it was actually a part of the Kubernetes API spec, or if I was supposed to use the custom resource written specifically for the API managed by my operator.

I ended up choosing the resource definitino for my deployment which was the latter.

I divided up the fields into 3 different categories as it seemed intuitive to do 

## Metadata
```yaml
# Cluster metadata
metadata:
  creationTimestamp: "2024-02-05T23:39:32Z"
  finalizers:
  - cluster.kubeblocks.io/finalizer
  generation: 1
  labels:
    clusterdefinition.kubeblocks.io/name: pulsar
    clusterversion.kubeblocks.io/name: pulsar-2.11.2
  name: rose90
  namespace: default
  resourceVersion: "37411"
  uid: 632e7cc5-496a-4014-b008-d291070074e6
``` 

## Specification
```yaml
# Detailed cluster specification
spec:
  affinity:
    # denotes the affinity of nodes to be spread out as preferred
    podAntiAffinity: Preferred
    tenancy: SharedNode
  # Refers to the template cluster definition used for this cluster
  clusterDefinitionRef: pulsar
  clusterVersionRef: pulsar-2.11.2
  # List of component specifications given in the base cluster specification that the user wants to replace
  componentSpecs:
    # To define changes on a component we first define a base definition reference
  - componentDefRef: pulsar-broker
    # Whether or not to turn on component level monitoring, off by default
    monitor: false
    name: pulsar-broker
    # defines the pod disruption budget creation behavior, false means this component needs a PodDisruptionBudget
    noCreatePDB: false
    # basically replicas from k8s api
    replicas: 1
    resources:
      # resource limits in terms of cpu and memory
      limits:
        cpu: "1"
        memory: 1Gi
      # resource requests in terms of cpu and memory
      requests:
        cpu: "1"
        memory: 1Gi
    rsmTransformPolicy: ToSts
    # name of service account the component depends on
    serviceAccountName: kb-rose90
    # defines and makes changes to the PVC claims of base component
    volumeClaimTemplates:
      # name of PVC
    - name: data
      # specifications of PVC
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 20Gi
  - componentDefRef: pulsar-proxy
    monitor: false
    name: pulsar-proxy
    noCreatePDB: false
    replicas: 1
    resources:
      limits:
        cpu: "1"
        memory: 1Gi
      requests:
        cpu: "1"
        memory: 1Gi
    rsmTransformPolicy: ToSts
    serviceAccountName: kb-rose90
    volumeClaimTemplates:
    - name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 20Gi
  - componentDefRef: bookies
    monitor: false
    name: bookies
    noCreatePDB: false
    replicas: 1
    resources:
      limits:
        cpu: "1"
        memory: 1Gi
      requests:
        cpu: "1"
        memory: 1Gi
    rsmTransformPolicy: ToSts
    serviceAccountName: kb-rose90
    volumeClaimTemplates:
    - name: journal
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 20Gi
    - name: ledgers
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 20Gi
  - componentDefRef: bookies-recovery
    monitor: false
    name: bookies-recovery
    noCreatePDB: false
    replicas: 1
    resources:
      limits:
        cpu: "1"
        memory: 1Gi
      requests:
        cpu: "1"
        memory: 1Gi
    rsmTransformPolicy: ToSts
    serviceAccountName: kb-rose90
    volumeClaimTemplates:
    - name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 20Gi
  - componentDefRef: zookeeper
    monitor: false
    name: zookeeper
    noCreatePDB: false
    replicas: 1
    resources:
      limits:
        cpu: "1"
        memory: 1Gi
      requests:
        cpu: "1"
        memory: 1Gi
    rsmTransformPolicy: ToSts
    serviceAccountName: kb-rose90
    volumeClaimTemplates:
    - name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 20Gi
  monitor: {}
  resources:
    cpu: "0"
    memory: "0"
  storage:
    size: "0"
  # what to do when cluster is terminated, delete will get rid of the deployment workloads and the underlying PVC
  terminationPolicy: Delete
```
## Status

```yaml
# Current status of cluster
status:
  clusterDefGeneration: 2
  components:
    bookies:
      phase: Updating
      podsReady: false
      podsReadyTime: "2024-02-14T20:20:47Z"
    bookies-recovery:
      phase: Running
      podsReady: true
      podsReadyTime: "2024-02-15T00:53:07Z"
    pulsar-broker:
      phase: Updating
      podsReady: false
      podsReadyTime: "2024-02-14T20:21:28Z"
    pulsar-proxy:
      phase: Updating
      podsReady: false
      podsReadyTime: "2024-02-14T20:21:59Z"
    zookeeper:
      phase: Running
      podsReady: true
      podsReadyTime: "2024-02-05T23:40:50Z"
  # describes a log of the latest state transitions, with why and when a transition happened
  conditions:
  - lastTransitionTime: "2024-02-05T23:39:32Z"
    message: 'The operator has started the provisioning of Cluster: rose90'
    observedGeneration: 1
    reason: PreCheckSucceed
    status: "True"
    type: ProvisioningStarted
  - lastTransitionTime: "2024-02-05T23:39:32Z"
    message: Successfully applied for resources
    observedGeneration: 1
    reason: ApplyResourcesSucceed
    status: "True"
    type: ApplyResources
  - lastTransitionTime: "2024-02-15T00:52:58Z"
    message: 'pods are not ready in Components: [bookies pulsar-broker pulsar-proxy],
      refer to related component message in Cluster.status.components'
    reason: ReplicasNotReady
    status: "False"
    type: ReplicasReady
  - lastTransitionTime: "2024-02-15T00:52:58Z"
    message: 'pods are unavailable in Components: [bookies pulsar-broker pulsar-proxy],
      refer to related component message in Cluster.status.components'
    reason: ComponentsNotReady
    status: "False"
    type: Ready
  observedGeneration: 1
  phase: Updating
```

## Coming up with a heuristic for complexity

The decisions that I made while coming up with this complexity metric are as follows

1. Only fields from the Specification category should be considered, since the rest can be broadly consdered as metadata
2. A hierarchy between fields should be decided on and fields should be ordered based on their impact on cluster complexity
3. After said hierarchy is constructed only the top _N_ fields should be considered to simplify.
4. Each field should be given an integer number correlated with a higher position in the hierarchy, this number will be treated as a multiplier in the case where the field contains an integer, if not it will be used as a literal to add to the running complexity heuristic sum

After examining the fields under the specification category, I came up with the following hierarchy ordered from highest to lowest importance.
- Length of componentSpecs field
- Total sum of the storage fields
- Total sum of all cpu fields
- Total sum of all memory fields
- The monitor field being True or False

And below is the integer mapping that I gave to each of these quantities
- Length of components specs field -> a multiplier of 10
- Total sum of storage fields -> a multiplier of 0.2 in terms of Gi
- Total sum of cpu fields -> a multiplier of 5 in terms of CPU cores
- Total sum of all memory fields -> a multiplier of 5 in terms of Gi
- The monitor field being True or False -> an added 10 points of complexity

So according to this my cluster CRD would get a score of : 

5 * 10 +  6 * 20 * 0.2 + 5 * 1 * 5 + 5 * 1 * 5 + 0 = 124

