### PR TITLE
HW2 Analysis of mpi-operator

### DIFF
--- a/operators/mpi-operator/mpi-operator.yaml
+++ b/operators/mpi-operator/mpi-operator.yaml
@@ -1,0 +1,8670 @@
+# --------------------------------------------------
+# - Single configuration deployment YAML for MPI-Operator
+# - Includes:
+#      CRD
+#      Namespace
+#      RBAC
+#      Controller deployment
+# --------------------------------------------------
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpijobs.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: MPIJob
+    listKind: MPIJobList
+    plural: mpijobs
+    singular: mpijob
+  scope: Namespaced
+  versions:
+  - name: v2beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              launcherCreationPolicy:
+                default: AtStartup
+                description: launcherCreationPolicy if WaitForWorkersReady, the launcher
+                  is created only after all workers are in Ready state. Defaults to
+                  AtStartup.
+                type: string
+              mpiImplementation:
+                default: OpenMPI
+                description: MPIImplementation is the MPI implementation. Options
+                  are "OpenMPI" (default), "Intel" and "MPICH".
+                enum:
+                - OpenMPI
+                - Intel
+                - MPICH
+                type: string
+              mpiReplicaSpecs:
+                additionalProperties:
+                  description: ReplicaSpec is a description of the replica
+                  properties:
+                    replicas:
+                      description: Replicas is the desired number of replicas of the
+                        given template. If unspecified, defaults to 1.
+                      format: int32
+                      type: integer
+                    restartPolicy:
+                      description: Restart policy for all replicas within the job.
+                        One of Always, OnFailure, Never and ExitCode. Default to Never.
+                      type: string
+                    template:
+                      description: Template is the object that describes the pod that
+                        will be created for this replica. RestartPolicy in PodTemplateSpec
+                        will be overide by RestartPolicy in ReplicaSpec
+                      properties:
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        spec:
+                          description: 'Specification of the desired behavior of the
+                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          properties:
+                            activeDeadlineSeconds:
+                              description: Optional duration in seconds the pod may
+                                be active on the node relative to StartTime before
+                                the system will actively try to mark it failed and
+                                kill associated containers. Value must be a positive
+                                integer.
+                              format: int64
+                              type: integer
+                            affinity:
+                              description: If specified, the pod's scheduling constraints
+                              properties:
+                                nodeAffinity:
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node matches the corresponding matchExpressions;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: An empty preferred scheduling
+                                          term matches all objects with implicit weight
+                                          0 (i.e. it's a no-op). A null preferred
+                                          scheduling term matches no objects (i.e.
+                                          is also a no-op).
+                                        properties:
+                                          preference:
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          weight:
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
+                                      properties:
+                                        nodeSelectorTerms:
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
+                                          items:
+                                            description: A null or empty node selector
+                                              term matches no objects. The requirements
+                                              of them are ANDed. The TopologySelectorTerm
+                                              type implements a subset of the NodeSelectorTerm.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          type: array
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                podAffinity:
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node has pods which matches the corresponding
+                                        podAffinityTerm; the node(s) with the highest
+                                        sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node. When there are
+                                        multiple elements, the lists of nodes corresponding
+                                        to each podAffinityTerm are intersected, i.e.
+                                        all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g. avoid putting this pod in the same
+                                    node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the anti-affinity
+                                        expressions specified by this field, but it
+                                        may choose a node that violates one or more
+                                        of the expressions. The node that is most
+                                        preferred is the one with the greatest sum
+                                        of weights, i.e. for each node that meets
+                                        all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity
+                                        expressions, etc.), compute a sum by iterating
+                                        through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which
+                                        matches the corresponding podAffinityTerm;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the anti-affinity requirements
+                                        specified by this field are not met at scheduling
+                                        time, the pod will not be scheduled onto the
+                                        node. If the anti-affinity requirements specified
+                                        by this field cease to be met at some point
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node. When
+                                        there are multiple elements, the lists of
+                                        nodes corresponding to each podAffinityTerm
+                                        are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              description: AutomountServiceAccountToken indicates
+                                whether a service account token should be automatically
+                                mounted.
+                              type: boolean
+                            containers:
+                              description: List of containers belonging to the pod.
+                                Containers cannot currently be added or removed. There
+                                must be at least one container in a Pod. Cannot be
+                                updated.
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previously defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name. This will be canonicalized
+                                                        upon output, so case-variant
+                                                        names will be understood as
+                                                        the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name. This will be canonicalized
+                                                        upon output, so case-variant
+                                                        names will be understood as
+                                                        the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    description: Resources resize policy for the container.
+                                    items:
+                                      description: ContainerResizePolicy represents
+                                        resource resize policy for the container.
+                                      properties:
+                                        resourceName:
+                                          description: 'Name of the resource to which
+                                            this resource resize policy applies. Supported
+                                            values: cpu, memory.'
+                                          type: string
+                                        restartPolicy:
+                                          description: Restart policy to apply when
+                                            specified resource is resized. If not
+                                            specified, it defaults to NotRequired.
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    properties:
+                                      claims:
+                                        description: "Claims lists the names of resources,
+                                          defined in spec.resourceClaims, that are
+                                          used by this container. \n This is an alpha
+                                          field and requires enabling the DynamicResourceAllocation
+                                          feature gate. \n This field is immutable.
+                                          It can only be set for containers."
+                                        items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: Name must match the name
+                                                of one entry in pod.spec.resourceClaims
+                                                of the Pod where this field is used.
+                                                It makes that resource available inside
+                                                a container.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. Requests cannot exceed Limits. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: The seccomp options to use by
+                                          this container. If seccomp options are provided
+                                          at both the pod & container level, the container
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used. The profile must be
+                                              preconfigured on the node to work. Must
+                                              be a descending path, relative to the
+                                              kubelet's configured seccomp profile
+                                              location. Must only be set if type is
+                                              "Localhost".
+                                            type: string
+                                          type:
+                                            description: "type indicates which kind
+                                              of seccomp profile will be applied.
+                                              Valid options are: \n Localhost - a
+                                              profile defined in a file on the node
+                                              should be used. RuntimeDefault - the
+                                              container runtime default profile should
+                                              be used. Unconfined - no profile should
+                                              be applied."
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            dnsConfig:
+                              description: Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated
+                                DNS configuration based on DNSPolicy.
+                              properties:
+                                nameservers:
+                                  description: A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers
+                                    generated from DNSPolicy. Duplicated nameservers
+                                    will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  description: A list of DNS resolver options. This
+                                    will be merged with the base options generated
+                                    from DNSPolicy. Duplicated entries will be removed.
+                                    Resolution options given in Options will override
+                                    those that appear in the base DNSPolicy.
+                                  items:
+                                    description: PodDNSConfigOption defines DNS resolver
+                                      options of a pod.
+                                    properties:
+                                      name:
+                                        description: Required.
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  description: A list of DNS search domains for host-name
+                                    lookup. This will be appended to the base search
+                                    paths generated from DNSPolicy. Duplicated search
+                                    paths will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              description: Set DNS policy for the pod. Defaults to
+                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
+                                'ClusterFirst', 'Default' or 'None'. DNS parameters
+                                given in DNSConfig will be merged with the policy
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
+                              type: string
+                            enableServiceLinks:
+                              description: 'EnableServiceLinks indicates whether information
+                                about services should be injected into pod''s environment
+                                variables, matching the syntax of Docker links. Optional:
+                                Defaults to true.'
+                              type: boolean
+                            ephemeralContainers:
+                              description: List of ephemeral containers run in this
+                                pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging.
+                                This list cannot be specified when creating a pod,
+                                and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
+                              items:
+                                description: "An EphemeralContainer is a temporary
+                                  container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral
+                                  containers have no resource or scheduling guarantees,
+                                  and they will not be restarted when they exit or
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation. \n To
+                                  add an ephemeral container, use the ephemeralcontainers
+                                  subresource of an existing Pod. Ephemeral containers
+                                  may not be removed or restarted."
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped
+                                      references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previously defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Lifecycle is not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name. This will be canonicalized
+                                                        upon output, so case-variant
+                                                        names will be understood as
+                                                        the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name. This will be canonicalized
+                                                        upon output, so case-variant
+                                                        names will be understood as
+                                                        the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the ephemeral container specified
+                                      as a DNS_LABEL. This name must be unique among
+                                      all containers, init containers and ephemeral
+                                      containers.
+                                    type: string
+                                  ports:
+                                    description: Ports are not allowed for ephemeral
+                                      containers.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    description: Resources resize policy for the container.
+                                    items:
+                                      description: ContainerResizePolicy represents
+                                        resource resize policy for the container.
+                                      properties:
+                                        resourceName:
+                                          description: 'Name of the resource to which
+                                            this resource resize policy applies. Supported
+                                            values: cpu, memory.'
+                                          type: string
+                                        restartPolicy:
+                                          description: Restart policy to apply when
+                                            specified resource is resized. If not
+                                            specified, it defaults to NotRequired.
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resources:
+                                    description: Resources are not allowed for ephemeral
+                                      containers. Ephemeral containers use spare resources
+                                      already allocated to the pod.
+                                    properties:
+                                      claims:
+                                        description: "Claims lists the names of resources,
+                                          defined in spec.resourceClaims, that are
+                                          used by this container. \n This is an alpha
+                                          field and requires enabling the DynamicResourceAllocation
+                                          feature gate. \n This field is immutable.
+                                          It can only be set for containers."
+                                        items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: Name must match the name
+                                                of one entry in pod.spec.resourceClaims
+                                                of the Pod where this field is used.
+                                                It makes that resource available inside
+                                                a container.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. Requests cannot exceed Limits. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'Optional: SecurityContext defines
+                                      the security options the ephemeral container
+                                      should be run with. If set, the fields of SecurityContext
+                                      override the equivalent fields of PodSecurityContext.'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: The seccomp options to use by
+                                          this container. If seccomp options are provided
+                                          at both the pod & container level, the container
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used. The profile must be
+                                              preconfigured on the node to work. Must
+                                              be a descending path, relative to the
+                                              kubelet's configured seccomp profile
+                                              location. Must only be set if type is
+                                              "Localhost".
+                                            type: string
+                                          type:
+                                            description: "type indicates which kind
+                                              of seccomp profile will be applied.
+                                              Valid options are: \n Localhost - a
+                                              profile defined in a file on the node
+                                              should be used. RuntimeDefault - the
+                                              container runtime default profile should
+                                              be used. Unconfined - no profile should
+                                              be applied."
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  targetContainerName:
+                                    description: "If set, the name of the container
+                                      from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces
+                                      (IPC, PID, etc) of this container. If not set
+                                      then the ephemeral container uses the namespaces
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature.
+                                      If the runtime does not support namespace targeting
+                                      then the result of setting this field is undefined."
+                                    type: string
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Subpath mounts are not allowed for
+                                      ephemeral containers. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            hostAliases:
+                              description: HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork
+                                pods.
+                              items:
+                                description: HostAlias holds the mapping between IP
+                                  and hostnames that will be injected as an entry
+                                  in the pod's hosts file.
+                                properties:
+                                  hostnames:
+                                    description: Hostnames for the above IP address.
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    description: IP address of the host file entry.
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              description: 'Use the host''s ipc namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostNetwork:
+                              description: Host networking requested for this pod.
+                                Use the host's network namespace. If this option is
+                                set, the ports that will be used must be specified.
+                                Default to false.
+                              type: boolean
+                            hostPID:
+                              description: 'Use the host''s pid namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostUsers:
+                              description: 'Use the host''s user namespace. Optional:
+                                Default to true. If set to true or not present, the
+                                pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to
+                                the host user namespace, such as loading a kernel
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod. Setting false is useful
+                                for mitigating container breakout vulnerabilities
+                                even allowing users to run their containers as root
+                                without actually having root privileges on the host.
+                                This field is alpha-level and is only honored by servers
+                                that enable the UserNamespacesSupport feature.'
+                              type: boolean
+                            hostname:
+                              description: Specifies the hostname of the Pod If not
+                                specified, the pod's hostname will be set to a system-defined
+                                value.
+                              type: string
+                            imagePullSecrets:
+                              description: 'ImagePullSecrets is an optional list of
+                                references to secrets in the same namespace to use
+                                for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual
+                                puller implementations for them to use. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              items:
+                                description: LocalObjectReference contains enough
+                                  information to let you locate the referenced object
+                                  inside the same namespace.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            initContainers:
+                              description: 'List of initialization containers belonging
+                                to the pod. Init containers are executed in order
+                                prior to containers being started. If any init container
+                                fails, the pod is considered to have failed and is
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers. Init containers may not have
+                                Lifecycle actions, Readiness probes, Liveness probes,
+                                or Startup probes. The resourceRequirements of an
+                                init container are taken into account during scheduling
+                                by finding the highest request/limit for each resource
+                                type, and then using the max of of that value or the
+                                sum of the normal containers. Limits are applied to
+                                init containers in a similar fashion. Init containers
+                                cannot currently be added or removed. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previously defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name. This will be canonicalized
+                                                        upon output, so case-variant
+                                                        names will be understood as
+                                                        the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name. This will be canonicalized
+                                                        upon output, so case-variant
+                                                        names will be understood as
+                                                        the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    description: Resources resize policy for the container.
+                                    items:
+                                      description: ContainerResizePolicy represents
+                                        resource resize policy for the container.
+                                      properties:
+                                        resourceName:
+                                          description: 'Name of the resource to which
+                                            this resource resize policy applies. Supported
+                                            values: cpu, memory.'
+                                          type: string
+                                        restartPolicy:
+                                          description: Restart policy to apply when
+                                            specified resource is resized. If not
+                                            specified, it defaults to NotRequired.
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    properties:
+                                      claims:
+                                        description: "Claims lists the names of resources,
+                                          defined in spec.resourceClaims, that are
+                                          used by this container. \n This is an alpha
+                                          field and requires enabling the DynamicResourceAllocation
+                                          feature gate. \n This field is immutable.
+                                          It can only be set for containers."
+                                        items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: Name must match the name
+                                                of one entry in pod.spec.resourceClaims
+                                                of the Pod where this field is used.
+                                                It makes that resource available inside
+                                                a container.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. Requests cannot exceed Limits. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: The seccomp options to use by
+                                          this container. If seccomp options are provided
+                                          at both the pod & container level, the container
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used. The profile must be
+                                              preconfigured on the node to work. Must
+                                              be a descending path, relative to the
+                                              kubelet's configured seccomp profile
+                                              location. Must only be set if type is
+                                              "Localhost".
+                                            type: string
+                                          type:
+                                            description: "type indicates which kind
+                                              of seccomp profile will be applied.
+                                              Valid options are: \n Localhost - a
+                                              profile defined in a file on the node
+                                              should be used. RuntimeDefault - the
+                                              container runtime default profile should
+                                              be used. Unconfined - no profile should
+                                              be applied."
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name.
+                                                    This will be canonicalized upon
+                                                    output, so case-variant names
+                                                    will be understood as the same
+                                                    header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            nodeName:
+                              description: NodeName is a request to schedule this
+                                pod onto a specific node. If it is non-empty, the
+                                scheduler simply schedules this pod onto that node,
+                                assuming that it fits resource requirements.
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: 'NodeSelector is a selector which must
+                                be true for the pod to fit on a node. Selector which
+                                must match a node''s labels for the pod to be scheduled
+                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              description: "Specifies the OS of the containers in
+                                the pod. Some pod and container fields are restricted
+                                if this is set. \n If the OS field is set to linux,
+                                the following fields must be unset: -securityContext.windowsOptions
+                                \n If the OS field is set to windows, following fields
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers
+                                - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                                - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                                - spec.securityContext.sysctls - spec.shareProcessNamespace
+                                - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                                - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
+                                - spec.containers[*].securityContext.seccompProfile
+                                - spec.containers[*].securityContext.capabilities
+                                - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                - spec.containers[*].securityContext.privileged -
+                                spec.containers[*].securityContext.allowPrivilegeEscalation
+                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                                - spec.containers[*].securityContext.runAsGroup"
+                              properties:
+                                name:
+                                  description: 'Name is the name of the operating
+                                    system. The currently supported values are linux
+                                    and windows. Additional value may be defined in
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Overhead represents the resource overhead
+                                associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time
+                                by the RuntimeClass admission controller. If the RuntimeClass
+                                admission controller is enabled, overhead must not
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set. If RuntimeClass is configured
+                                and selected in the PodSpec, Overhead will be set
+                                to the value defined in the corresponding RuntimeClass,
+                                otherwise it will remain unset and treated as zero.
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                              type: object
+                            preemptionPolicy:
+                              description: PreemptionPolicy is the Policy for preempting
+                                pods with lower priority. One of Never, PreemptLowerPriority.
+                                Defaults to PreemptLowerPriority if unset.
+                              type: string
+                            priority:
+                              description: The priority value. Various system components
+                                use this field to find the priority of the pod. When
+                                Priority Admission Controller is enabled, it prevents
+                                users from setting this field. The admission controller
+                                populates this field from PriorityClassName. The higher
+                                the value, the higher the priority.
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
+                            readinessGates:
+                              description: 'If specified, all readiness gates will
+                                be evaluated for pod readiness. A pod is ready when
+                                all its containers are ready AND all conditions specified
+                                in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              items:
+                                description: PodReadinessGate contains the reference
+                                  to a pod condition
+                                properties:
+                                  conditionType:
+                                    description: ConditionType refers to a condition
+                                      in the pod's condition list with matching type.
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                            resourceClaims:
+                              description: "ResourceClaims defines which ResourceClaims
+                                must be allocated and reserved before the Pod is allowed
+                                to start. The resources will be made available to
+                                those containers which consume them by name. \n This
+                                is an alpha field and requires enabling the DynamicResourceAllocation
+                                feature gate. \n This field is immutable."
+                              items:
+                                description: PodResourceClaim references exactly one
+                                  ResourceClaim through a ClaimSource. It adds a name
+                                  to it that uniquely identifies the ResourceClaim
+                                  inside the Pod. Containers that need access to the
+                                  ResourceClaim reference it with this name.
+                                properties:
+                                  name:
+                                    description: Name uniquely identifies this resource
+                                      claim inside the pod. This must be a DNS_LABEL.
+                                    type: string
+                                  source:
+                                    description: Source describes where to find the
+                                      ResourceClaim.
+                                    properties:
+                                      resourceClaimName:
+                                        description: ResourceClaimName is the name
+                                          of a ResourceClaim object in the same namespace
+                                          as this pod.
+                                        type: string
+                                      resourceClaimTemplateName:
+                                        description: "ResourceClaimTemplateName is
+                                          the name of a ResourceClaimTemplate object
+                                          in the same namespace as this pod. \n The
+                                          template will be used to create a new ResourceClaim,
+                                          which will be bound to this pod. When this
+                                          pod is deleted, the ResourceClaim will also
+                                          be deleted. The name of the ResourceClaim
+                                          will be <pod name>-<resource name>, where
+                                          <resource name> is the PodResourceClaim.Name.
+                                          Pod validation will reject the pod if the
+                                          concatenated name is not valid for a ResourceClaim
+                                          (e.g. too long). \n An existing ResourceClaim
+                                          with that name that is not owned by the
+                                          pod will not be used for the pod to avoid
+                                          using an unrelated resource by mistake.
+                                          Scheduling and pod startup are then blocked
+                                          until the unrelated ResourceClaim is removed.
+                                          \n This field is immutable and no changes
+                                          will be made to the corresponding ResourceClaim
+                                          by the control plane after creating the
+                                          ResourceClaim."
+                                        type: string
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            restartPolicy:
+                              description: 'Restart policy for all containers within
+                                the pod. One of Always, OnFailure, Never. In some
+                                contexts, only a subset of those values may be permitted.
+                                Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              type: string
+                            runtimeClassName:
+                              description: 'RuntimeClassName refers to a RuntimeClass
+                                object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                              type: string
+                            schedulerName:
+                              description: If specified, the pod will be dispatched
+                                by specified scheduler. If not specified, the pod
+                                will be dispatched by default scheduler.
+                              type: string
+                            schedulingGates:
+                              description: "SchedulingGates is an opaque list of values
+                                that if specified will block scheduling the pod. If
+                                schedulingGates is not empty, the pod will stay in
+                                the SchedulingGated state and the scheduler will not
+                                attempt to schedule the pod. \n SchedulingGates can
+                                only be set at pod creation time, and be removed only
+                                afterwards. \n This is a beta feature enabled by the
+                                PodSchedulingReadiness feature gate."
+                              items:
+                                description: PodSchedulingGate is associated to a
+                                  Pod to guard its scheduling.
+                                properties:
+                                  name:
+                                    description: Name of the scheduling gate. Each
+                                      scheduling gate must have a unique name field.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            securityContext:
+                              description: 'SecurityContext holds pod-level security
+                                attributes and common container settings. Optional:
+                                Defaults to empty.  See type description for default
+                                values of each field.'
+                              properties:
+                                fsGroup:
+                                  description: "A special supplemental group that
+                                    applies to all containers in a pod. Some volume
+                                    types allow the Kubelet to change the ownership
+                                    of that volume to be owned by the pod: \n 1. The
+                                    owning GID will be the FSGroup 2. The setgid bit
+                                    is set (new files created in the volume will be
+                                    owned by FSGroup) 3. The permission bits are OR'd
+                                    with rw-rw---- \n If unset, the Kubelet will not
+                                    modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows."
+                                  format: int64
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  description: 'fsGroupChangePolicy defines behavior
+                                    of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will
+                                    only apply to volume types which support fsGroup
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
+                                  type: string
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the
+                                    value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    all containers. If unspecified, the container
+                                    runtime will allocate a random SELinux context
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by the containers
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: "type indicates which kind of seccomp
+                                        profile will be applied. Valid options are:
+                                        \n Localhost - a profile defined in a file
+                                        on the node should be used. RuntimeDefault
+                                        - the container runtime default profile should
+                                        be used. Unconfined - no profile should be
+                                        applied."
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                supplementalGroups:
+                                  description: A list of groups applied to the first
+                                    process run in each container, in addition to
+                                    the container's primary GID, the fsGroup (if specified),
+                                    and group memberships defined in the container
+                                    image for the uid of the container process. If
+                                    unspecified, no additional groups are added to
+                                    any container. Note that group memberships defined
+                                    in the container image for the uid of the container
+                                    process are still effective, even if they are
+                                    not included in this list. Note that this field
+                                    cannot be set when spec.os.name is windows.
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                sysctls:
+                                  description: Sysctls hold a list of namespaced sysctls
+                                    used for the pod. Pods with unsupported sysctls
+                                    (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  items:
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
+                                    properties:
+                                      name:
+                                        description: Name of a property to set
+                                        type: string
+                                      value:
+                                        description: Value of a property to set
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: 'DeprecatedServiceAccount is a depreciated
+                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                instead.'
+                              type: string
+                            serviceAccountName:
+                              description: 'ServiceAccountName is the name of the
+                                ServiceAccount to use to run this pod. More info:
+                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              type: string
+                            setHostnameAsFQDN:
+                              description: If true the pod's hostname will be configured
+                                as the pod's FQDN, rather than the leaf name (the
+                                default). In Linux containers, this means setting
+                                the FQDN in the hostname field of the kernel (the
+                                nodename field of struct utsname). In Windows containers,
+                                this means setting the registry value of hostname
+                                for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
+                                to FQDN. If a pod does not have FQDN, this has no
+                                effect. Default to false.
+                              type: boolean
+                            shareProcessNamespace:
+                              description: 'Share a single process namespace between
+                                all of the containers in a pod. When this is set containers
+                                will be able to view and signal processes from other
+                                containers in the same pod, and the first process
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
+                              type: boolean
+                            subdomain:
+                              description: If specified, the fully qualified Pod hostname
+                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                domain>". If not specified, the pod will not have
+                                a domainname at all.
+                              type: string
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully. May be decreased in delete
+                                request. Value must be non-negative integer. The value
+                                zero indicates stop immediately via the kill signal
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead. The
+                                grace period is the duration in seconds after the
+                                processes running in the pod are sent a termination
+                                signal and the time when the processes are forcibly
+                                halted with a kill signal. Set this value longer than
+                                the expected cleanup time for your process. Defaults
+                                to 30 seconds.
+                              format: int64
+                              type: integer
+                            tolerations:
+                              description: If specified, the pod's tolerations.
+                              items:
+                                description: The pod this Toleration is attached to
+                                  tolerates any taint that matches the triple <key,value,effect>
+                                  using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect indicates the taint effect
+                                      to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule,
+                                      PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration
+                                      applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists;
+                                      this combination means to match all values and
+                                      all keys.
+                                    type: string
+                                  operator:
+                                    description: Operator represents a key's relationship
+                                      to the value. Valid operators are Exists and
+                                      Equal. Defaults to Equal. Exists is equivalent
+                                      to wildcard for value, so that a pod can tolerate
+                                      all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the
+                                      period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is
+                                      ignored) tolerates the taint. By default, it
+                                      is not set, which means tolerate the taint forever
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration
+                                      matches to. If the operator is Exists, the value
+                                      should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              description: TopologySpreadConstraints describes how
+                                a group of pods ought to spread across topology domains.
+                                Scheduler will schedule pods in a way which abides
+                                by the constraints. All topologySpreadConstraints
+                                are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: LabelSelector is used to find matching
+                                      pods. Pods that match this label selector are
+                                      counted to determine the number of pods in their
+                                      corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: "MatchLabelKeys is a set of pod label
+                                      keys to select the pods over which spreading
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. The
+                                      same key is forbidden to exist in both MatchLabelKeys
+                                      and LabelSelector. MatchLabelKeys cannot be
+                                      set when LabelSelector isn't set. Keys that
+                                      don't exist in the incoming pod labels will
+                                      be ignored. A null or empty list means only
+                                      match against labelSelector. \n This is a beta
+                                      field and requires the MatchLabelKeysInPodTopologySpread
+                                      feature gate to be enabled (enabled by default)."
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  maxSkew:
+                                    description: 'MaxSkew describes the degree to
+                                      which pods may be unevenly distributed. When
+                                      `whenUnsatisfiable=DoNotSchedule`, it is the
+                                      maximum permitted difference between the number
+                                      of matching pods in the target topology and
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
+                                      cluster, MaxSkew is set to 1, and pods with
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      it is used to give higher precedence to topologies
+                                      that satisfy it. It''s a required field. Default
+                                      value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: "MinDomains indicates a minimum number
+                                      of eligible domains. When the number of eligible
+                                      domains with matching topology keys is less
+                                      than minDomains, Pod Topology Spread treats
+                                      \"global minimum\" as 0, and then the calculation
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling. As a result, when
+                                      the number of eligible domains is less than
+                                      minDomains, scheduler won't schedule more than
+                                      maxSkew Pods to those domains. If value is nil,
+                                      the constraint behaves as if MinDomains is equal
+                                      to 1. Valid values are integers greater than
+                                      0. When value is not nil, WhenUnsatisfiable
+                                      must be DoNotSchedule. \n For example, in a
+                                      3-zone cluster, MaxSkew is set to 2, MinDomains
+                                      is set to 5 and pods with the same labelSelector
+                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
+                                      \ P P  |  P P  |  P P  | The number of domains
+                                      is less than 5(MinDomains), so \"global minimum\"
+                                      is treated as 0. In this situation, new pod
+                                      with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new
+                                      Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew. \n This is a beta field
+                                      and requires the MinDomainsInPodTopologySpread
+                                      feature gate to be enabled (enabled by default)."
+                                    format: int32
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    description: "NodeAffinityPolicy indicates how
+                                      we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options
+                                      are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                                      are included in the calculations. - Ignore:
+                                      nodeAffinity/nodeSelector are ignored. All nodes
+                                      are included in the calculations. \n If this
+                                      value is nil, the behavior is equivalent to
+                                      the Honor policy. This is a beta-level feature
+                                      default enabled by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: "NodeTaintsPolicy indicates how we
+                                      will treat node taints when calculating pod
+                                      topology spread skew. Options are: - Honor:
+                                      nodes without taints, along with tainted nodes
+                                      for which the incoming pod has a toleration,
+                                      are included. - Ignore: node taints are ignored.
+                                      All nodes are included. \n If this value is
+                                      nil, the behavior is equivalent to the Ignore
+                                      policy. This is a beta-level feature default
+                                      enabled by the NodeInclusionPolicyInPodTopologySpread
+                                      feature flag."
+                                    type: string
+                                  topologyKey:
+                                    description: TopologyKey is the key of node labels.
+                                      Nodes that have a label with this key and identical
+                                      values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket",
+                                      and try to put balanced number of pods into
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes meet the requirements
+                                      of nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: 'WhenUnsatisfiable indicates how
+                                      to deal with a pod if it doesn''t satisfy the
+                                      spread constraint. - DoNotSchedule (default)
+                                      tells the scheduler not to schedule it. - ScheduleAnyway
+                                      tells the scheduler to schedule the pod in any
+                                      location, but giving higher precedence to topologies
+                                      that would help reduce the skew. A constraint
+                                      is considered "Unsatisfiable" for an incoming
+                                      pod if and only if every possible node assignment
+                                      for that pod would violate "MaxSkew" on some
+                                      topology. For example, in a 3-zone cluster,
+                                      MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1: | zone1 | zone2
+                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                                      is set to DoNotSchedule, incoming pod can only
+                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                                      as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can
+                                      still be imbalanced, but scheduler won''t make
+                                      it *more* imbalanced. It''s a required field.'
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
+                            volumes:
+                              description: 'List of volumes that can be mounted by
+                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              items:
+                                description: Volume represents a named volume in a
+                                  pod that may be accessed by any container in the
+                                  pod.
+                                properties:
+                                  awsElasticBlockStore:
+                                    description: 'awsElasticBlockStore represents
+                                      an AWS Disk resource that is attached to a kubelet''s
+                                      host machine and then exposed to the pod. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
+                                        type: string
+                                      partition:
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        type: boolean
+                                      volumeID:
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  azureDisk:
+                                    description: azureDisk represents an Azure Data
+                                      Disk mount on the host and bind mount to the
+                                      pod.
+                                    properties:
+                                      cachingMode:
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
+                                        type: string
+                                      diskName:
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
+                                        type: string
+                                      diskURI:
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
+                                        type: string
+                                      fsType:
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      kind:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
+                                          single blob disk per storage account  Managed:
+                                          azure managed data disk (only in managed
+                                          availability set). defaults to shared'
+                                        type: string
+                                      readOnly:
+                                        description: readOnly Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                    required:
+                                    - diskName
+                                    - diskURI
+                                    type: object
+                                  azureFile:
+                                    description: azureFile represents an Azure File
+                                      Service mount on the host and bind mount to
+                                      the pod.
+                                    properties:
+                                      readOnly:
+                                        description: readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      secretName:
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
+                                        type: string
+                                      shareName:
+                                        description: shareName is the azure share
+                                          Name
+                                        type: string
+                                    required:
+                                    - secretName
+                                    - shareName
+                                    type: object
+                                  cephfs:
+                                    description: cephFS represents a Ceph FS mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      monitors:
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        items:
+                                          type: string
+                                        type: array
+                                      path:
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: boolean
+                                      secretFile:
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: string
+                                      secretRef:
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      user:
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: string
+                                    required:
+                                    - monitors
+                                    type: object
+                                  cinder:
+                                    description: 'cinder represents a cinder volume
+                                      attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      volumeID:
+                                        description: 'volumeID used to identify the
+                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  configMap:
+                                    description: configMap represents a configMap
+                                      that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  csi:
+                                    description: csi (Container Storage Interface)
+                                      represents ephemeral storage that is handled
+                                      by certain external CSI drivers (Beta feature).
+                                    properties:
+                                      driver:
+                                        description: driver is the name of the CSI
+                                          driver that handles this volume. Consult
+                                          with your admin for the correct name as
+                                          registered in the cluster.
+                                        type: string
+                                      fsType:
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
+                                        type: string
+                                      nodePublishSecretRef:
+                                        description: nodePublishSecretRef is a reference
+                                          to the secret object containing sensitive
+                                          information to pass to the CSI driver to
+                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
+                                          calls. This field is optional, and  may
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      readOnly:
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: volumeAttributes stores driver-specific
+                                          properties that are passed to the CSI driver.
+                                          Consult your driver's documentation for
+                                          supported values.
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI represents downward API
+                                      about the pod that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits to use on
+                                          created files by default. Must be a Optional:
+                                          mode bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: Items is a list of downward API
+                                          volume file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  emptyDir:
+                                    description: 'emptyDir represents a temporary
+                                      directory that shares a pod''s lifetime. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    properties:
+                                      medium:
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  ephemeral:
+                                    description: "ephemeral represents a volume that
+                                      is handled by a cluster storage driver. The
+                                      volume's lifecycle is tied to the pod that defines
+                                      it - it will be created before the pod starts,
+                                      and deleted when the pod is removed. \n Use
+                                      this if: a) the volume is only needed while
+                                      the pod runs, b) features of normal volumes
+                                      like restoring from snapshot or capacity tracking
+                                      are needed, c) the storage driver is specified
+                                      through a storage class, and d) the storage
+                                      driver supports dynamic volume provisioning
+                                      through a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more information on the connection between
+                                      this volume type and PersistentVolumeClaim).
+                                      \n Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than
+                                      the lifecycle of an individual pod. \n Use CSI
+                                      for light-weight local ephemeral volumes if
+                                      the CSI driver is meant to be used that way
+                                      - see the documentation of the driver for more
+                                      information. \n A pod can use both types of
+                                      ephemeral volumes and persistent volumes at
+                                      the same time."
+                                    properties:
+                                      volumeClaimTemplate:
+                                        description: "Will be used to create a stand-alone
+                                          PVC to provision the volume. The pod in
+                                          which this EphemeralVolumeSource is embedded
+                                          will be the owner of the PVC, i.e. the PVC
+                                          will be deleted together with the pod.  The
+                                          name of the PVC will be `<pod name>-<volume
+                                          name>` where `<volume name>` is the name
+                                          from the `PodSpec.Volumes` array entry.
+                                          Pod validation will reject the pod if the
+                                          concatenated name is not valid for a PVC
+                                          (for example, too long). \n An existing
+                                          PVC with that name that is not owned by
+                                          the pod will *not* be used for the pod to
+                                          avoid using an unrelated volume by mistake.
+                                          Starting the pod is then blocked until the
+                                          unrelated PVC is removed. If such a pre-created
+                                          PVC is meant to be used by the pod, the
+                                          PVC has to updated with an owner reference
+                                          to the pod once the pod exists. Normally
+                                          this should not be necessary, but it may
+                                          be useful when manually reconstructing a
+                                          broken cluster. \n This field is read-only
+                                          and no changes will be made by Kubernetes
+                                          to the PVC after it has been created. \n
+                                          Required, must not be nil."
+                                        properties:
+                                          metadata:
+                                            description: May contain labels and annotations
+                                              that will be copied into the PVC when
+                                              creating it. No other fields are allowed
+                                              and will be rejected during validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                            type: object
+                                          spec:
+                                            description: The specification for the
+                                              PersistentVolumeClaim. The entire content
+                                              is copied unchanged into the PVC that
+                                              gets created from this template. The
+                                              same fields as in a PersistentVolumeClaim
+                                              are also valid here.
+                                            properties:
+                                              accessModes:
+                                                description: 'accessModes contains
+                                                  the desired access modes the volume
+                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                items:
+                                                  type: string
+                                                type: array
+                                              dataSource:
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. When
+                                                  the AnyVolumeDataSource feature
+                                                  gate is enabled, dataSource contents
+                                                  will be copied to dataSourceRef,
+                                                  and dataSourceRef contents will
+                                                  be copied to dataSource when dataSourceRef.namespace
+                                                  is not specified. If the namespace
+                                                  is specified, then dataSourceRef
+                                                  will not be copied to dataSource.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              dataSourceRef:
+                                                description: 'dataSourceRef specifies
+                                                  the object from which to populate
+                                                  the volume with data, if a non-empty
+                                                  volume is desired. This may be any
+                                                  object from a non-empty API group
+                                                  (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the dataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, when namespace isn''t
+                                                  specified in dataSourceRef, both
+                                                  fields (dataSource and dataSourceRef)
+                                                  will be set to the same value automatically
+                                                  if one of them is empty and the
+                                                  other is non-empty. When namespace
+                                                  is specified in dataSourceRef, dataSource
+                                                  isn''t set to the same value and
+                                                  must be empty. There are three important
+                                                  differences between dataSource and
+                                                  dataSourceRef: * While dataSource
+                                                  only allows two specific types of
+                                                  objects, dataSourceRef allows any
+                                                  non-core object, as well as PersistentVolumeClaim
+                                                  objects. * While dataSource ignores
+                                                  disallowed values (dropping them),
+                                                  dataSourceRef preserves all values,
+                                                  and generates an error if a disallowed
+                                                  value is specified. * While dataSource
+                                                  only allows local objects, dataSourceRef
+                                                  allows objects in any namespaces.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled. (Alpha) Using
+                                                  the namespace field of dataSourceRef
+                                                  requires the CrossNamespaceVolumeDataSource
+                                                  feature gate to be enabled.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                  namespace:
+                                                    description: Namespace is the
+                                                      namespace of resource being
+                                                      referenced Note that when a
+                                                      namespace is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                                      object is required in the referent
+                                                      namespace to allow that namespace's
+                                                      owner to accept the reference.
+                                                      See the ReferenceGrant documentation
+                                                      for details. (Alpha) This field
+                                                      requires the CrossNamespaceVolumeDataSource
+                                                      feature gate to be enabled.
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              resources:
+                                                description: 'resources represents
+                                                  the minimum resources the volume
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                properties:
+                                                  claims:
+                                                    description: "Claims lists the
+                                                      names of resources, defined
+                                                      in spec.resourceClaims, that
+                                                      are used by this container.
+                                                      \n This is an alpha field and
+                                                      requires enabling the DynamicResourceAllocation
+                                                      feature gate. \n This field
+                                                      is immutable. It can only be
+                                                      set for containers."
+                                                    items:
+                                                      description: ResourceClaim references
+                                                        one entry in PodSpec.ResourceClaims.
+                                                      properties:
+                                                        name:
+                                                          description: Name must match
+                                                            the name of one entry
+                                                            in pod.spec.resourceClaims
+                                                            of the Pod where this
+                                                            field is used. It makes
+                                                            that resource available
+                                                            inside a container.
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: 'Limits describes
+                                                      the maximum amount of compute
+                                                      resources allowed. More info:
+                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: 'Requests describes
+                                                      the minimum amount of compute
+                                                      resources required. If Requests
+                                                      is omitted for a container,
+                                                      it defaults to Limits if that
+                                                      is explicitly specified, otherwise
+                                                      to an implementation-defined
+                                                      value. Requests cannot exceed
+                                                      Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              storageClassName:
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                type: string
+                                              volumeMode:
+                                                description: volumeMode defines what
+                                                  type of volume is required by the
+                                                  claim. Value of Filesystem is implied
+                                                  when not included in claim spec.
+                                                type: string
+                                              volumeName:
+                                                description: volumeName is the binding
+                                                  reference to the PersistentVolume
+                                                  backing this claim.
+                                                type: string
+                                            type: object
+                                        required:
+                                        - spec
+                                        type: object
+                                    type: object
+                                  fc:
+                                    description: fc represents a Fibre Channel resource
+                                      that is attached to a kubelet's host machine
+                                      and then exposed to the pod.
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified. TODO: how do we prevent
+                                          errors in the filesystem from compromising
+                                          the machine'
+                                        type: string
+                                      lun:
+                                        description: 'lun is Optional: FC target lun
+                                          number'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
+                                        type: boolean
+                                      targetWWNs:
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
+                                        items:
+                                          type: string
+                                        type: array
+                                      wwids:
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  flexVolume:
+                                    description: flexVolume represents a generic volume
+                                      resource that is provisioned/attached using
+                                      an exec based plugin.
+                                    properties:
+                                      driver:
+                                        description: driver is the name of the driver
+                                          to use for this volume.
+                                        type: string
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
+                                        type: object
+                                      readOnly:
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - driver
+                                    type: object
+                                  flocker:
+                                    description: flocker represents a Flocker volume
+                                      attached to a kubelet's host machine. This depends
+                                      on the Flocker control service being running
+                                    properties:
+                                      datasetName:
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
+                                        type: string
+                                      datasetUUID:
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    description: 'gcePersistentDisk represents a GCE
+                                      Disk resource that is attached to a kubelet''s
+                                      host machine and then exposed to the pod. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
+                                        type: string
+                                      partition:
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        format: int32
+                                        type: integer
+                                      pdName:
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        type: boolean
+                                    required:
+                                    - pdName
+                                    type: object
+                                  gitRepo:
+                                    description: 'gitRepo represents a git repository
+                                      at a particular revision. DEPRECATED: GitRepo
+                                      is deprecated. To provision a container with
+                                      a git repo, mount an EmptyDir into an InitContainer
+                                      that clones the repo using git, then mount the
+                                      EmptyDir into the Pod''s container.'
+                                    properties:
+                                      directory:
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
+                                        type: string
+                                      repository:
+                                        description: repository is the URL
+                                        type: string
+                                      revision:
+                                        description: revision is the commit hash for
+                                          the specified revision.
+                                        type: string
+                                    required:
+                                    - repository
+                                    type: object
+                                  glusterfs:
+                                    description: 'glusterfs represents a Glusterfs
+                                      mount on the host that shares a pod''s lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    properties:
+                                      endpoints:
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: string
+                                      path:
+                                        description: 'path is the Glusterfs volume
+                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          Glusterfs volume to be mounted with read-only
+                                          permissions. Defaults to false. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: boolean
+                                    required:
+                                    - endpoints
+                                    - path
+                                    type: object
+                                  hostPath:
+                                    description: 'hostPath represents a pre-existing
+                                      file or directory on the host machine that is
+                                      directly exposed to the container. This is generally
+                                      used for system agents or other privileged things
+                                      that are allowed to see the host machine. Most
+                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      --- TODO(jonesdl) We need to restrict who can
+                                      use host directory mounts and who can/can not
+                                      mount host directories as read/write.'
+                                    properties:
+                                      path:
+                                        description: 'path of the directory on the
+                                          host. If the path is a symlink, it will
+                                          follow the link to the real path. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        type: string
+                                      type:
+                                        description: 'type for HostPath Volume Defaults
+                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  iscsi:
+                                    description: 'iscsi represents an ISCSI Disk resource
+                                      that is attached to a kubelet''s host machine
+                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    properties:
+                                      chapAuthDiscovery:
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
+                                        type: boolean
+                                      chapAuthSession:
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
+                                        type: boolean
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
+                                        type: string
+                                      initiatorName:
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
+                                        type: string
+                                      iqn:
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
+                                        type: string
+                                      iscsiInterface:
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
+                                        type: string
+                                      lun:
+                                        description: lun represents iSCSI Target Lun
+                                          number.
+                                        format: int32
+                                        type: integer
+                                      portals:
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
+                                        items:
+                                          type: string
+                                        type: array
+                                      readOnly:
+                                        description: readOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      targetPortal:
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
+                                        type: string
+                                    required:
+                                    - iqn
+                                    - lun
+                                    - targetPortal
+                                    type: object
+                                  name:
+                                    description: 'name of the volume. Must be a DNS_LABEL
+                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  nfs:
+                                    description: 'nfs represents an NFS mount on the
+                                      host that shares a pod''s lifetime More info:
+                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    properties:
+                                      path:
+                                        description: 'path that is exported by the
+                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          NFS export to be mounted with read-only
+                                          permissions. Defaults to false. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: boolean
+                                      server:
+                                        description: 'server is the hostname or IP
+                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: string
+                                    required:
+                                    - path
+                                    - server
+                                    type: object
+                                  persistentVolumeClaim:
+                                    description: 'persistentVolumeClaimVolumeSource
+                                      represents a reference to a PersistentVolumeClaim
+                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    properties:
+                                      claimName:
+                                        description: 'claimName is the name of a PersistentVolumeClaim
+                                          in the same namespace as the pod using this
+                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        type: string
+                                      readOnly:
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  photonPersistentDisk:
+                                    description: photonPersistentDisk represents a
+                                      PhotonController persistent disk attached and
+                                      mounted on kubelets host machine
+                                    properties:
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      pdID:
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
+                                        type: string
+                                    required:
+                                    - pdID
+                                    type: object
+                                  portworxVolume:
+                                    description: portworxVolume represents a portworx
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: fSType represents the filesystem
+                                          type to mount Must be a filesystem type
+                                          supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to
+                                          be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      volumeID:
+                                        description: volumeID uniquely identifies
+                                          a Portworx volume
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  projected:
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
+                                    properties:
+                                      defaultMode:
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      sources:
+                                        description: sources is the list of volume
+                                          projections
+                                        items:
+                                          description: Projection that may be projected
+                                            along with other supported volume types
+                                          properties:
+                                            configMap:
+                                              description: configMap information about
+                                                the configMap data to project
+                                              properties:
+                                                items:
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
+                                                    the listed keys will be projected
+                                                    into the specified paths, and
+                                                    unlisted keys will not be present.
+                                                    If a key is specified which is
+                                                    not present in the ConfigMap,
+                                                    the volume setup will error unless
+                                                    it is marked optional. Paths must
+                                                    be relative and may not contain
+                                                    the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
+                                                          on this file. Must be an
+                                                          octal value between 0000
+                                                          and 0777 or a decimal value
+                                                          between 0 and 511. YAML
+                                                          accepts both octal and decimal
+                                                          values, JSON requires decimal
+                                                          values for mode bits. If
+                                                          not specified, the volume
+                                                          defaultMode will be used.
+                                                          This might be in conflict
+                                                          with other options that
+                                                          affect the file mode, like
+                                                          fsGroup, and the result
+                                                          can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: path is the relative
+                                                          path of the file to map
+                                                          the key to. May not be an
+                                                          absolute path. May not contain
+                                                          the path element '..'. May
+                                                          not start with the string
+                                                          '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            downwardAPI:
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
+                                              properties:
+                                                items:
+                                                  description: Items is a list of
+                                                    DownwardAPIVolume file
+                                                  items:
+                                                    description: DownwardAPIVolumeFile
+                                                      represents information to create
+                                                      the file containing the pod
+                                                      field
+                                                    properties:
+                                                      fieldRef:
+                                                        description: 'Required: Selects
+                                                          a field of the pod: only
+                                                          annotations, labels, name
+                                                          and namespace are supported.'
+                                                        properties:
+                                                          apiVersion:
+                                                            description: Version of
+                                                              the schema the FieldPath
+                                                              is written in terms
+                                                              of, defaults to "v1".
+                                                            type: string
+                                                          fieldPath:
+                                                            description: Path of the
+                                                              field to select in the
+                                                              specified API version.
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      mode:
+                                                        description: 'Optional: mode
+                                                          bits used to set permissions
+                                                          on this file, must be an
+                                                          octal value between 0000
+                                                          and 0777 or a decimal value
+                                                          between 0 and 511. YAML
+                                                          accepts both octal and decimal
+                                                          values, JSON requires decimal
+                                                          values for mode bits. If
+                                                          not specified, the volume
+                                                          defaultMode will be used.
+                                                          This might be in conflict
+                                                          with other options that
+                                                          affect the file mode, like
+                                                          fsGroup, and the result
+                                                          can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: 'Required: Path
+                                                          is  the relative path name
+                                                          of the file to be created.
+                                                          Must not be absolute or
+                                                          contain the ''..'' path.
+                                                          Must be utf-8 encoded. The
+                                                          first item of the relative
+                                                          path must not start with
+                                                          ''..'''
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        description: 'Selects a resource
+                                                          of the container: only resources
+                                                          limits and requests (limits.cpu,
+                                                          limits.memory, requests.cpu
+                                                          and requests.memory) are
+                                                          currently supported.'
+                                                        properties:
+                                                          containerName:
+                                                            description: 'Container
+                                                              name: required for volumes,
+                                                              optional for env vars'
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            description: Specifies
+                                                              the output format of
+                                                              the exposed resources,
+                                                              defaults to "1"
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            description: 'Required:
+                                                              resource to select'
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            secret:
+                                              description: secret information about
+                                                the secret data to project
+                                              properties:
+                                                items:
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
+                                                    the listed keys will be projected
+                                                    into the specified paths, and
+                                                    unlisted keys will not be present.
+                                                    If a key is specified which is
+                                                    not present in the Secret, the
+                                                    volume setup will error unless
+                                                    it is marked optional. Paths must
+                                                    be relative and may not contain
+                                                    the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
+                                                          on this file. Must be an
+                                                          octal value between 0000
+                                                          and 0777 or a decimal value
+                                                          between 0 and 511. YAML
+                                                          accepts both octal and decimal
+                                                          values, JSON requires decimal
+                                                          values for mode bits. If
+                                                          not specified, the volume
+                                                          defaultMode will be used.
+                                                          This might be in conflict
+                                                          with other options that
+                                                          affect the file mode, like
+                                                          fsGroup, and the result
+                                                          can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: path is the relative
+                                                          path of the file to map
+                                                          the key to. May not be an
+                                                          absolute path. May not contain
+                                                          the path element '..'. May
+                                                          not start with the string
+                                                          '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            serviceAccountToken:
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
+                                                data to project
+                                              properties:
+                                                audience:
+                                                  description: audience is the intended
+                                                    audience of the token. A recipient
+                                                    of a token must identify itself
+                                                    with an identifier specified in
+                                                    the audience of the token, and
+                                                    otherwise should reject the token.
+                                                    The audience defaults to the identifier
+                                                    of the apiserver.
+                                                  type: string
+                                                expirationSeconds:
+                                                  description: expirationSeconds is
+                                                    the requested duration of validity
+                                                    of the service account token.
+                                                    As the token approaches expiration,
+                                                    the kubelet volume plugin will
+                                                    proactively rotate the service
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
+                                                  format: int64
+                                                  type: integer
+                                                path:
+                                                  description: path is the path relative
+                                                    to the mount point of the file
+                                                    to project the token into.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                          type: object
+                                        type: array
+                                    type: object
+                                  quobyte:
+                                    description: quobyte represents a Quobyte mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      group:
+                                        description: group to map volume access to
+                                          Default is no group
+                                        type: string
+                                      readOnly:
+                                        description: readOnly here will force the
+                                          Quobyte volume to be mounted with read-only
+                                          permissions. Defaults to false.
+                                        type: boolean
+                                      registry:
+                                        description: registry represents a single
+                                          or multiple Quobyte Registry services specified
+                                          as a string as host:port pair (multiple
+                                          entries are separated with commas) which
+                                          acts as the central registry for volumes
+                                        type: string
+                                      tenant:
+                                        description: tenant owning the given Quobyte
+                                          volume in the Backend Used with dynamically
+                                          provisioned Quobyte volumes, value is set
+                                          by the plugin
+                                        type: string
+                                      user:
+                                        description: user to map volume access to
+                                          Defaults to serivceaccount user
+                                        type: string
+                                      volume:
+                                        description: volume is a string that references
+                                          an already created Quobyte volume by name.
+                                        type: string
+                                    required:
+                                    - registry
+                                    - volume
+                                    type: object
+                                  rbd:
+                                    description: 'rbd represents a Rados Block Device
+                                      mount on the host that shares a pod''s lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem
+                                          from compromising the machine'
+                                        type: string
+                                      image:
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      keyring:
+                                        description: 'keyring is the path to key ring
+                                          for RBDUser. Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      monitors:
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        items:
+                                          type: string
+                                        type: array
+                                      pool:
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'secretRef is name of the authentication
+                                          secret for RBDUser. If provided overrides
+                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      user:
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                    required:
+                                    - image
+                                    - monitors
+                                    type: object
+                                  scaleIO:
+                                    description: scaleIO represents a ScaleIO persistent
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
+                                        type: string
+                                      gateway:
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
+                                        type: string
+                                      protectionDomain:
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
+                                        type: string
+                                      readOnly:
+                                        description: readOnly Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef references to the secret
+                                          for ScaleIO user and other sensitive information.
+                                          If this is not provided, Login operation
+                                          will fail.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      sslEnabled:
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
+                                        type: boolean
+                                      storageMode:
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
+                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        type: string
+                                      storagePool:
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
+                                        type: string
+                                      system:
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
+                                        type: string
+                                    required:
+                                    - gateway
+                                    - secretRef
+                                    - system
+                                    type: object
+                                  secret:
+                                    description: 'secret represents a secret that
+                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    properties:
+                                      defaultMode:
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: items If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                  storageos:
+                                    description: storageOS represents a StorageOS
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef specifies the secret
+                                          to use for obtaining the StorageOS API credentials.  If
+                                          not specified, default values will be attempted.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      volumeName:
+                                        description: volumeName is the human-readable
+                                          name of the StorageOS volume.  Volume names
+                                          are only unique within a namespace.
+                                        type: string
+                                      volumeNamespace:
+                                        description: volumeNamespace specifies the
+                                          scope of the volume within StorageOS.  If
+                                          no namespace is specified then the Pod's
+                                          namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within
+                                          StorageOS for tighter integration. Set VolumeName
+                                          to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS. Namespaces that do not
+                                          pre-exist within StorageOS will be created.
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    description: vsphereVolume represents a vSphere
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      storagePolicyID:
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
+                                        type: string
+                                      storagePolicyName:
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
+                                        type: string
+                                      volumePath:
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
+                                        type: string
+                                    required:
+                                    - volumePath
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          required:
+                          - containers
+                          type: object
+                      type: object
+                  type: object
+                description: MPIReplicaSpecs contains maps from `MPIReplicaType` to
+                  `ReplicaSpec` that specify the MPI replicas to run.
+                type: object
+              runPolicy:
+                description: RunPolicy encapsulates various runtime policies of the
+                  job.
+                properties:
+                  activeDeadlineSeconds:
+                    description: Specifies the duration in seconds relative to the
+                      startTime that the job may be active before the system tries
+                      to terminate it; value must be positive integer.
+                    format: int64
+                    type: integer
+                  backoffLimit:
+                    description: Optional number of retries before marking this job
+                      failed.
+                    format: int32
+                    type: integer
+                  cleanPodPolicy:
+                    description: CleanPodPolicy defines the policy to kill pods after
+                      the job completes. Default to Running.
+                    type: string
+                  schedulingPolicy:
+                    description: SchedulingPolicy defines the policy related to scheduling,
+                      e.g. gang-scheduling
+                    properties:
+                      minAvailable:
+                        description: "MinAvailable defines the minimal number of member
+                          to run the PodGroup. If the gang-scheduling isn't empty,
+                          input is passed to `.spec.minMember` in PodGroup. Note that,
+                          when using this field, you need to make sure the application
+                          supports resizing (e.g., Elastic Horovod). \n If not set,
+                          it defaults to the number of workers."
+                        format: int32
+                        type: integer
+                      minResources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: MinResources defines the minimal resources of
+                          members to run the PodGroup. If the gang-scheduling isn't
+                          empty, input is passed to `.spec.minResources` in PodGroup
+                          for scheduler-plugins.
+                        type: object
+                      priorityClass:
+                        description: PriorityClass defines the PodGroup's PriorityClass.
+                          If the gang-scheduling is set to the volcano, input is passed
+                          to `.spec.priorityClassName` in PodGroup for volcano, and
+                          if it is set to the scheduler-plugins, input isn't passed
+                          to PodGroup for scheduler-plugins.
+                        type: string
+                      queue:
+                        description: Queue defines the queue name to allocate resource
+                          for PodGroup. If the gang-scheduling is set to the volcano,
+                          input is passed to `.spec.queue` in PodGroup for the volcano,
+                          and if it is set to the scheduler-plugins, input isn't passed
+                          to PodGroup.
+                        type: string
+                      scheduleTimeoutSeconds:
+                        description: SchedulerTimeoutSeconds defines the maximal time
+                          of members to wait before run the PodGroup. If the gang-scheduling
+                          is set to the scheduler-plugins, input is passed to `.spec.scheduleTimeoutSeconds`
+                          in PodGroup for the scheduler-plugins, and if it is set
+                          to the volcano, input isn't passed to PodGroup.
+                        format: int32
+                        type: integer
+                    type: object
+                  suspend:
+                    default: false
+                    description: "suspend specifies whether the MPIJob controller
+                      should create Pods or not. If a MPIJob is created with suspend
+                      set to true, no Pods are created by the MPIJob controller. If
+                      a MPIJob is suspended after creation (i.e. the flag goes from
+                      false to true), the MPIJob controller will delete all active
+                      Pods and PodGroups associated with this MPIJob. Also, it will
+                      suspend the Launcher Job. Users must design their workload to
+                      gracefully handle this. Suspending a Job will reset the StartTime
+                      field of the MPIJob. \n Defaults to false."
+                    type: boolean
+                  ttlSecondsAfterFinished:
+                    description: TTLSecondsAfterFinished is the TTL to clean up jobs.
+                      It may take extra ReconcilePeriod seconds for the cleanup, since
+                      reconcile gets called periodically. Default to infinite.
+                    format: int32
+                    type: integer
+                type: object
+              slotsPerWorker:
+                default: 1
+                description: Specifies the number of slots per worker used in hostfile.
+                  Defaults to 1.
+                format: int32
+                type: integer
+              sshAuthMountPath:
+                default: /root/.ssh
+                description: SSHAuthMountPath is the directory where SSH keys are
+                  mounted. Defaults to "/root/.ssh".
+                type: string
+            required:
+            - mpiReplicaSpecs
+            type: object
+          status:
+            description: JobStatus represents the current observed state of the training
+              Job.
+            properties:
+              completionTime:
+                description: Represents time when the job was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
+                format: date-time
+                type: string
+              conditions:
+                description: conditions is a list of current observed job conditions.
+                items:
+                  description: JobCondition describes the state of the job at a certain
+                    point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of job condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastReconcileTime:
+                description: Represents last time when the job was reconciled. It
+                  is not guaranteed to be set in happens-before order across separate
+                  operations. It is represented in RFC3339 form and is in UTC.
+                format: date-time
+                type: string
+              replicaStatuses:
+                additionalProperties:
+                  description: ReplicaStatus represents the current observed state
+                    of the replica.
+                  properties:
+                    active:
+                      description: The number of actively running pods.
+                      format: int32
+                      type: integer
+                    failed:
+                      description: The number of pods which reached phase failed.
+                      format: int32
+                      type: integer
+                    labelSelector:
+                      description: 'Deprecated: Use selector instead'
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    selector:
+                      description: A selector is a label query over a set of resources.
+                        The result of matchLabels and matchExpressions are ANDed.
+                        An empty selector matches all objects. A null selector matches
+                        no objects.
+                      type: string
+                    succeeded:
+                      description: The number of pods which reached phase succeeded.
+                      format: int32
+                      type: integer
+                  type: object
+                description: replicaStatuses is map of ReplicaType and ReplicaStatus,
+                  specifies the status of each replica.
+                type: object
+              startTime:
+                description: Represents time when the job was acknowledged by the
+                  job controller. It is not guaranteed to be set in happens-before
+                  order across separate operations. It is represented in RFC3339 form
+                  and is in UTC.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+  namespace: mpi-operator
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-mpijobs-admin
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin: "true"
+  name: kubeflow-mpijobs-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  - mpijobs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-mpijobs-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  - mpijobs/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - list
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  - mpijobs/finalizers
+  - mpijobs/status
+  verbs:
+  - '*'
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.incubator.k8s.io
+  - scheduling.sigs.dev
+  - scheduling.volcano.sh
+  resources:
+  - queues
+  - podgroups
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.x-k8s.io
+  resources:
+  - podgroups
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mpi-operator
+subjects:
+- kind: ServiceAccount
+  name: mpi-operator
+  namespace: mpi-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mpi-operator
+    app.kubernetes.io/component: mpijob
+    app.kubernetes.io/name: mpi-operator
+    kustomize.component: mpi-operator
+  name: mpi-operator
+  namespace: mpi-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mpi-operator
+      app.kubernetes.io/component: mpijob
+      app.kubernetes.io/name: mpi-operator
+      kustomize.component: mpi-operator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: mpi-operator
+        app.kubernetes.io/component: mpijob
+        app.kubernetes.io/name: mpi-operator
+        kustomize.component: mpi-operator
+    spec:
+      containers:
+      - args:
+        - -alsologtostderr
+        - --lock-namespace=mpi-operator
+        image: mpioperator/mpi-operator:master
+        name: mpi-operator
+      serviceAccountName: mpi-operator

--- a/operators/mpi-operator/xp12-system-state.json
+++ b/operators/mpi-operator/xp12-system-state.json
@@ -7,7 +7,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -37,15 +37,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "cluster-admin",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "135",
+                "resource_version": "173",
                 "self_link": null,
-                "uid": "be2dfc41-8ade-46ec-9a55-a369b4dbe171"
+                "uid": "c4ddd44c-362d-4387-b423-7c000e738348"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -66,7 +66,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:10+00:00",
+                "creation_timestamp": "2024-02-12T22:18:54+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -84,15 +84,15 @@
                         "manager": "kubectl-create",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:10+00:00"
+                        "time": "2024-02-12T22:18:54+00:00"
                     }
                 ],
                 "name": "kindnet",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "269",
+                "resource_version": "307",
                 "self_link": null,
-                "uid": "a2fd7d69-68a1-4a8d-af14-495edc2a2fb4"
+                "uid": "d9eb3a32-c353-4c9c-8cb4-c17ba1ffcc78"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -113,7 +113,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "creation_timestamp": "2024-02-12T22:18:51+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -131,15 +131,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:07+00:00"
+                        "time": "2024-02-12T22:18:51+00:00"
                     }
                 ],
                 "name": "kubeadm:get-nodes",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "213",
+                "resource_version": "246",
                 "self_link": null,
-                "uid": "02fcc43c-f7bd-4d17-9e2e-d1f56c47ae44"
+                "uid": "1ba90a29-8f86-406d-97ce-748567decb77"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -160,7 +160,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "creation_timestamp": "2024-02-12T22:18:51+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -178,15 +178,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:07+00:00"
+                        "time": "2024-02-12T22:18:51+00:00"
                     }
                 ],
                 "name": "kubeadm:kubelet-bootstrap",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "214",
+                "resource_version": "247",
                 "self_link": null,
-                "uid": "30260fee-2f7c-4f5a-8343-dc8f943f26bf"
+                "uid": "e8212eba-506b-49dc-bb38-7f695d05519e"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -207,7 +207,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "creation_timestamp": "2024-02-12T22:18:51+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -225,15 +225,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:07+00:00"
+                        "time": "2024-02-12T22:18:51+00:00"
                     }
                 ],
                 "name": "kubeadm:node-autoapprove-bootstrap",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "216",
+                "resource_version": "248",
                 "self_link": null,
-                "uid": "613364cb-5dca-420e-ae63-65fb3bf57cbe"
+                "uid": "8c13b639-b1a4-409b-9847-2caf89b9b1b0"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -254,7 +254,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "creation_timestamp": "2024-02-12T22:18:51+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -272,15 +272,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:07+00:00"
+                        "time": "2024-02-12T22:18:51+00:00"
                     }
                 ],
                 "name": "kubeadm:node-autoapprove-certificate-rotation",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "217",
+                "resource_version": "249",
                 "self_link": null,
-                "uid": "507e3e30-9ee4-4040-96b6-f81a8c52b629"
+                "uid": "5038cc7e-fba9-433f-880d-d048eb05c38c"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -301,7 +301,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:08+00:00",
+                "creation_timestamp": "2024-02-12T22:18:52+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -319,15 +319,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:08+00:00"
+                        "time": "2024-02-12T22:18:52+00:00"
                     }
                 ],
                 "name": "kubeadm:node-proxier",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "244",
+                "resource_version": "263",
                 "self_link": null,
-                "uid": "6adbc3b4-0655-4496-afb7-58a84b2d7744"
+                "uid": "4f43dc14-9d9d-4cf7-913d-befc2513f67d"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -350,7 +350,7 @@
                 "annotations": {
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-bind\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"local-path-provisioner-role\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"local-path-provisioner-service-account\",\"namespace\":\"local-path-storage\"}]}\n"
                 },
-                "creation_timestamp": "2024-02-07T19:16:11+00:00",
+                "creation_timestamp": "2024-02-12T22:18:55+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -374,15 +374,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:11+00:00"
+                        "time": "2024-02-12T22:18:55+00:00"
                     }
                 ],
                 "name": "local-path-provisioner-bind",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "282",
+                "resource_version": "326",
                 "self_link": null,
-                "uid": "4444b608-5f3c-485b-9216-deb50e45f26c"
+                "uid": "e3c65ed7-69bd-487d-be91-7fd766578ed5"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -405,7 +405,7 @@
                 "annotations": {
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"mpi-operator\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"mpi-operator\",\"namespace\":\"mpi-operator\"}]}\n"
                 },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "creation_timestamp": "2024-02-12T22:19:15+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -441,15 +441,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:19:15+00:00"
                     }
                 ],
                 "name": "mpi-operator",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "770",
+                "resource_version": "580",
                 "self_link": null,
-                "uid": "a8993f03-c51e-4a64-b1c0-15092f986f60"
+                "uid": "3daea7be-a20b-4a33-941e-c6ddd09402bb"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -472,7 +472,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -502,15 +502,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:basic-user",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "138",
+                "resource_version": "176",
                 "self_link": null,
-                "uid": "b665a296-c4e6-4e10-913f-f8623d6388ea"
+                "uid": "e9eab731-465b-482c-8de3-69164888fc24"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -533,7 +533,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -563,15 +563,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:attachdetach-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "147",
+                "resource_version": "185",
                 "self_link": null,
-                "uid": "3323a5c4-3751-4775-a5b0-1003253b000d"
+                "uid": "87348a6e-4137-42da-88d9-594b789e2244"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -594,7 +594,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -624,15 +624,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:certificate-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "174",
+                "resource_version": "211",
                 "self_link": null,
-                "uid": "f34b7082-e579-4cad-9501-acb82b7e1108"
+                "uid": "45ae3dd2-ca62-4702-bc06-4cef5863312e"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -655,7 +655,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -685,15 +685,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:clusterrole-aggregation-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "148",
+                "resource_version": "186",
                 "self_link": null,
-                "uid": "16a0160f-d4d9-4cb2-8bf2-9167588ffd75"
+                "uid": "2f024ed6-1d88-4020-bdf4-c9287d6d19df"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -716,7 +716,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -746,15 +746,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:cronjob-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "149",
+                "resource_version": "187",
                 "self_link": null,
-                "uid": "863c672c-775c-4c4c-acda-a7d3dc2ed846"
+                "uid": "c2157ff5-dc41-41a9-8a65-ce2a8d467dbb"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -777,7 +777,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -807,15 +807,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:daemon-set-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "150",
+                "resource_version": "188",
                 "self_link": null,
-                "uid": "fc503a7c-5da7-4f91-91b9-07ca4e919743"
+                "uid": "cb617038-183e-4f25-bab8-f1d663076597"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -838,7 +838,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -868,15 +868,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:deployment-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "151",
+                "resource_version": "189",
                 "self_link": null,
-                "uid": "2a73843c-e8a1-4aa5-963a-6fb9792cabdc"
+                "uid": "d42b791b-88e1-4afd-9b48-78e7474cbe89"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -899,7 +899,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -929,15 +929,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:disruption-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "152",
+                "resource_version": "190",
                 "self_link": null,
-                "uid": "0a697f6a-450e-433b-a1af-10f2c464c76a"
+                "uid": "99b6969a-f576-4e35-9749-8dfe9c74b508"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -960,7 +960,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -990,15 +990,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:endpoint-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "154",
+                "resource_version": "191",
                 "self_link": null,
-                "uid": "d4c84b33-28d4-42fa-87c0-339eddb809f7"
+                "uid": "d524513e-c700-4531-980e-7bff16c67d3e"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1021,7 +1021,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1051,15 +1051,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:endpointslice-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "155",
+                "resource_version": "192",
                 "self_link": null,
-                "uid": "d202e038-4a97-4e4a-9c6b-7854c3383ba0"
+                "uid": "f69cfd5c-ad89-4f9f-8255-98d044e5c6d6"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1082,7 +1082,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1112,15 +1112,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:endpointslicemirroring-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "156",
+                "resource_version": "193",
                 "self_link": null,
-                "uid": "75c4e5ee-762c-471c-aa0c-51f15cd0f247"
+                "uid": "cce78a17-d158-4f0d-979f-792cfec3a817"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1143,7 +1143,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1173,15 +1173,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:ephemeral-volume-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "158",
+                "resource_version": "195",
                 "self_link": null,
-                "uid": "56eeb686-e9c2-489b-9b16-afb6e3008730"
+                "uid": "7179c818-a672-4694-bb2e-52a1e46c1ffa"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1204,7 +1204,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1234,15 +1234,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:expand-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "157",
+                "resource_version": "194",
                 "self_link": null,
-                "uid": "23a2d19b-b034-4b5a-a712-4510e9a4e657"
+                "uid": "2f0a825e-81b6-4e9f-ae11-c731d00c6880"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1265,7 +1265,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1295,15 +1295,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:generic-garbage-collector",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "159",
+                "resource_version": "196",
                 "self_link": null,
-                "uid": "dfc4553a-60d2-4fc7-8b58-3891153538a1"
+                "uid": "559b53cb-829c-4493-8a12-7415f68b4701"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1326,7 +1326,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1356,15 +1356,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:horizontal-pod-autoscaler",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "160",
+                "resource_version": "197",
                 "self_link": null,
-                "uid": "18f42914-9082-4cf0-95e9-2368adb7e69f"
+                "uid": "5d88b52e-4f14-47a9-b5eb-aece63e30eb6"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1387,7 +1387,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1417,15 +1417,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:job-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "161",
+                "resource_version": "198",
                 "self_link": null,
-                "uid": "707ed406-7616-46a8-ae88-e6529b336d43"
+                "uid": "69a1572c-00cb-4199-8c41-499829cb8c04"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1448,7 +1448,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1478,15 +1478,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:namespace-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "162",
+                "resource_version": "199",
                 "self_link": null,
-                "uid": "a3efec8a-e1d1-46dc-96d7-74b2ee27efa2"
+                "uid": "c13bbafc-f3cc-4629-836a-6f38782d9e36"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1509,7 +1509,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1539,15 +1539,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:node-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "163",
+                "resource_version": "200",
                 "self_link": null,
-                "uid": "87c96c3f-a588-4f3d-9e64-2d8ef2f8fc36"
+                "uid": "be55f62a-137f-45e6-924c-07c681049dd0"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1570,7 +1570,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1600,15 +1600,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:persistent-volume-binder",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "164",
+                "resource_version": "201",
                 "self_link": null,
-                "uid": "17bfe0e5-d6b9-4b9e-b49b-1742fc85336e"
+                "uid": "118a01ab-15d9-4187-aa75-1809f77a5d7f"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1631,7 +1631,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1661,15 +1661,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:pod-garbage-collector",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "165",
+                "resource_version": "202",
                 "self_link": null,
-                "uid": "c4d84fe8-9b01-4cb0-9d85-9282844ef1a8"
+                "uid": "b1e80953-c55a-4b42-b2d8-dadd3c4cf1c7"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1692,7 +1692,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1722,15 +1722,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:pv-protection-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "176",
+                "resource_version": "213",
                 "self_link": null,
-                "uid": "b143ad34-d8ba-4977-94b5-bbac6a7bc3c0"
+                "uid": "dc439a20-e8dc-4a30-8abd-111ccb11aee6"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1753,7 +1753,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1783,15 +1783,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:pvc-protection-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "175",
+                "resource_version": "212",
                 "self_link": null,
-                "uid": "c5e7a62a-e021-4fc4-b902-56e062d656ed"
+                "uid": "44a69b0d-5834-45ed-b464-60d24384af2b"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1814,7 +1814,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1844,15 +1844,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:replicaset-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "166",
+                "resource_version": "203",
                 "self_link": null,
-                "uid": "56206277-a409-4e3f-8a11-aaaf541a0223"
+                "uid": "2fa2adb2-3b08-47cd-a82b-f4e34efa1c72"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1875,7 +1875,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1905,15 +1905,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:replication-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "167",
+                "resource_version": "204",
                 "self_link": null,
-                "uid": "0e2737af-4399-4c7e-b3d8-189324847eac"
+                "uid": "67192aa1-7b9a-4e09-895d-b50a3188cf48"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1936,7 +1936,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -1966,15 +1966,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:resourcequota-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "168",
+                "resource_version": "205",
                 "self_link": null,
-                "uid": "278460b0-b8e1-47c3-ba8e-de6457583c37"
+                "uid": "3de0bac3-8907-415d-bb80-6611f4ecde57"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -1997,7 +1997,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2027,15 +2027,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:root-ca-cert-publisher",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "178",
+                "resource_version": "215",
                 "self_link": null,
-                "uid": "804844c6-1121-4f05-852e-a8a99e876492"
+                "uid": "1c9ea715-17e0-4f16-98d7-55cb84748dd7"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2058,7 +2058,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2088,15 +2088,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:route-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "169",
+                "resource_version": "206",
                 "self_link": null,
-                "uid": "6b6634e8-425c-44f8-9f38-6f86f7b796ef"
+                "uid": "1570c657-620f-43ad-b2a7-4252a4b46546"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2119,7 +2119,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2149,15 +2149,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:service-account-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "170",
+                "resource_version": "207",
                 "self_link": null,
-                "uid": "fa6b5bac-b2e3-4b93-9908-063c4f304d11"
+                "uid": "4e859fe8-854d-4961-9dc5-7a32ce294a07"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2180,7 +2180,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2210,15 +2210,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:service-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "171",
+                "resource_version": "208",
                 "self_link": null,
-                "uid": "8ea8367a-807b-43ac-ba93-9c176efea59b"
+                "uid": "2f336674-a90f-4810-a634-92cdfa9b720d"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2241,7 +2241,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2271,15 +2271,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:statefulset-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "172",
+                "resource_version": "209",
                 "self_link": null,
-                "uid": "0d8c3732-4fbf-44ca-833d-860bf6e4ef09"
+                "uid": "5257a2e9-802c-49eb-871e-cd2856e18046"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2302,7 +2302,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2332,15 +2332,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:ttl-after-finished-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "177",
+                "resource_version": "214",
                 "self_link": null,
-                "uid": "39543532-2b38-4364-91ee-bc4ef98b1046"
+                "uid": "65be3352-64fa-4954-8e1a-679981c8eb4c"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2363,7 +2363,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2393,15 +2393,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:controller:ttl-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "173",
+                "resource_version": "210",
                 "self_link": null,
-                "uid": "5eed15d4-951e-4e9b-989c-a7bf4003ef80"
+                "uid": "ac218047-6bfb-4d88-a850-47449ee6a2b9"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2422,7 +2422,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:08+00:00",
+                "creation_timestamp": "2024-02-12T22:18:52+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2440,15 +2440,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:08+00:00"
+                        "time": "2024-02-12T22:18:52+00:00"
                     }
                 ],
                 "name": "system:coredns",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "232",
+                "resource_version": "255",
                 "self_link": null,
-                "uid": "26d6112e-7bbb-4946-a97d-6688c7c160dc"
+                "uid": "13ab3057-9ceb-48b2-a338-fe97caf146d1"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2471,7 +2471,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2501,15 +2501,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:discovery",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "137",
+                "resource_version": "175",
                 "self_link": null,
-                "uid": "c64f36a7-abc0-4fe8-83c1-0df4d430581c"
+                "uid": "d5a9e084-3fb5-4720-b033-13a9f302315a"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2532,7 +2532,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2562,15 +2562,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:kube-controller-manager",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "141",
+                "resource_version": "179",
                 "self_link": null,
-                "uid": "26cdada5-8b6f-46dd-9049-df3bdbf88801"
+                "uid": "6d925129-6445-4144-af25-476e1da4c13c"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2593,7 +2593,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2623,15 +2623,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:kube-dns",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "142",
+                "resource_version": "180",
                 "self_link": null,
-                "uid": "067090ab-aa91-4078-8322-8f98e9d192c2"
+                "uid": "da7c70de-0ca1-40c0-a4ed-1a815f804a81"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2654,7 +2654,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2684,15 +2684,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:kube-scheduler",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "143",
+                "resource_version": "181",
                 "self_link": null,
-                "uid": "5766d388-c005-49e6-bcfd-d6d2d03d0780"
+                "uid": "943d1bc6-3cb1-48e4-807e-34a61d56a9bc"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2715,7 +2715,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2745,15 +2745,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:monitoring",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "136",
+                "resource_version": "174",
                 "self_link": null,
-                "uid": "5b0ca3e6-4c8c-4f30-9a0a-403b222326be"
+                "uid": "39b69f40-1aba-4beb-9ac5-86172802be9b"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2776,7 +2776,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2805,15 +2805,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:node",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "145",
+                "resource_version": "183",
                 "self_link": null,
-                "uid": "7aec7017-0bb5-4efd-b259-b3381d2b6812"
+                "uid": "5a4c433d-3e05-4973-9f04-78363ddb6f6d"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2829,7 +2829,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2859,15 +2859,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:node-proxier",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "140",
+                "resource_version": "178",
                 "self_link": null,
-                "uid": "b7b1ccfb-53c8-44df-9147-e459f9402aef"
+                "uid": "e05fabcd-a9cb-4050-a372-aadb90365ba6"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2890,7 +2890,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2920,15 +2920,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:public-info-viewer",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "139",
+                "resource_version": "177",
                 "self_link": null,
-                "uid": "aa6dd882-60a7-4412-987e-d5bd3a4fa9bc"
+                "uid": "22fc35be-601a-438d-9930-2e5f67f1b27a"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -2957,7 +2957,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -2987,15 +2987,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:service-account-issuer-discovery",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "146",
+                "resource_version": "184",
                 "self_link": null,
-                "uid": "5040fe78-79ea-41d6-aac5-a8fb77d1afc5"
+                "uid": "990d81a7-4025-4aee-b9e7-c58f8e92d9e4"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -3018,7 +3018,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -3048,15 +3048,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:05+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
                 "name": "system:volume-scheduler",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "144",
+                "resource_version": "182",
                 "self_link": null,
-                "uid": "23456e43-2733-4a39-ab19-14bc9fe09a6b"
+                "uid": "59eb2670-324c-4327-ba3b-b22d0bcb070b"
             },
             "role_ref": {
                 "api_group": "rbac.authorization.k8s.io",
@@ -3091,7 +3091,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -3110,7 +3110,7 @@
                         "manager": "clusterrole-aggregation-controller",
                         "operation": "Apply",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:21+00:00"
+                        "time": "2024-02-12T22:19:06+00:00"
                     },
                     {
                         "api_version": "rbac.authorization.k8s.io/v1",
@@ -3134,15 +3134,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "admin",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "348",
+                "resource_version": "409",
                 "self_link": null,
-                "uid": "1838e67e-1fe3-4c4d-b998-9a3ec29853af"
+                "uid": "a4a46812-c9e9-42fd-b11f-b057b17e8cf0"
             },
             "rules": [
                 {
@@ -3629,7 +3629,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -3658,15 +3658,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "cluster-admin",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "70",
+                "resource_version": "111",
                 "self_link": null,
-                "uid": "17d9528d-9568-4d8f-b851-e7d087b7b0a7"
+                "uid": "22044d0b-5320-418d-afc9-e433ccb7de16"
             },
             "rules": [
                 {
@@ -3712,7 +3712,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -3732,7 +3732,7 @@
                         "manager": "clusterrole-aggregation-controller",
                         "operation": "Apply",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:21+00:00"
+                        "time": "2024-02-12T22:19:06+00:00"
                     },
                     {
                         "api_version": "rbac.authorization.k8s.io/v1",
@@ -3757,15 +3757,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "edit",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "336",
+                "resource_version": "402",
                 "self_link": null,
-                "uid": "9cf796c8-e779-4834-85ad-01c404c23397"
+                "uid": "edc7bb5d-05a5-4c23-ba4a-777a75d32ec0"
             },
             "rules": [
                 {
@@ -4216,7 +4216,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:10+00:00",
+                "creation_timestamp": "2024-02-12T22:18:54+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4233,15 +4233,15 @@
                         "manager": "kubectl-create",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:10+00:00"
+                        "time": "2024-02-12T22:18:54+00:00"
                     }
                 ],
                 "name": "kindnet",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "268",
+                "resource_version": "306",
                 "self_link": null,
-                "uid": "4d12914e-4031-44b6-b7b3-b01575fd5cfe"
+                "uid": "6afb47dd-af63-4809-a8c8-cb8f90a3814a"
             },
             "rules": [
                 {
@@ -4281,7 +4281,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "creation_timestamp": "2024-02-12T22:18:51+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4298,15 +4298,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:07+00:00"
+                        "time": "2024-02-12T22:18:51+00:00"
                     }
                 ],
                 "name": "kubeadm:get-nodes",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "211",
+                "resource_version": "245",
                 "self_link": null,
-                "uid": "e3c47cb4-25be-4bdd-89e4-165ede758034"
+                "uid": "7c8558d9-63a1-418d-ac09-1369823381ae"
             },
             "rules": [
                 {
@@ -4341,7 +4341,7 @@
                 "annotations": {
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"aggregationRule\":{\"clusterRoleSelectors\":[{\"matchLabels\":{\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin\":\"true\"}}]},\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin\":\"true\"},\"name\":\"kubeflow-mpijobs-admin\"},\"rules\":[]}\n"
                 },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "creation_timestamp": "2024-02-12T22:19:15+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4364,7 +4364,7 @@
                         "manager": "clusterrole-aggregation-controller",
                         "operation": "Apply",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:21:45+00:00"
                     },
                     {
                         "api_version": "rbac.authorization.k8s.io/v1",
@@ -4392,15 +4392,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:21:45+00:00"
                     }
                 ],
                 "name": "kubeflow-mpijobs-admin",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "766",
+                "resource_version": "944",
                 "self_link": null,
-                "uid": "657335f2-9615-4b3e-bbd1-06a430b51a24"
+                "uid": "1d430018-feef-4599-9354-1343ee2289c9"
             },
             "rules": [
                 {
@@ -4434,7 +4434,7 @@
                 "annotations": {
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit\":\"true\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin\":\"true\"},\"name\":\"kubeflow-mpijobs-edit\"},\"rules\":[{\"apiGroups\":[\"kubeflow.org\"],\"resources\":[\"mpijobs\",\"mpijobs/status\"],\"verbs\":[\"get\",\"list\",\"watch\",\"create\",\"delete\",\"deletecollection\",\"patch\",\"update\"]}]}\n"
                 },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "creation_timestamp": "2024-02-12T22:19:15+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4473,15 +4473,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:19:15+00:00"
                     }
                 ],
                 "name": "kubeflow-mpijobs-edit",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "765",
+                "resource_version": "576",
                 "self_link": null,
-                "uid": "516a2843-f2c5-424a-b16f-4c82ba15ab36"
+                "uid": "f89d6bec-cc01-42e0-ab72-e6ca649a2af9"
             },
             "rules": [
                 {
@@ -4515,7 +4515,7 @@
                 "annotations": {
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view\":\"true\"},\"name\":\"kubeflow-mpijobs-view\"},\"rules\":[{\"apiGroups\":[\"kubeflow.org\"],\"resources\":[\"mpijobs\",\"mpijobs/status\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
                 },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "creation_timestamp": "2024-02-12T22:19:15+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4552,15 +4552,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:19:15+00:00"
                     }
                 ],
                 "name": "kubeflow-mpijobs-view",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "767",
+                "resource_version": "578",
                 "self_link": null,
-                "uid": "5c5c3a00-5f44-4d80-9e32-66b24f39565b"
+                "uid": "c5e31c08-a075-411d-b3e2-ba2dbe801fd2"
             },
             "rules": [
                 {
@@ -4589,7 +4589,7 @@
                 "annotations": {
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-role\"},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"nodes\",\"persistentvolumeclaims\",\"configmaps\"],\"verbs\":[\"get\",\"list\",\"watch\"]},{\"apiGroups\":[\"\"],\"resources\":[\"endpoints\",\"persistentvolumes\",\"pods\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"\"],\"resources\":[\"events\"],\"verbs\":[\"create\",\"patch\"]},{\"apiGroups\":[\"storage.k8s.io\"],\"resources\":[\"storageclasses\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
                 },
-                "creation_timestamp": "2024-02-07T19:16:11+00:00",
+                "creation_timestamp": "2024-02-12T22:18:55+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4612,15 +4612,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:11+00:00"
+                        "time": "2024-02-12T22:18:55+00:00"
                     }
                 ],
                 "name": "local-path-provisioner-role",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "281",
+                "resource_version": "325",
                 "self_link": null,
-                "uid": "3abc43a6-f46e-48ba-aa49-fdc69450f161"
+                "uid": "8f78a3f6-44d7-4543-8692-488900f46a11"
             },
             "rules": [
                 {
@@ -4694,7 +4694,7 @@
                 "annotations": {
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\"},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"configmaps\",\"secrets\",\"services\"],\"verbs\":[\"create\",\"list\",\"watch\",\"update\"]},{\"apiGroups\":[\"\"],\"resources\":[\"pods\"],\"verbs\":[\"create\",\"get\",\"list\",\"watch\",\"delete\",\"update\",\"patch\"]},{\"apiGroups\":[\"\"],\"resources\":[\"pods/exec\"],\"verbs\":[\"create\"]},{\"apiGroups\":[\"\"],\"resources\":[\"endpoints\"],\"verbs\":[\"create\",\"get\",\"update\"]},{\"apiGroups\":[\"\"],\"resources\":[\"events\"],\"verbs\":[\"create\",\"patch\"]},{\"apiGroups\":[\"batch\"],\"resources\":[\"jobs\"],\"verbs\":[\"create\",\"list\",\"update\",\"watch\"]},{\"apiGroups\":[\"apiextensions.k8s.io\"],\"resources\":[\"customresourcedefinitions\"],\"verbs\":[\"create\",\"get\"]},{\"apiGroups\":[\"kubeflow.org\"],\"resources\":[\"mpijobs\",\"mpijobs/finalizers\",\"mpijobs/status\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"coordination.k8s.io\"],\"resources\":[\"leases\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"scheduling.incubator.k8s.io\",\"scheduling.sigs.dev\",\"scheduling.volcano.sh\"],\"resources\":[\"queues\",\"podgroups\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"scheduling.x-k8s.io\"],\"resources\":[\"podgroups\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"scheduling.k8s.io\"],\"resources\":[\"priorityclasses\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
                 },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "creation_timestamp": "2024-02-12T22:19:15+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4729,15 +4729,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:19:15+00:00"
                     }
                 ],
                 "name": "mpi-operator",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "769",
+                "resource_version": "579",
                 "self_link": null,
-                "uid": "1376499c-e6e9-4e85-8bff-037418597d41"
+                "uid": "d83cbee4-6a67-4b35-a69b-5f5bb6f9b1b8"
             },
             "rules": [
                 {
@@ -4931,7 +4931,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -4962,15 +4962,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:aggregate-to-admin",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "78",
+                "resource_version": "119",
                 "self_link": null,
-                "uid": "5a291a5d-42e0-4e69-8933-97dd16586f64"
+                "uid": "5ce96ac6-5c54-426c-8dba-675f41cafe9c"
             },
             "rules": [
                 {
@@ -5017,7 +5017,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5048,15 +5048,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:aggregate-to-edit",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "79",
+                "resource_version": "120",
                 "self_link": null,
-                "uid": "c743cbb5-e3d4-4b29-adcb-f9231d1470a0"
+                "uid": "9b63baaa-e678-4f6c-8573-f60ac1c450a3"
             },
             "rules": [
                 {
@@ -5313,7 +5313,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5344,15 +5344,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:aggregate-to-view",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "80",
+                "resource_version": "121",
                 "self_link": null,
-                "uid": "182be56b-6d7a-4b92-9e8e-3f2b119c20cd"
+                "uid": "5b46ee4b-d040-4303-b9d9-101a03f7f7ec"
             },
             "rules": [
                 {
@@ -5561,7 +5561,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5590,15 +5590,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:auth-delegator",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "86",
+                "resource_version": "127",
                 "self_link": null,
-                "uid": "35d1b84a-11f2-40e7-b608-b31746edb8e1"
+                "uid": "3eb43574-23e8-4c32-acfc-568802a6e4fb"
             },
             "rules": [
                 {
@@ -5637,7 +5637,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5666,15 +5666,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:basic-user",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "73",
+                "resource_version": "114",
                 "self_link": null,
-                "uid": "8df32434-e247-413e-9c58-573e2233f145"
+                "uid": "4952d684-e9a0-49be-8d6b-dde557e743d9"
             },
             "rules": [
                 {
@@ -5714,7 +5714,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5743,15 +5743,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "92",
+                "resource_version": "132",
                 "self_link": null,
-                "uid": "a1be3fbb-2f76-4f52-9c6c-e13dedbe4bd1"
+                "uid": "15497c74-1ede-4364-a9b9-0be530d38c14"
             },
             "rules": [
                 {
@@ -5777,7 +5777,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5806,15 +5806,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "93",
+                "resource_version": "133",
                 "self_link": null,
-                "uid": "d05f4c88-cd31-4342-9774-36f5f17727b2"
+                "uid": "720ec3aa-e4f2-4d73-a596-af85e47f2a34"
             },
             "rules": [
                 {
@@ -5840,7 +5840,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5869,15 +5869,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:certificates.k8s.io:kube-apiserver-client-approver",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "97",
+                "resource_version": "137",
                 "self_link": null,
-                "uid": "ba9cfb30-84e9-4034-991d-fc6cf3ef938c"
+                "uid": "7c5f5a0b-4966-46b2-956e-adddf362ee7d"
             },
             "rules": [
                 {
@@ -5905,7 +5905,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5934,15 +5934,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:certificates.k8s.io:kube-apiserver-client-kubelet-approver",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "98",
+                "resource_version": "138",
                 "self_link": null,
-                "uid": "bec72241-a69b-4e8c-907a-6a209692df43"
+                "uid": "900a9113-ab2d-45fe-998e-4408651b8f27"
             },
             "rules": [
                 {
@@ -5970,7 +5970,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -5999,15 +5999,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:certificates.k8s.io:kubelet-serving-approver",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "96",
+                "resource_version": "136",
                 "self_link": null,
-                "uid": "9e94ae7d-e10e-4e0e-ba54-78788f051cb3"
+                "uid": "30ef9480-24f9-4953-9b56-b11e386704b2"
             },
             "rules": [
                 {
@@ -6035,7 +6035,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6064,15 +6064,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:certificates.k8s.io:legacy-unknown-approver",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "95",
+                "resource_version": "135",
                 "self_link": null,
-                "uid": "c44b59c0-2261-4f9b-bb1b-128f2a4a3a68"
+                "uid": "fda94783-d354-4adc-aa74-95c7945d75a1"
             },
             "rules": [
                 {
@@ -6100,7 +6100,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6129,15 +6129,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:attachdetach-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "102",
+                "resource_version": "142",
                 "self_link": null,
-                "uid": "06d8e9d9-49cc-4cfb-93b9-f2d6644750d4"
+                "uid": "8c8f7427-d846-4064-a53b-6c8de0f58c8c"
             },
             "rules": [
                 {
@@ -6271,7 +6271,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6300,15 +6300,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:certificate-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "130",
+                "resource_version": "168",
                 "self_link": null,
-                "uid": "ecb26171-533a-49eb-9d31-1e84fdeccd3a"
+                "uid": "a2747a77-2353-419e-9b97-2256c83422f1"
             },
             "rules": [
                 {
@@ -6413,7 +6413,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6442,15 +6442,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:clusterrole-aggregation-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "103",
+                "resource_version": "143",
                 "self_link": null,
-                "uid": "e83c7609-9697-4f29-8f54-dc47d5c7a32a"
+                "uid": "4a90505f-f007-4176-8ccc-098c3662ccd2"
             },
             "rules": [
                 {
@@ -6481,7 +6481,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6510,15 +6510,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:cronjob-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "104",
+                "resource_version": "144",
                 "self_link": null,
-                "uid": "022050d6-03be-48d2-bc76-3af9a2f3fdc0"
+                "uid": "291ff7c8-1749-46ac-bbf6-9cb89ded3a15"
             },
             "rules": [
                 {
@@ -6622,7 +6622,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6651,15 +6651,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:daemon-set-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "105",
+                "resource_version": "145",
                 "self_link": null,
-                "uid": "7adf6a30-8f9c-4b31-b8fc-0001519840a0"
+                "uid": "80f78ccb-df6c-47f5-bcd2-637a2a47fd61"
             },
             "rules": [
                 {
@@ -6795,7 +6795,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6824,15 +6824,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:deployment-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "106",
+                "resource_version": "146",
                 "self_link": null,
-                "uid": "6d30972c-63d2-4db4-9334-bb1d028102b3"
+                "uid": "8ba32408-218f-45f0-b287-10c480e2b0eb"
             },
             "rules": [
                 {
@@ -6942,7 +6942,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -6971,15 +6971,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:disruption-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "107",
+                "resource_version": "147",
                 "self_link": null,
-                "uid": "1303cc5b-83e4-4865-9e30-d73366c3558b"
+                "uid": "3991e15c-e091-4c46-bc90-307568935320"
             },
             "rules": [
                 {
@@ -7124,7 +7124,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -7153,15 +7153,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:endpoint-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "109",
+                "resource_version": "148",
                 "self_link": null,
-                "uid": "a8e40bed-bd74-42d9-95e6-300361cd5ca4"
+                "uid": "a555b393-9b22-439c-9841-bb5c42339a10"
             },
             "rules": [
                 {
@@ -7236,7 +7236,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -7265,15 +7265,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:endpointslice-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "110",
+                "resource_version": "149",
                 "self_link": null,
-                "uid": "83b81e89-b468-4f6f-be92-37b75fab5718"
+                "uid": "d3515c43-b124-4e2d-9cc2-954945d5cfc2"
             },
             "rules": [
                 {
@@ -7349,7 +7349,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -7378,15 +7378,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:endpointslicemirroring-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "111",
+                "resource_version": "150",
                 "self_link": null,
-                "uid": "c5cb5a2c-4f1e-47d3-8fea-d970e7f4cb3a"
+                "uid": "46f84913-1457-4134-967e-1fbb4347e8fe"
             },
             "rules": [
                 {
@@ -7474,7 +7474,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -7503,15 +7503,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:ephemeral-volume-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "113",
+                "resource_version": "152",
                 "self_link": null,
-                "uid": "62c73a7e-d22a-4e72-b116-b7213672add3"
+                "uid": "2447303e-e0e9-4b20-91d6-dc93d24b072d"
             },
             "rules": [
                 {
@@ -7584,7 +7584,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -7613,15 +7613,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:expand-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "112",
+                "resource_version": "151",
                 "self_link": null,
-                "uid": "095bc024-1861-4720-8730-8f2ab70593bb"
+                "uid": "9381c88f-3674-47e3-a40e-93ea09b5d672"
             },
             "rules": [
                 {
@@ -7738,7 +7738,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -7767,15 +7767,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:generic-garbage-collector",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "114",
+                "resource_version": "153",
                 "self_link": null,
-                "uid": "50e667e1-51d7-45cf-ae62-826c85175523"
+                "uid": "a2bc2dae-b930-430d-b53f-1a6e5b58a2b4"
             },
             "rules": [
                 {
@@ -7822,7 +7822,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -7851,15 +7851,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:horizontal-pod-autoscaler",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "115",
+                "resource_version": "154",
                 "self_link": null,
-                "uid": "a5295d21-c44c-4a37-bdb1-3af96b7f34f4"
+                "uid": "ab6bc0b2-e6b1-4425-bfec-fd98cc8a9cb3"
             },
             "rules": [
                 {
@@ -7984,7 +7984,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8013,15 +8013,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:job-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "117",
+                "resource_version": "155",
                 "self_link": null,
-                "uid": "76f76d4b-db61-4dae-bb0f-d7ab630a65f1"
+                "uid": "22adace9-09ba-4b83-a7f4-12310539b4a6"
             },
             "rules": [
                 {
@@ -8110,7 +8110,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8139,15 +8139,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:namespace-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "118",
+                "resource_version": "156",
                 "self_link": null,
-                "uid": "fe59af5a-cabf-4859-9ebf-7fdbb725ada3"
+                "uid": "fd30a22f-f6ae-4519-b7e1-83e0262a51f6"
             },
             "rules": [
                 {
@@ -8206,7 +8206,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8235,15 +8235,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:node-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "119",
+                "resource_version": "157",
                 "self_link": null,
-                "uid": "a41e02c7-0456-4792-adcd-b9fc28b2b937"
+                "uid": "226ea026-689a-4288-8b92-d91515e1234f"
             },
             "rules": [
                 {
@@ -8360,7 +8360,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8389,15 +8389,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:persistent-volume-binder",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "120",
+                "resource_version": "158",
                 "self_link": null,
-                "uid": "a48a9335-152f-46a7-8dff-f4edc412ab07"
+                "uid": "cb593845-efcf-49d9-baf5-f15c47513966"
             },
             "rules": [
                 {
@@ -8589,7 +8589,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8618,15 +8618,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:pod-garbage-collector",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "121",
+                "resource_version": "159",
                 "self_link": null,
-                "uid": "fbbed0dc-8d50-4875-a1ba-869b9664f58b"
+                "uid": "e6a53fcc-30b9-4bf1-ac49-f22ff0d046b7"
             },
             "rules": [
                 {
@@ -8681,7 +8681,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8710,15 +8710,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:pv-protection-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "132",
+                "resource_version": "170",
                 "self_link": null,
-                "uid": "edf9ec55-041d-417e-8070-48dd3fdc2c63"
+                "uid": "98eee38f-7b5b-4f68-b03e-9b4f9f121408"
             },
             "rules": [
                 {
@@ -8763,7 +8763,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8792,15 +8792,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:pvc-protection-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "131",
+                "resource_version": "169",
                 "self_link": null,
-                "uid": "cb0d434a-b9ba-4b2e-8eb4-ae7be7bbbb7a"
+                "uid": "91c0b5e9-b830-457b-b04c-25aeb00358ae"
             },
             "rules": [
                 {
@@ -8860,7 +8860,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -8889,15 +8889,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:replicaset-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "122",
+                "resource_version": "160",
                 "self_link": null,
-                "uid": "e535f2a4-9963-4790-bb94-3cc126edf8e2"
+                "uid": "d9b8384b-f392-467e-9c16-a8533fead454"
             },
             "rules": [
                 {
@@ -8988,7 +8988,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9017,15 +9017,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:replication-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "123",
+                "resource_version": "161",
                 "self_link": null,
-                "uid": "2ffdf41b-b74a-441e-aa06-47aa38d979bd"
+                "uid": "6006205c-c305-4b08-8d9b-3c28c231acf3"
             },
             "rules": [
                 {
@@ -9113,7 +9113,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9142,15 +9142,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:resourcequota-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "124",
+                "resource_version": "162",
                 "self_link": null,
-                "uid": "a4d97374-c78f-4ed5-8061-703e06c87158"
+                "uid": "6548d8e7-4020-4f5b-b5c2-37856c193fa1"
             },
             "rules": [
                 {
@@ -9206,7 +9206,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9235,15 +9235,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:root-ca-cert-publisher",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "134",
+                "resource_version": "172",
                 "self_link": null,
-                "uid": "fd90e012-1600-4477-a1a7-66376e256a1a"
+                "uid": "cf19ba95-febf-48f7-82b9-ad507e65c78b"
             },
             "rules": [
                 {
@@ -9286,7 +9286,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9315,15 +9315,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:route-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "125",
+                "resource_version": "163",
                 "self_link": null,
-                "uid": "6b2040f4-f8cb-4ec3-9f68-ba23f9bcbd37"
+                "uid": "055a8efb-36b8-4751-9f3e-1f57639fb441"
             },
             "rules": [
                 {
@@ -9379,7 +9379,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9408,15 +9408,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:service-account-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "126",
+                "resource_version": "164",
                 "self_link": null,
-                "uid": "2748e468-92f8-441c-b65a-a7d602e8dae0"
+                "uid": "32d877a0-b503-44fc-8e81-c7c9d98ce696"
             },
             "rules": [
                 {
@@ -9458,7 +9458,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9487,15 +9487,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:service-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "127",
+                "resource_version": "165",
                 "self_link": null,
-                "uid": "be8787f6-ccdf-4630-ad08-bb5c90f863c1"
+                "uid": "1805e627-e9c8-4eaa-adb9-385759e5290d"
             },
             "rules": [
                 {
@@ -9567,7 +9567,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9596,15 +9596,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:statefulset-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "128",
+                "resource_version": "166",
                 "self_link": null,
-                "uid": "13720dd3-63af-4034-8a37-a1df55d3f7d2"
+                "uid": "772c8087-f167-417a-964d-6641edd06078"
             },
             "rules": [
                 {
@@ -9752,7 +9752,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9781,15 +9781,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:ttl-after-finished-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "133",
+                "resource_version": "171",
                 "self_link": null,
-                "uid": "3a30f497-9f8c-4e73-8f5b-8de85c6f0614"
+                "uid": "88a57f35-d7ef-4a70-97f0-42c750bf0c1a"
             },
             "rules": [
                 {
@@ -9834,7 +9834,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9863,15 +9863,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:controller:ttl-controller",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "129",
+                "resource_version": "167",
                 "self_link": null,
-                "uid": "eda02675-2c0e-4009-b0cb-a87b70d44814"
+                "uid": "7a9f5a1c-d693-465b-87e0-931ec7823d59"
             },
             "rules": [
                 {
@@ -9914,7 +9914,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:16:08+00:00",
+                "creation_timestamp": "2024-02-12T22:18:52+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -9931,15 +9931,15 @@
                         "manager": "kubeadm",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:08+00:00"
+                        "time": "2024-02-12T22:18:52+00:00"
                     }
                 ],
                 "name": "system:coredns",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "231",
+                "resource_version": "254",
                 "self_link": null,
-                "uid": "e12d41c0-c802-45ff-b172-03ec81752535"
+                "uid": "f682c96b-73b9-481f-85eb-f2dfcef7cfdd"
             },
             "rules": [
                 {
@@ -9996,7 +9996,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10025,15 +10025,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:discovery",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "71",
+                "resource_version": "112",
                 "self_link": null,
-                "uid": "c210a05d-2193-4cd4-8867-77c48dc03aa4"
+                "uid": "4ca55f94-ad24-4423-8ab4-671de5e38e28"
             },
             "rules": [
                 {
@@ -10067,7 +10067,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10096,15 +10096,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:heapster",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "81",
+                "resource_version": "122",
                 "self_link": null,
-                "uid": "d7709e7e-2864-442c-96f3-ff87ec1210e4"
+                "uid": "e26026d7-9da2-45cb-bafb-0cb58f1f5418"
             },
             "rules": [
                 {
@@ -10150,7 +10150,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10179,15 +10179,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:kube-aggregator",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "87",
+                "resource_version": "128",
                 "self_link": null,
-                "uid": "3def03f7-ac6e-4eff-b102-7b545f84df76"
+                "uid": "7bb8f6b7-7e80-4810-a93d-05c01e7c87b1"
             },
             "rules": [
                 {
@@ -10216,7 +10216,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10245,15 +10245,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:kube-controller-manager",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "88",
+                "resource_version": "129",
                 "self_link": null,
-                "uid": "4ff54c49-f16b-4ec2-b355-612bcaf913bd"
+                "uid": "b8c6a7d2-d327-45cc-8f37-b82671f6beb1"
             },
             "rules": [
                 {
@@ -10450,7 +10450,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10479,15 +10479,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:kube-dns",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "89",
+                "resource_version": "130",
                 "self_link": null,
-                "uid": "04f1ee43-51cb-4c33-9820-b8f5c5489cec"
+                "uid": "0e9ae66d-3a22-49a0-8e86-260093155a39"
             },
             "rules": [
                 {
@@ -10515,7 +10515,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10544,15 +10544,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:kube-scheduler",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "101",
+                "resource_version": "141",
                 "self_link": null,
-                "uid": "3e7c2489-1a53-44bc-9b47-02c2aa1b48a9"
+                "uid": "95dc9869-3397-49aa-8b22-00fcc77e634a"
             },
             "rules": [
                 {
@@ -10862,7 +10862,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10891,15 +10891,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:kubelet-api-admin",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "84",
+                "resource_version": "125",
                 "self_link": null,
-                "uid": "e26a8d83-e44a-4d7e-b3cc-8c089dd3ee85"
+                "uid": "c28480b7-b1ef-434a-9a9f-8e1cf1a778d3"
             },
             "rules": [
                 {
@@ -10956,7 +10956,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -10985,15 +10985,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:monitoring",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "72",
+                "resource_version": "113",
                 "self_link": null,
-                "uid": "835b5d80-13d2-40e9-9303-57a5d194434f"
+                "uid": "b6b20ee2-2109-4603-90f0-b0bc44acd309"
             },
             "rules": [
                 {
@@ -11024,7 +11024,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11053,15 +11053,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:node",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "82",
+                "resource_version": "123",
                 "self_link": null,
-                "uid": "720fbcd1-39be-4d6f-9aab-08d2769fc7ea"
+                "uid": "c3f9c290-cc05-4383-9ae1-bddc4a10b48e"
             },
             "rules": [
                 {
@@ -11395,7 +11395,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11424,15 +11424,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:node-bootstrapper",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "85",
+                "resource_version": "126",
                 "self_link": null,
-                "uid": "81ab62eb-fd12-4009-a492-f69c02b0438f"
+                "uid": "0b32bf43-5302-468c-a014-361f530cfde6"
             },
             "rules": [
                 {
@@ -11461,7 +11461,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11490,15 +11490,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:node-problem-detector",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "83",
+                "resource_version": "124",
                 "self_link": null,
-                "uid": "b02adb4d-55a5-47cb-8645-525ecd5b7df3"
+                "uid": "112cf61b-3dd8-47e1-80e8-875d86620d27"
             },
             "rules": [
                 {
@@ -11553,7 +11553,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11582,15 +11582,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:node-proxier",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "100",
+                "resource_version": "140",
                 "self_link": null,
-                "uid": "94fa67ad-41f1-4290-a123-1aa9a8ba7b74"
+                "uid": "f4c173a7-20da-49b7-881e-9ab19c84fbb9"
             },
             "rules": [
                 {
@@ -11663,7 +11663,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11692,15 +11692,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:persistent-volume-provisioner",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "91",
+                "resource_version": "131",
                 "self_link": null,
-                "uid": "9d4be23f-c4ab-4205-8ec1-526ec1a40723"
+                "uid": "d0bfbcb5-66f2-48fa-971b-d27eb2a5c4a6"
             },
             "rules": [
                 {
@@ -11790,7 +11790,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11819,15 +11819,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:public-info-viewer",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "74",
+                "resource_version": "115",
                 "self_link": null,
-                "uid": "e39fb456-b079-4f7f-92e1-84907bccfd0b"
+                "uid": "81f4cb0d-54ea-4187-805d-bceabc6de150"
             },
             "rules": [
                 {
@@ -11855,7 +11855,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11884,15 +11884,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:service-account-issuer-discovery",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "99",
+                "resource_version": "139",
                 "self_link": null,
-                "uid": "851facb8-7cb8-4ae5-92af-aba176bfba5e"
+                "uid": "00b43177-41e6-4530-b7e7-028f5d7f1476"
             },
             "rules": [
                 {
@@ -11917,7 +11917,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -11946,15 +11946,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:04+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "system:volume-scheduler",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "94",
+                "resource_version": "134",
                 "self_link": null,
-                "uid": "b9bf2685-5983-4cc4-be0d-96f4a7b000ad"
+                "uid": "7a2c595c-ac8e-4856-83df-c85fcaf6c788"
             },
             "rules": [
                 {
@@ -12025,7 +12025,7 @@
                 "annotations": {
                     "rbac.authorization.kubernetes.io/autoupdate": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "creation_timestamp": "2024-02-12T22:18:49+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -12045,7 +12045,7 @@
                         "manager": "clusterrole-aggregation-controller",
                         "operation": "Apply",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:21+00:00"
+                        "time": "2024-02-12T22:19:06+00:00"
                     },
                     {
                         "api_version": "rbac.authorization.k8s.io/v1",
@@ -12070,15 +12070,15 @@
                         "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:03+00:00"
+                        "time": "2024-02-12T22:18:49+00:00"
                     }
                 ],
                 "name": "view",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "331",
+                "resource_version": "392",
                 "self_link": null,
-                "uid": "70c65ff8-f81e-4337-baa2-9e3c294b9e1a"
+                "uid": "0ef4c431-170e-42f0-b868-3ae0ffd9606f"
             },
             "rules": [
                 {
@@ -12285,7 +12285,7 @@
             "api_version": null,
             "binary_data": null,
             "data": {
-                "ca.crt": "-----BEGIN CERTIFICATE-----\nMIIC/jCCAeagAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl\ncm5ldGVzMB4XDTI0MDIwNzE5MTUzOFoXDTM0MDIwNDE5MTUzOFowFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKg7\nm3u5q7aUkeEMyhNSiBgBmhvEebCwvwHHb5rubENxrt9e5iIIuUixACv7rqXRYqGy\nipSnDm5xK5UR22r889BoCAPZV1lvGSlMDKMsFVC9kADplnFmiB14/D+JO11aXXSp\nGgIromR9ZKqUQvC3boENclnrphd6/c7FJttBHA+wp9EGnEP9xs9aqSmczSCcnPRt\n76Sw4+HJnF6BC60Dtk3ht1rxGXZ0U9HB8IwKidqYEIYw5rw7SENyY6LXBiHV+jX9\ny5ujQKtq/ZtU7HzUBufZNxWIxmdJlQ1bs3HsQQq7mqr1Q4XlD4p4omO4m8uxrp5u\ntDL+sFCNM6gZBj91RCUCAwEAAaNZMFcwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB\n/wQFMAMBAf8wHQYDVR0OBBYEFLD/EjgMVAaNhEcbTDJ0ntQqxp1lMBUGA1UdEQQO\nMAyCCmt1YmVybmV0ZXMwDQYJKoZIhvcNAQELBQADggEBAFAizAWZc7TklddmPqnw\nvpxaPgFQfqYcUkNjFCEf5vkSxVs8cTw4VvDBZCXhI1L5JOa4XBTzww2PYmrydpm7\n/av2pqFfGteqifVEibRky9RoSgJku1gGpnqI+F8FqwTC9JjHWhAvHAn5+7+PFj1k\n2i2KAlnBajk30mn1DD9+LyG9pAHFzHT5u4mle+rwgqbIN0YrlhkPqe5ZRsdaQjlS\nxN9jduOiNGWfERneGS1Yo7uyjO4bz6nex3FXffch/GyxbW00fMrijqU6CwJCKSAF\n7YTjhaYIKyd4VbV3aooqpqoQQ1FIPmLLiRe5tXanwW1is1Enae1tLFiJuHvi+mKB\nixQ=\n-----END CERTIFICATE-----\n"
+                "ca.crt": "-----BEGIN CERTIFICATE-----\nMIIC/jCCAeagAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl\ncm5ldGVzMB4XDTI0MDIxMjIyMTgzMFoXDTM0MDIwOTIyMTgzMFowFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMa8\nimN1ymLOBIS2L5JFSJqasFgfREc/ZhC7uZi0hbx+L0bYTdBbQPiMxnrpJCfJVjlp\nApbnJ2qDrsA2KIfOawBbYs2p3iQuG3k7cZyvdHzVAlWqus96j4Pczofb1oR9qDCY\nYxqml7/t0e1lgiPZIRVwSin/a7Hi0Jc4NoMVgzXJQWn58Qx32Q2sFkmlLt9jAr92\nVhsO2ZrN6ftqkjwBe869B24eron1/eNQ3XpdVPQ/MGrAi3jflQJZW5TRTjhyrsR4\nauq3fiZY8JwHHhB9RCcejGgidQ3/CFWmkl6EokGUbHNbU0iJ5gXPzhcIvC0CsCic\nn+tWmmEcZC8rScEAY9cCAwEAAaNZMFcwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB\n/wQFMAMBAf8wHQYDVR0OBBYEFChgIHtp5yQbsb8aze5Fr+JPUF0uMBUGA1UdEQQO\nMAyCCmt1YmVybmV0ZXMwDQYJKoZIhvcNAQELBQADggEBAAAJ13y8No+6fD/Mp6v/\nb2Tk9BotaDyMl0VF83SIL08JFYmQvzFE/1ZSgptKMxDm6VK4nyg6NvIfJdPV5miz\nZCNeQgp6XoQGhzSKKEYvsrHLsodpYunbgeXYvWsBR5g8wbZiME3OsoJcFFq9Pxor\nwixCmzHPvP0ytnXZrIcUU1va5IX4mDauMsLdz61TEJGrBowZTYVRE3bRvTQemXMq\nKIoviQRj2V3yY3ZtCvXVShNiTj5Dt3nrkH14cI7DlQwoP2AGSFhKP35Fk9FjghYs\nOtWnPqhKtb1r1odLWpRzQwAx4xDRLgLevdGwVlXNyzPJxR1xz4p0XfDdT8ygM0x6\n5kI=\n-----END CERTIFICATE-----\n"
             },
             "immutable": null,
             "kind": null,
@@ -12293,7 +12293,7 @@
                 "annotations": {
                     "kubernetes.io/description": "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. No other usage is guaranteed across distributions of Kubernetes clusters."
                 },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "creation_timestamp": "2024-02-12T22:19:06+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -12319,354 +12319,164 @@
                         "manager": "kube-controller-manager",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:19:06+00:00"
                     }
                 ],
                 "name": "kube-root-ca.crt",
-                "namespace": "mpi-operator",
+                "namespace": "default",
                 "owner_references": null,
-                "resource_version": "760",
+                "resource_version": "356",
                 "self_link": null,
-                "uid": "f33ecdb3-9e3a-403e-9d20-aa76761bf28d"
+                "uid": "802b9543-2252-4793-aba6-4e735c3c314e"
+            }
+        },
+        "pi-config": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "discover_hosts.sh": "#!/bin/sh\necho pi-worker-0.pi-worker.default.svc\necho pi-worker-1.pi-worker.default.svc\n",
+                "hostfile": "pi-worker-0.pi-worker.default.svc slots=1\npi-worker-1.pi-worker.default.svc slots=1\n"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-12T22:26:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "pi"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:discover_hosts.sh": {},
+                                "f:hostfile": {}
+                            },
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"a853a5db-531f-4382-b291-a10b5a140c20\"}": {}
+                                }
+                            }
+                        },
+                        "manager": "mpi-operator",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-12T22:26:59+00:00"
+                    }
+                ],
+                "name": "pi-config",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "kubeflow.org/v2beta1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "MPIJob",
+                        "name": "pi",
+                        "uid": "a853a5db-531f-4382-b291-a10b5a140c20"
+                    }
+                ],
+                "resource_version": "1595",
+                "self_link": null,
+                "uid": "929d8c16-6e97-4a46-9ea8-57da4f891246"
             }
         }
     },
     "cron_job": {},
     "daemon_set": {},
-    "deployment": {
-        "mpi-operator": {
+    "deployment": {},
+    "endpoint": {
+        "kubernetes": {
             "api_version": null,
             "kind": null,
             "metadata": {
-                "annotations": {
-                    "deployment.kubernetes.io/revision": "1",
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\",\"namespace\":\"mpi-operator\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"}},\"template\":{\"metadata\":{\"annotations\":{\"sidecar.istio.io/inject\":\"false\"},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"}},\"spec\":{\"containers\":[{\"args\":[\"-alsologtostderr\",\"--lock-namespace=mpi-operator\"],\"image\":\"mpioperator/mpi-operator:master\",\"name\":\"mpi-operator\"}],\"serviceAccountName\":\"mpi-operator\"}}}}\n"
-                },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "annotations": null,
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
                 "generate_name": null,
-                "generation": 1,
+                "generation": null,
                 "labels": {
-                    "app": "mpi-operator",
-                    "app.kubernetes.io/component": "mpijob",
-                    "app.kubernetes.io/name": "mpi-operator",
-                    "kustomize.component": "mpi-operator"
+                    "endpointslice.kubernetes.io/skip-mirror": "true"
                 },
                 "managed_fields": [
                     {
-                        "api_version": "apps/v1",
+                        "api_version": "v1",
                         "fields_type": "FieldsV1",
                         "fields_v1": {
                             "f:metadata": {
-                                "f:annotations": {
-                                    ".": {},
-                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                                },
                                 "f:labels": {
                                     ".": {},
-                                    "f:app": {},
-                                    "f:app.kubernetes.io/component": {},
-                                    "f:app.kubernetes.io/name": {},
-                                    "f:kustomize.component": {}
+                                    "f:endpointslice.kubernetes.io/skip-mirror": {}
                                 }
                             },
-                            "f:spec": {
-                                "f:progressDeadlineSeconds": {},
-                                "f:replicas": {},
-                                "f:revisionHistoryLimit": {},
-                                "f:selector": {},
-                                "f:strategy": {
-                                    "f:rollingUpdate": {
-                                        ".": {},
-                                        "f:maxSurge": {},
-                                        "f:maxUnavailable": {}
-                                    },
-                                    "f:type": {}
-                                },
-                                "f:template": {
-                                    "f:metadata": {
-                                        "f:annotations": {
-                                            ".": {},
-                                            "f:sidecar.istio.io/inject": {}
-                                        },
-                                        "f:labels": {
-                                            ".": {},
-                                            "f:app": {},
-                                            "f:app.kubernetes.io/component": {},
-                                            "f:app.kubernetes.io/name": {},
-                                            "f:kustomize.component": {}
-                                        }
-                                    },
-                                    "f:spec": {
-                                        "f:containers": {
-                                            "k:{\"name\":\"mpi-operator\"}": {
-                                                ".": {},
-                                                "f:args": {},
-                                                "f:image": {},
-                                                "f:imagePullPolicy": {},
-                                                "f:name": {},
-                                                "f:resources": {},
-                                                "f:terminationMessagePath": {},
-                                                "f:terminationMessagePolicy": {}
-                                            }
-                                        },
-                                        "f:dnsPolicy": {},
-                                        "f:restartPolicy": {},
-                                        "f:schedulerName": {},
-                                        "f:securityContext": {},
-                                        "f:serviceAccount": {},
-                                        "f:serviceAccountName": {},
-                                        "f:terminationGracePeriodSeconds": {}
-                                    }
-                                }
-                            }
+                            "f:subsets": {}
                         },
-                        "manager": "kubectl-client-side-apply",
+                        "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
-                    },
-                    {
-                        "api_version": "apps/v1",
-                        "fields_type": "FieldsV1",
-                        "fields_v1": {
-                            "f:metadata": {
-                                "f:annotations": {
-                                    "f:deployment.kubernetes.io/revision": {}
-                                }
-                            },
-                            "f:status": {
-                                "f:availableReplicas": {},
-                                "f:conditions": {
-                                    ".": {},
-                                    "k:{\"type\":\"Available\"}": {
-                                        ".": {},
-                                        "f:lastTransitionTime": {},
-                                        "f:lastUpdateTime": {},
-                                        "f:message": {},
-                                        "f:reason": {},
-                                        "f:status": {},
-                                        "f:type": {}
-                                    },
-                                    "k:{\"type\":\"Progressing\"}": {
-                                        ".": {},
-                                        "f:lastTransitionTime": {},
-                                        "f:lastUpdateTime": {},
-                                        "f:message": {},
-                                        "f:reason": {},
-                                        "f:status": {},
-                                        "f:type": {}
-                                    }
-                                },
-                                "f:observedGeneration": {},
-                                "f:readyReplicas": {},
-                                "f:replicas": {},
-                                "f:updatedReplicas": {}
-                            }
-                        },
-                        "manager": "kube-controller-manager",
-                        "operation": "Update",
-                        "subresource": "status",
-                        "time": "2024-02-07T19:21:32+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
-                "name": "mpi-operator",
-                "namespace": "mpi-operator",
+                "name": "kubernetes",
+                "namespace": "default",
                 "owner_references": null,
-                "resource_version": "1147",
+                "resource_version": "234",
                 "self_link": null,
-                "uid": "7a910c00-7d78-4054-a271-91aadea59e1a"
+                "uid": "bd1fd7ea-52cc-4c4d-8e81-f22ba61e3426"
             },
-            "spec": {
-                "min_ready_seconds": null,
-                "paused": null,
-                "progress_deadline_seconds": 600,
-                "replicas": 1,
-                "revision_history_limit": 10,
-                "selector": {
-                    "match_expressions": null,
-                    "match_labels": {
-                        "app": "mpi-operator",
-                        "app.kubernetes.io/component": "mpijob",
-                        "app.kubernetes.io/name": "mpi-operator",
-                        "kustomize.component": "mpi-operator"
-                    }
-                },
-                "strategy": {
-                    "rolling_update": {
-                        "max_surge": "25%",
-                        "max_unavailable": "25%"
-                    },
-                    "type": "RollingUpdate"
-                },
-                "template": {
-                    "metadata": {
-                        "annotations": {
-                            "sidecar.istio.io/inject": "false"
-                        },
-                        "creation_timestamp": null,
-                        "deletion_grace_period_seconds": null,
-                        "deletion_timestamp": null,
-                        "finalizers": null,
-                        "generate_name": null,
-                        "generation": null,
-                        "labels": {
-                            "app": "mpi-operator",
-                            "app.kubernetes.io/component": "mpijob",
-                            "app.kubernetes.io/name": "mpi-operator",
-                            "kustomize.component": "mpi-operator"
-                        },
-                        "managed_fields": null,
-                        "name": null,
-                        "namespace": null,
-                        "owner_references": null,
-                        "resource_version": null,
-                        "self_link": null,
-                        "uid": null
-                    },
-                    "spec": {
-                        "active_deadline_seconds": null,
-                        "affinity": null,
-                        "automount_service_account_token": null,
-                        "containers": [
-                            {
-                                "args": [
-                                    "-alsologtostderr",
-                                    "--lock-namespace=mpi-operator"
-                                ],
-                                "command": null,
-                                "env": null,
-                                "env_from": null,
-                                "image": "mpioperator/mpi-operator:master",
-                                "image_pull_policy": "IfNotPresent",
-                                "lifecycle": null,
-                                "liveness_probe": null,
-                                "name": "mpi-operator",
-                                "ports": null,
-                                "readiness_probe": null,
-                                "resources": {
-                                    "claims": null,
-                                    "limits": null,
-                                    "requests": null
-                                },
-                                "security_context": null,
-                                "startup_probe": null,
-                                "stdin": null,
-                                "stdin_once": null,
-                                "termination_message_path": "/dev/termination-log",
-                                "termination_message_policy": "File",
-                                "tty": null,
-                                "volume_devices": null,
-                                "volume_mounts": null,
-                                "working_dir": null
-                            }
-                        ],
-                        "dns_config": null,
-                        "dns_policy": "ClusterFirst",
-                        "enable_service_links": null,
-                        "ephemeral_containers": null,
-                        "host_aliases": null,
-                        "host_ipc": null,
-                        "host_network": null,
-                        "host_pid": null,
-                        "host_users": null,
-                        "hostname": null,
-                        "image_pull_secrets": null,
-                        "init_containers": null,
-                        "node_name": null,
-                        "node_selector": null,
-                        "os": null,
-                        "overhead": null,
-                        "preemption_policy": null,
-                        "priority": null,
-                        "priority_class_name": null,
-                        "readiness_gates": null,
-                        "resource_claims": null,
-                        "restart_policy": "Always",
-                        "runtime_class_name": null,
-                        "scheduler_name": "default-scheduler",
-                        "scheduling_gates": null,
-                        "security_context": {
-                            "fs_group": null,
-                            "fs_group_change_policy": null,
-                            "run_as_group": null,
-                            "run_as_non_root": null,
-                            "run_as_user": null,
-                            "se_linux_options": null,
-                            "seccomp_profile": null,
-                            "supplemental_groups": null,
-                            "sysctls": null,
-                            "windows_options": null
-                        },
-                        "service_account": "mpi-operator",
-                        "service_account_name": "mpi-operator",
-                        "set_hostname_as_fqdn": null,
-                        "share_process_namespace": null,
-                        "subdomain": null,
-                        "termination_grace_period_seconds": 30,
-                        "tolerations": null,
-                        "topology_spread_constraints": null,
-                        "volumes": null
-                    }
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": null,
+                            "ip": "172.18.0.5",
+                            "node_name": null,
+                            "target_ref": null
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": [
+                        {
+                            "app_protocol": null,
+                            "name": "https",
+                            "port": 6443,
+                            "protocol": "TCP"
+                        }
+                    ]
                 }
-            },
-            "status": {
-                "available_replicas": 1,
-                "collision_count": null,
-                "conditions": [
-                    {
-                        "last_transition_time": "2024-02-07T19:18:34+00:00",
-                        "last_update_time": "2024-02-07T19:18:49+00:00",
-                        "message": "ReplicaSet \"mpi-operator-6b8447f5cd\" has successfully progressed.",
-                        "reason": "NewReplicaSetAvailable",
-                        "status": "True",
-                        "type": "Progressing"
-                    },
-                    {
-                        "last_transition_time": "2024-02-07T19:21:32+00:00",
-                        "last_update_time": "2024-02-07T19:21:32+00:00",
-                        "message": "Deployment has minimum availability.",
-                        "reason": "MinimumReplicasAvailable",
-                        "status": "True",
-                        "type": "Available"
-                    }
-                ],
-                "observed_generation": 1,
-                "ready_replicas": 1,
-                "replicas": 1,
-                "unavailable_replicas": null,
-                "updated_replicas": 1
-            }
-        }
-    },
-    "endpoint": {},
-    "ingress": {},
-    "job": {},
-    "network_policy": {},
-    "persistent_volume_claim": {},
-    "persistent_volume": {},
-    "pod": {
-        "mpi-operator-6b8447f5cd-xcptc": {
+            ]
+        },
+        "pi-worker": {
             "api_version": null,
             "kind": null,
             "metadata": {
                 "annotations": {
-                    "sidecar.istio.io/inject": "false"
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2024-02-12T22:26:59Z"
                 },
-                "creation_timestamp": "2024-02-07T19:18:35+00:00",
+                "creation_timestamp": "2024-02-12T22:26:48+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
-                "generate_name": "mpi-operator-6b8447f5cd-",
+                "generate_name": null,
                 "generation": null,
                 "labels": {
-                    "app": "mpi-operator",
-                    "app.kubernetes.io/component": "mpijob",
-                    "app.kubernetes.io/name": "mpi-operator",
-                    "kustomize.component": "mpi-operator",
-                    "pod-template-hash": "6b8447f5cd"
+                    "app": "pi",
+                    "service.kubernetes.io/headless": ""
                 },
                 "managed_fields": [
                     {
@@ -12676,49 +12486,181 @@
                             "f:metadata": {
                                 "f:annotations": {
                                     ".": {},
-                                    "f:sidecar.istio.io/inject": {}
+                                    "f:endpoints.kubernetes.io/last-change-trigger-time": {}
                                 },
-                                "f:generateName": {},
                                 "f:labels": {
                                     ".": {},
                                     "f:app": {},
-                                    "f:app.kubernetes.io/component": {},
-                                    "f:app.kubernetes.io/name": {},
-                                    "f:kustomize.component": {},
-                                    "f:pod-template-hash": {}
-                                },
-                                "f:ownerReferences": {
-                                    ".": {},
-                                    "k:{\"uid\":\"72d94527-ebb3-430f-8b51-48092f88db4b\"}": {}
+                                    "f:service.kubernetes.io/headless": {}
                                 }
                             },
-                            "f:spec": {
-                                "f:containers": {
-                                    "k:{\"name\":\"mpi-operator\"}": {
-                                        ".": {},
-                                        "f:args": {},
-                                        "f:image": {},
-                                        "f:imagePullPolicy": {},
-                                        "f:name": {},
-                                        "f:resources": {},
-                                        "f:terminationMessagePath": {},
-                                        "f:terminationMessagePolicy": {}
-                                    }
-                                },
-                                "f:dnsPolicy": {},
-                                "f:enableServiceLinks": {},
-                                "f:restartPolicy": {},
-                                "f:schedulerName": {},
-                                "f:securityContext": {},
-                                "f:serviceAccount": {},
-                                "f:serviceAccountName": {},
-                                "f:terminationGracePeriodSeconds": {}
-                            }
+                            "f:subsets": {}
                         },
                         "manager": "kube-controller-manager",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:26:59+00:00"
+                    }
+                ],
+                "name": "pi-worker",
+                "namespace": "default",
+                "owner_references": null,
+                "resource_version": "1593",
+                "self_link": null,
+                "uid": "4858e1c4-47f0-4d3c-b8b5-9d880fd90cd5"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": "pi-worker-1",
+                            "ip": "10.244.1.2",
+                            "node_name": "kind-worker",
+                            "target_ref": {
+                                "api_version": null,
+                                "field_path": null,
+                                "kind": "Pod",
+                                "name": "pi-worker-1",
+                                "namespace": "default",
+                                "resource_version": null,
+                                "uid": "1a67baab-b441-4478-bfe4-31737be86025"
+                            }
+                        },
+                        {
+                            "hostname": "pi-worker-0",
+                            "ip": "10.244.3.2",
+                            "node_name": "kind-worker3",
+                            "target_ref": {
+                                "api_version": null,
+                                "field_path": null,
+                                "kind": "Pod",
+                                "name": "pi-worker-0",
+                                "namespace": "default",
+                                "resource_version": null,
+                                "uid": "93a88d29-171d-4778-8e57-3c3f2e4ac165"
+                            }
+                        }
+                    ],
+                    "not_ready_addresses": null,
+                    "ports": null
+                }
+            ]
+        }
+    },
+    "ingress": {},
+    "job": {},
+    "network_policy": {},
+    "persistent_volume_claim": {},
+    "persistent_volume": {},
+    "pod": {
+        "pi-worker-0": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-12T22:26:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "training.kubeflow.org/job-name": "pi",
+                    "training.kubeflow.org/job-role": "worker",
+                    "training.kubeflow.org/operator-name": "mpi-operator",
+                    "training.kubeflow.org/replica-index": "0"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:training.kubeflow.org/job-name": {},
+                                    "f:training.kubeflow.org/job-role": {},
+                                    "f:training.kubeflow.org/operator-name": {},
+                                    "f:training.kubeflow.org/replica-index": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"a853a5db-531f-4382-b291-a10b5a140c20\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"mpi-worker\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"K_MPI_JOB_ROLE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsUser": {}
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/home/mpiuser/.ssh\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:hostname": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {},
+                                "f:subdomain": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"ssh-auth\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:items": {},
+                                            "f:secretName": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "mpi-operator",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-12T22:26:48+00:00"
                     },
                     {
                         "api_version": "v1",
@@ -12754,7 +12696,7 @@
                                 "f:podIP": {},
                                 "f:podIPs": {
                                     ".": {},
-                                    "k:{\"ip\":\"10.244.1.2\"}": {
+                                    "k:{\"ip\":\"10.244.3.2\"}": {
                                         ".": {},
                                         "f:ip": {}
                                     }
@@ -12765,24 +12707,24 @@
                         "manager": "kubelet",
                         "operation": "Update",
                         "subresource": "status",
-                        "time": "2024-02-07T19:21:29+00:00"
+                        "time": "2024-02-12T22:26:59+00:00"
                     }
                 ],
-                "name": "mpi-operator-6b8447f5cd-xcptc",
-                "namespace": "mpi-operator",
+                "name": "pi-worker-0",
+                "namespace": "default",
                 "owner_references": [
                     {
-                        "api_version": "apps/v1",
+                        "api_version": "kubeflow.org/v2beta1",
                         "block_owner_deletion": true,
                         "controller": true,
-                        "kind": "ReplicaSet",
-                        "name": "mpi-operator-6b8447f5cd",
-                        "uid": "72d94527-ebb3-430f-8b51-48092f88db4b"
+                        "kind": "MPIJob",
+                        "name": "pi",
+                        "uid": "a853a5db-531f-4382-b291-a10b5a140c20"
                     }
                 ],
-                "resource_version": "1142",
+                "resource_version": "1592",
                 "self_link": null,
-                "uid": "93c4e218-e327-4be1-b306-1bd669218017"
+                "uid": "93a88d29-171d-4778-8e57-3c3f2e4ac165"
             },
             "spec": {
                 "active_deadline_seconds": null,
@@ -12791,25 +12733,52 @@
                 "containers": [
                     {
                         "args": [
-                            "-alsologtostderr",
-                            "--lock-namespace=mpi-operator"
+                            "-De",
+                            "-f",
+                            "/home/mpiuser/.sshd_config"
                         ],
-                        "command": null,
-                        "env": null,
+                        "command": [
+                            "/usr/sbin/sshd"
+                        ],
+                        "env": [
+                            {
+                                "name": "K_MPI_JOB_ROLE",
+                                "value": "worker",
+                                "value_from": null
+                            }
+                        ],
                         "env_from": null,
-                        "image": "mpioperator/mpi-operator:master",
+                        "image": "mpioperator/mpi-pi:openmpi",
                         "image_pull_policy": "IfNotPresent",
                         "lifecycle": null,
                         "liveness_probe": null,
-                        "name": "mpi-operator",
+                        "name": "mpi-worker",
                         "ports": null,
                         "readiness_probe": null,
                         "resources": {
                             "claims": null,
-                            "limits": null,
-                            "requests": null
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1Gi"
+                            },
+                            "requests": {
+                                "cpu": "1",
+                                "memory": "1Gi"
+                            }
                         },
-                        "security_context": null,
+                        "security_context": {
+                            "allow_privilege_escalation": null,
+                            "capabilities": null,
+                            "privileged": null,
+                            "proc_mount": null,
+                            "read_only_root_filesystem": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": 1000,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "windows_options": null
+                        },
                         "startup_probe": null,
                         "stdin": null,
                         "stdin_once": null,
@@ -12819,9 +12788,17 @@
                         "volume_devices": null,
                         "volume_mounts": [
                             {
+                                "mount_path": "/home/mpiuser/.ssh",
+                                "mount_propagation": null,
+                                "name": "ssh-auth",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
                                 "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
                                 "mount_propagation": null,
-                                "name": "kube-api-access-2qsz5",
+                                "name": "kube-api-access-695tz",
                                 "read_only": true,
                                 "sub_path": null,
                                 "sub_path_expr": null
@@ -12839,10 +12816,10 @@
                 "host_network": null,
                 "host_pid": null,
                 "host_users": null,
-                "hostname": null,
+                "hostname": "pi-worker-0",
                 "image_pull_secrets": null,
                 "init_containers": null,
-                "node_name": "kind-worker2",
+                "node_name": "kind-worker3",
                 "node_selector": null,
                 "os": null,
                 "overhead": null,
@@ -12851,7 +12828,7 @@
                 "priority_class_name": null,
                 "readiness_gates": null,
                 "resource_claims": null,
-                "restart_policy": "Always",
+                "restart_policy": "Never",
                 "runtime_class_name": null,
                 "scheduler_name": "default-scheduler",
                 "scheduling_gates": null,
@@ -12867,11 +12844,11 @@
                     "sysctls": null,
                     "windows_options": null
                 },
-                "service_account": "mpi-operator",
-                "service_account_name": "mpi-operator",
+                "service_account": "default",
+                "service_account_name": "default",
                 "set_hostname_as_fqdn": null,
                 "share_process_namespace": null,
-                "subdomain": null,
+                "subdomain": "pi-worker",
                 "termination_grace_period_seconds": 30,
                 "tolerations": [
                     {
@@ -12910,7 +12887,60 @@
                         "glusterfs": null,
                         "host_path": null,
                         "iscsi": null,
-                        "name": "kube-api-access-2qsz5",
+                        "name": "ssh-auth",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": {
+                            "default_mode": 420,
+                            "items": [
+                                {
+                                    "key": "ssh-privatekey",
+                                    "mode": null,
+                                    "path": "id_rsa"
+                                },
+                                {
+                                    "key": "ssh-publickey",
+                                    "mode": null,
+                                    "path": "id_rsa.pub"
+                                },
+                                {
+                                    "key": "ssh-publickey",
+                                    "mode": null,
+                                    "path": "authorized_keys"
+                                }
+                            ],
+                            "optional": null,
+                            "secret_name": "pi-ssh"
+                        },
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-695tz",
                         "nfs": null,
                         "persistent_volume_claim": null,
                         "photon_persistent_disk": null,
@@ -12977,7 +13007,7 @@
                 "conditions": [
                     {
                         "last_probe_time": null,
-                        "last_transition_time": "2024-02-07T19:18:35+00:00",
+                        "last_transition_time": "2024-02-12T22:26:48+00:00",
                         "message": null,
                         "reason": null,
                         "status": "True",
@@ -12985,7 +13015,7 @@
                     },
                     {
                         "last_probe_time": null,
-                        "last_transition_time": "2024-02-07T19:21:27+00:00",
+                        "last_transition_time": "2024-02-12T22:26:59+00:00",
                         "message": null,
                         "reason": null,
                         "status": "True",
@@ -12993,7 +13023,7 @@
                     },
                     {
                         "last_probe_time": null,
-                        "last_transition_time": "2024-02-07T19:21:27+00:00",
+                        "last_transition_time": "2024-02-12T22:26:59+00:00",
                         "message": null,
                         "reason": null,
                         "status": "True",
@@ -13001,7 +13031,7 @@
                     },
                     {
                         "last_probe_time": null,
-                        "last_transition_time": "2024-02-07T19:18:35+00:00",
+                        "last_transition_time": "2024-02-12T22:26:48+00:00",
                         "message": null,
                         "reason": null,
                         "status": "True",
@@ -13010,29 +13040,21 @@
                 ],
                 "container_statuses": [
                     {
-                        "container_id": "containerd://08e85bc6e7f36f28e7b739bc2c8e54c113b19ded589327662de5fb5361692209",
-                        "image": "docker.io/mpioperator/mpi-operator:master",
-                        "image_id": "docker.io/mpioperator/mpi-operator@sha256:57e02cd03a5281e0c3eb0712f8a66db3cee83867ef0433169d5f6dd00963d3d2",
+                        "container_id": "containerd://036e8196d266d77aa93026d82a518872b6c8ff808605e8eee78c6bb82e33816e",
+                        "image": "docker.io/mpioperator/mpi-pi:openmpi",
+                        "image_id": "docker.io/mpioperator/mpi-pi@sha256:87bb28d964b0c1fc28438552e85e7a6236060cba31ac1996bc3b9376e1855a79",
                         "last_state": {
                             "running": null,
-                            "terminated": {
-                                "container_id": "containerd://0bd28afbf354047025f8b9198f513c29252904445d3e63824c38e99568bba2a3",
-                                "exit_code": 255,
-                                "finished_at": "2024-02-07T19:21:21+00:00",
-                                "message": null,
-                                "reason": "Error",
-                                "signal": null,
-                                "started_at": "2024-02-07T19:18:48+00:00"
-                            },
+                            "terminated": null,
                             "waiting": null
                         },
-                        "name": "mpi-operator",
+                        "name": "mpi-worker",
                         "ready": true,
-                        "restart_count": 1,
+                        "restart_count": 0,
                         "started": true,
                         "state": {
                             "running": {
-                                "started_at": "2024-02-07T19:21:26+00:00"
+                                "started_at": "2024-02-12T22:26:59+00:00"
                             },
                             "terminated": null,
                             "waiting": null
@@ -13045,285 +13067,614 @@
                 "message": null,
                 "nominated_node_name": null,
                 "phase": "Running",
+                "pod_ip": "10.244.3.2",
+                "pod_i_ps": [
+                    {
+                        "ip": "10.244.3.2"
+                    }
+                ],
+                "qos_class": "Guaranteed",
+                "reason": null,
+                "start_time": "2024-02-12T22:26:48+00:00"
+            }
+        },
+        "pi-worker-1": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-12T22:26:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "training.kubeflow.org/job-name": "pi",
+                    "training.kubeflow.org/job-role": "worker",
+                    "training.kubeflow.org/operator-name": "mpi-operator",
+                    "training.kubeflow.org/replica-index": "1"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:training.kubeflow.org/job-name": {},
+                                    "f:training.kubeflow.org/job-role": {},
+                                    "f:training.kubeflow.org/operator-name": {},
+                                    "f:training.kubeflow.org/replica-index": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"a853a5db-531f-4382-b291-a10b5a140c20\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"mpi-worker\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"K_MPI_JOB_ROLE\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:value": {}
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:limits": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            },
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:securityContext": {
+                                            ".": {},
+                                            "f:runAsUser": {}
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/home/mpiuser/.ssh\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:hostname": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {},
+                                "f:subdomain": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"ssh-auth\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:items": {},
+                                            "f:secretName": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "mpi-operator",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-12T22:26:48+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"ContainersReady\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Initialized\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:containerStatuses": {},
+                                "f:hostIP": {},
+                                "f:phase": {},
+                                "f:podIP": {},
+                                "f:podIPs": {
+                                    ".": {},
+                                    "k:{\"ip\":\"10.244.1.2\"}": {
+                                        ".": {},
+                                        "f:ip": {}
+                                    }
+                                },
+                                "f:startTime": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-12T22:26:59+00:00"
+                    }
+                ],
+                "name": "pi-worker-1",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "kubeflow.org/v2beta1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "MPIJob",
+                        "name": "pi",
+                        "uid": "a853a5db-531f-4382-b291-a10b5a140c20"
+                    }
+                ],
+                "resource_version": "1584",
+                "self_link": null,
+                "uid": "1a67baab-b441-4478-bfe4-31737be86025"
+            },
+            "spec": {
+                "active_deadline_seconds": null,
+                "affinity": null,
+                "automount_service_account_token": null,
+                "containers": [
+                    {
+                        "args": [
+                            "-De",
+                            "-f",
+                            "/home/mpiuser/.sshd_config"
+                        ],
+                        "command": [
+                            "/usr/sbin/sshd"
+                        ],
+                        "env": [
+                            {
+                                "name": "K_MPI_JOB_ROLE",
+                                "value": "worker",
+                                "value_from": null
+                            }
+                        ],
+                        "env_from": null,
+                        "image": "mpioperator/mpi-pi:openmpi",
+                        "image_pull_policy": "IfNotPresent",
+                        "lifecycle": null,
+                        "liveness_probe": null,
+                        "name": "mpi-worker",
+                        "ports": null,
+                        "readiness_probe": null,
+                        "resources": {
+                            "claims": null,
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1Gi"
+                            },
+                            "requests": {
+                                "cpu": "1",
+                                "memory": "1Gi"
+                            }
+                        },
+                        "security_context": {
+                            "allow_privilege_escalation": null,
+                            "capabilities": null,
+                            "privileged": null,
+                            "proc_mount": null,
+                            "read_only_root_filesystem": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": 1000,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "windows_options": null
+                        },
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/home/mpiuser/.ssh",
+                                "mount_propagation": null,
+                                "name": "ssh-auth",
+                                "read_only": null,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            },
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-wcwpl",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    }
+                ],
+                "dns_config": null,
+                "dns_policy": "ClusterFirst",
+                "enable_service_links": true,
+                "ephemeral_containers": null,
+                "host_aliases": null,
+                "host_ipc": null,
+                "host_network": null,
+                "host_pid": null,
+                "host_users": null,
+                "hostname": "pi-worker-1",
+                "image_pull_secrets": null,
+                "init_containers": null,
+                "node_name": "kind-worker",
+                "node_selector": null,
+                "os": null,
+                "overhead": null,
+                "preemption_policy": "PreemptLowerPriority",
+                "priority": 0,
+                "priority_class_name": null,
+                "readiness_gates": null,
+                "resource_claims": null,
+                "restart_policy": "Never",
+                "runtime_class_name": null,
+                "scheduler_name": "default-scheduler",
+                "scheduling_gates": null,
+                "security_context": {
+                    "fs_group": null,
+                    "fs_group_change_policy": null,
+                    "run_as_group": null,
+                    "run_as_non_root": null,
+                    "run_as_user": null,
+                    "se_linux_options": null,
+                    "seccomp_profile": null,
+                    "supplemental_groups": null,
+                    "sysctls": null,
+                    "windows_options": null
+                },
+                "service_account": "default",
+                "service_account_name": "default",
+                "set_hostname_as_fqdn": null,
+                "share_process_namespace": null,
+                "subdomain": "pi-worker",
+                "termination_grace_period_seconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    }
+                ],
+                "topology_spread_constraints": null,
+                "volumes": [
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "ssh-auth",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": null,
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": {
+                            "default_mode": 420,
+                            "items": [
+                                {
+                                    "key": "ssh-privatekey",
+                                    "mode": null,
+                                    "path": "id_rsa"
+                                },
+                                {
+                                    "key": "ssh-publickey",
+                                    "mode": null,
+                                    "path": "id_rsa.pub"
+                                },
+                                {
+                                    "key": "ssh-publickey",
+                                    "mode": null,
+                                    "path": "authorized_keys"
+                                }
+                            ],
+                            "optional": null,
+                            "secret_name": "pi-ssh"
+                        },
+                        "storageos": null,
+                        "vsphere_volume": null
+                    },
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-wcwpl",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": {
+                            "default_mode": 420,
+                            "sources": [
+                                {
+                                    "config_map": null,
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": {
+                                        "audience": null,
+                                        "expiration_seconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "config_map": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "mode": null,
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt",
+                                        "optional": null
+                                    },
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": null
+                                },
+                                {
+                                    "config_map": null,
+                                    "downward_api": {
+                                        "items": [
+                                            {
+                                                "field_ref": {
+                                                    "api_version": "v1",
+                                                    "field_path": "metadata.namespace"
+                                                },
+                                                "mode": null,
+                                                "path": "namespace",
+                                                "resource_field_ref": null
+                                            }
+                                        ]
+                                    },
+                                    "secret": null,
+                                    "service_account_token": null
+                                }
+                            ]
+                        },
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-12T22:26:48+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-12T22:26:59+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-12T22:26:59+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-12T22:26:48+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "container_statuses": [
+                    {
+                        "container_id": "containerd://897158e9aa0d7485a887ca2feceac73e2848d1e74d375874ecfd3807648c5fa1",
+                        "image": "docker.io/mpioperator/mpi-pi:openmpi",
+                        "image_id": "docker.io/mpioperator/mpi-pi@sha256:87bb28d964b0c1fc28438552e85e7a6236060cba31ac1996bc3b9376e1855a79",
+                        "last_state": {
+                            "running": null,
+                            "terminated": null,
+                            "waiting": null
+                        },
+                        "name": "mpi-worker",
+                        "ready": true,
+                        "restart_count": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-12T22:26:59+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    }
+                ],
+                "ephemeral_container_statuses": null,
+                "host_ip": "172.18.0.2",
+                "init_container_statuses": null,
+                "message": null,
+                "nominated_node_name": null,
+                "phase": "Running",
                 "pod_ip": "10.244.1.2",
                 "pod_i_ps": [
                     {
                         "ip": "10.244.1.2"
                     }
                 ],
-                "qos_class": "BestEffort",
+                "qos_class": "Guaranteed",
                 "reason": null,
-                "start_time": "2024-02-07T19:18:35+00:00"
+                "start_time": "2024-02-12T22:26:48+00:00"
             }
         }
     },
-    "replica_set": {
-        "mpi-operator-6b8447f5cd": {
+    "replica_set": {},
+    "role_binding": {},
+    "role": {},
+    "secret": {
+        "pi-ssh": {
             "api_version": null,
+            "data": {
+                "ssh-privatekey": "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1JSGNBZ0VCQkVJQTkrbEo0cDNoN2tCWnd0aVJ1Mm51bjZSc0wrdUNWdGlta1FPenNpVm1aRmRaTmxUcGlXOHQKRWtrTE9mSmNhdEZhUVptNll0d3JMOTI5T0w3Y1FKL0I2c09nQndZRks0RUVBQ09oZ1lrRGdZWUFCQUZSeVBkTApJYXhyb09LcWVVQy94QjBiamJtMEE2bEVtUG1tT3hrK0o3M2pqdjg1NTN1a1NtYTEya1FyUUh2WkdGcXVNZnl1CkYxNk1Cc212MDJjWWFVbEo0d0ZQSllwMXM4ZGxyam44VnJGK0FBS2pJUVBuSTBtaGJxdXFCdGFrNGhYNGw1TDAKbUJzWnJRVG5ZOEREN1FadE93LzB0TEk3d0QrbkhsVVZhRGI4K1VMakx3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=",
+                "ssh-publickey": "ZWNkc2Etc2hhMi1uaXN0cDUyMSBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEExTWpFQUFBQUlibWx6ZEhBMU1qRUFBQUNGQkFGUnlQZExJYXhyb09LcWVVQy94QjBiamJtMEE2bEVtUG1tT3hrK0o3M2pqdjg1NTN1a1NtYTEya1FyUUh2WkdGcXVNZnl1RjE2TUJzbXYwMmNZYVVsSjR3RlBKWXAxczhkbHJqbjhWckYrQUFLaklRUG5JMG1oYnF1cUJ0YWs0aFg0bDVMMG1Cc1pyUVRuWThERDdRWnRPdy8wdExJN3dEK25IbFVWYURiOCtVTGpMdz09Cg=="
+            },
+            "immutable": null,
             "kind": null,
             "metadata": {
-                "annotations": {
-                    "deployment.kubernetes.io/desired-replicas": "1",
-                    "deployment.kubernetes.io/max-replicas": "2",
-                    "deployment.kubernetes.io/revision": "1"
-                },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "annotations": null,
+                "creation_timestamp": "2024-02-12T22:26:48+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
                 "generate_name": null,
-                "generation": 1,
+                "generation": null,
                 "labels": {
-                    "app": "mpi-operator",
-                    "app.kubernetes.io/component": "mpijob",
-                    "app.kubernetes.io/name": "mpi-operator",
-                    "kustomize.component": "mpi-operator",
-                    "pod-template-hash": "6b8447f5cd"
+                    "app": "pi"
                 },
                 "managed_fields": [
                     {
-                        "api_version": "apps/v1",
+                        "api_version": "v1",
                         "fields_type": "FieldsV1",
                         "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:ssh-privatekey": {},
+                                "f:ssh-publickey": {}
+                            },
                             "f:metadata": {
-                                "f:annotations": {
-                                    ".": {},
-                                    "f:deployment.kubernetes.io/desired-replicas": {},
-                                    "f:deployment.kubernetes.io/max-replicas": {},
-                                    "f:deployment.kubernetes.io/revision": {}
-                                },
                                 "f:labels": {
                                     ".": {},
-                                    "f:app": {},
-                                    "f:app.kubernetes.io/component": {},
-                                    "f:app.kubernetes.io/name": {},
-                                    "f:kustomize.component": {},
-                                    "f:pod-template-hash": {}
+                                    "f:app": {}
                                 },
                                 "f:ownerReferences": {
                                     ".": {},
-                                    "k:{\"uid\":\"7a910c00-7d78-4054-a271-91aadea59e1a\"}": {}
+                                    "k:{\"uid\":\"a853a5db-531f-4382-b291-a10b5a140c20\"}": {}
                                 }
                             },
-                            "f:spec": {
-                                "f:replicas": {},
-                                "f:selector": {},
-                                "f:template": {
-                                    "f:metadata": {
-                                        "f:annotations": {
-                                            ".": {},
-                                            "f:sidecar.istio.io/inject": {}
-                                        },
-                                        "f:labels": {
-                                            ".": {},
-                                            "f:app": {},
-                                            "f:app.kubernetes.io/component": {},
-                                            "f:app.kubernetes.io/name": {},
-                                            "f:kustomize.component": {},
-                                            "f:pod-template-hash": {}
-                                        }
-                                    },
-                                    "f:spec": {
-                                        "f:containers": {
-                                            "k:{\"name\":\"mpi-operator\"}": {
-                                                ".": {},
-                                                "f:args": {},
-                                                "f:image": {},
-                                                "f:imagePullPolicy": {},
-                                                "f:name": {},
-                                                "f:resources": {},
-                                                "f:terminationMessagePath": {},
-                                                "f:terminationMessagePolicy": {}
-                                            }
-                                        },
-                                        "f:dnsPolicy": {},
-                                        "f:restartPolicy": {},
-                                        "f:schedulerName": {},
-                                        "f:securityContext": {},
-                                        "f:serviceAccount": {},
-                                        "f:serviceAccountName": {},
-                                        "f:terminationGracePeriodSeconds": {}
-                                    }
-                                }
-                            }
+                            "f:type": {}
                         },
-                        "manager": "kube-controller-manager",
+                        "manager": "mpi-operator",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
-                    },
-                    {
-                        "api_version": "apps/v1",
-                        "fields_type": "FieldsV1",
-                        "fields_v1": {
-                            "f:status": {
-                                "f:availableReplicas": {},
-                                "f:fullyLabeledReplicas": {},
-                                "f:observedGeneration": {},
-                                "f:readyReplicas": {},
-                                "f:replicas": {}
-                            }
-                        },
-                        "manager": "kube-controller-manager",
-                        "operation": "Update",
-                        "subresource": "status",
-                        "time": "2024-02-07T19:21:29+00:00"
+                        "time": "2024-02-12T22:26:48+00:00"
                     }
                 ],
-                "name": "mpi-operator-6b8447f5cd",
-                "namespace": "mpi-operator",
+                "name": "pi-ssh",
+                "namespace": "default",
                 "owner_references": [
                     {
-                        "api_version": "apps/v1",
+                        "api_version": "kubeflow.org/v2beta1",
                         "block_owner_deletion": true,
                         "controller": true,
-                        "kind": "Deployment",
-                        "name": "mpi-operator",
-                        "uid": "7a910c00-7d78-4054-a271-91aadea59e1a"
+                        "kind": "MPIJob",
+                        "name": "pi",
+                        "uid": "a853a5db-531f-4382-b291-a10b5a140c20"
                     }
                 ],
-                "resource_version": "1143",
+                "resource_version": "1532",
                 "self_link": null,
-                "uid": "72d94527-ebb3-430f-8b51-48092f88db4b"
+                "uid": "5b2fe0ab-dd1d-4445-9a32-71f948fd731d"
             },
-            "spec": {
-                "min_ready_seconds": null,
-                "replicas": 1,
-                "selector": {
-                    "match_expressions": null,
-                    "match_labels": {
-                        "app": "mpi-operator",
-                        "app.kubernetes.io/component": "mpijob",
-                        "app.kubernetes.io/name": "mpi-operator",
-                        "kustomize.component": "mpi-operator",
-                        "pod-template-hash": "6b8447f5cd"
-                    }
-                },
-                "template": {
-                    "metadata": {
-                        "annotations": {
-                            "sidecar.istio.io/inject": "false"
-                        },
-                        "creation_timestamp": null,
-                        "deletion_grace_period_seconds": null,
-                        "deletion_timestamp": null,
-                        "finalizers": null,
-                        "generate_name": null,
-                        "generation": null,
-                        "labels": {
-                            "app": "mpi-operator",
-                            "app.kubernetes.io/component": "mpijob",
-                            "app.kubernetes.io/name": "mpi-operator",
-                            "kustomize.component": "mpi-operator",
-                            "pod-template-hash": "6b8447f5cd"
-                        },
-                        "managed_fields": null,
-                        "name": null,
-                        "namespace": null,
-                        "owner_references": null,
-                        "resource_version": null,
-                        "self_link": null,
-                        "uid": null
-                    },
-                    "spec": {
-                        "active_deadline_seconds": null,
-                        "affinity": null,
-                        "automount_service_account_token": null,
-                        "containers": [
-                            {
-                                "args": [
-                                    "-alsologtostderr",
-                                    "--lock-namespace=mpi-operator"
-                                ],
-                                "command": null,
-                                "env": null,
-                                "env_from": null,
-                                "image": "mpioperator/mpi-operator:master",
-                                "image_pull_policy": "IfNotPresent",
-                                "lifecycle": null,
-                                "liveness_probe": null,
-                                "name": "mpi-operator",
-                                "ports": null,
-                                "readiness_probe": null,
-                                "resources": {
-                                    "claims": null,
-                                    "limits": null,
-                                    "requests": null
-                                },
-                                "security_context": null,
-                                "startup_probe": null,
-                                "stdin": null,
-                                "stdin_once": null,
-                                "termination_message_path": "/dev/termination-log",
-                                "termination_message_policy": "File",
-                                "tty": null,
-                                "volume_devices": null,
-                                "volume_mounts": null,
-                                "working_dir": null
-                            }
-                        ],
-                        "dns_config": null,
-                        "dns_policy": "ClusterFirst",
-                        "enable_service_links": null,
-                        "ephemeral_containers": null,
-                        "host_aliases": null,
-                        "host_ipc": null,
-                        "host_network": null,
-                        "host_pid": null,
-                        "host_users": null,
-                        "hostname": null,
-                        "image_pull_secrets": null,
-                        "init_containers": null,
-                        "node_name": null,
-                        "node_selector": null,
-                        "os": null,
-                        "overhead": null,
-                        "preemption_policy": null,
-                        "priority": null,
-                        "priority_class_name": null,
-                        "readiness_gates": null,
-                        "resource_claims": null,
-                        "restart_policy": "Always",
-                        "runtime_class_name": null,
-                        "scheduler_name": "default-scheduler",
-                        "scheduling_gates": null,
-                        "security_context": {
-                            "fs_group": null,
-                            "fs_group_change_policy": null,
-                            "run_as_group": null,
-                            "run_as_non_root": null,
-                            "run_as_user": null,
-                            "se_linux_options": null,
-                            "seccomp_profile": null,
-                            "supplemental_groups": null,
-                            "sysctls": null,
-                            "windows_options": null
-                        },
-                        "service_account": "mpi-operator",
-                        "service_account_name": "mpi-operator",
-                        "set_hostname_as_fqdn": null,
-                        "share_process_namespace": null,
-                        "subdomain": null,
-                        "termination_grace_period_seconds": 30,
-                        "tolerations": null,
-                        "topology_spread_constraints": null,
-                        "volumes": null
-                    }
-                }
-            },
-            "status": {
-                "available_replicas": 1,
-                "conditions": null,
-                "fully_labeled_replicas": 1,
-                "observed_generation": 1,
-                "ready_replicas": 1,
-                "replicas": 1
-            }
+            "string_data": null,
+            "type": "kubernetes.io/ssh-auth"
         }
     },
-    "role_binding": {},
-    "role": {},
-    "secret": {},
     "service_account": {
         "default": {
             "api_version": null,
@@ -13332,7 +13683,7 @@
             "kind": null,
             "metadata": {
                 "annotations": null,
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "creation_timestamp": "2024-02-12T22:19:06+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -13341,34 +13692,30 @@
                 "labels": null,
                 "managed_fields": null,
                 "name": "default",
-                "namespace": "mpi-operator",
+                "namespace": "default",
                 "owner_references": null,
-                "resource_version": "759",
+                "resource_version": "357",
                 "self_link": null,
-                "uid": "0fef7cde-58ca-4911-88eb-a17c73d7cc6d"
+                "uid": "98712e69-dffc-4ff1-bae4-b1360afc7067"
             },
             "secrets": null
-        },
-        "mpi-operator": {
+        }
+    },
+    "service": {
+        "kubernetes": {
             "api_version": null,
-            "automount_service_account_token": null,
-            "image_pull_secrets": null,
             "kind": null,
             "metadata": {
-                "annotations": {
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\",\"namespace\":\"mpi-operator\"}}\n"
-                },
-                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "annotations": null,
+                "creation_timestamp": "2024-02-12T22:18:50+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
                 "generate_name": null,
                 "generation": null,
                 "labels": {
-                    "app": "mpi-operator",
-                    "app.kubernetes.io/component": "mpijob",
-                    "app.kubernetes.io/name": "mpi-operator",
-                    "kustomize.component": "mpi-operator"
+                    "component": "apiserver",
+                    "provider": "kubernetes"
                 },
                 "managed_fields": [
                     {
@@ -13376,36 +13723,180 @@
                         "fields_type": "FieldsV1",
                         "fields_v1": {
                             "f:metadata": {
-                                "f:annotations": {
-                                    ".": {},
-                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
-                                },
                                 "f:labels": {
                                     ".": {},
-                                    "f:app": {},
-                                    "f:app.kubernetes.io/component": {},
-                                    "f:app.kubernetes.io/name": {},
-                                    "f:kustomize.component": {}
+                                    "f:component": {},
+                                    "f:provider": {}
                                 }
+                            },
+                            "f:spec": {
+                                "f:clusterIP": {},
+                                "f:internalTrafficPolicy": {},
+                                "f:ipFamilyPolicy": {},
+                                "f:ports": {
+                                    ".": {},
+                                    "k:{\"port\":443,\"protocol\":\"TCP\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:port": {},
+                                        "f:protocol": {},
+                                        "f:targetPort": {}
+                                    }
+                                },
+                                "f:sessionAffinity": {},
+                                "f:type": {}
                             }
                         },
-                        "manager": "kubectl-client-side-apply",
+                        "manager": "kube-apiserver",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:18:34+00:00"
+                        "time": "2024-02-12T22:18:50+00:00"
                     }
                 ],
-                "name": "mpi-operator",
-                "namespace": "mpi-operator",
+                "name": "kubernetes",
+                "namespace": "default",
                 "owner_references": null,
-                "resource_version": "763",
+                "resource_version": "232",
                 "self_link": null,
-                "uid": "df35796b-a3d3-4771-b22d-5452a08862d7"
+                "uid": "3485c020-97f8-411e-9201-fd6aaa84a55b"
             },
-            "secrets": null
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "10.96.0.1",
+                "cluster_i_ps": [
+                    "10.96.0.1"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": [
+                    {
+                        "app_protocol": null,
+                        "name": "https",
+                        "node_port": null,
+                        "port": 443,
+                        "protocol": "TCP",
+                        "target_port": 6443
+                    }
+                ],
+                "publish_not_ready_addresses": null,
+                "selector": null,
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
+        },
+        "pi-worker": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-12T22:26:48+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "pi"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"a853a5db-531f-4382-b291-a10b5a140c20\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:clusterIP": {},
+                                "f:internalTrafficPolicy": {},
+                                "f:selector": {},
+                                "f:sessionAffinity": {},
+                                "f:type": {}
+                            }
+                        },
+                        "manager": "mpi-operator",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-12T22:26:48+00:00"
+                    }
+                ],
+                "name": "pi-worker",
+                "namespace": "default",
+                "owner_references": [
+                    {
+                        "api_version": "kubeflow.org/v2beta1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "MPIJob",
+                        "name": "pi",
+                        "uid": "a853a5db-531f-4382-b291-a10b5a140c20"
+                    }
+                ],
+                "resource_version": "1527",
+                "self_link": null,
+                "uid": "fb844fe4-8e6c-4864-9b73-98f977049701"
+            },
+            "spec": {
+                "allocate_load_balancer_node_ports": null,
+                "cluster_ip": "None",
+                "cluster_i_ps": [
+                    "None"
+                ],
+                "external_i_ps": null,
+                "external_name": null,
+                "external_traffic_policy": null,
+                "health_check_node_port": null,
+                "internal_traffic_policy": "Cluster",
+                "ip_families": [
+                    "IPv4"
+                ],
+                "ip_family_policy": "SingleStack",
+                "load_balancer_class": null,
+                "load_balancer_ip": null,
+                "load_balancer_source_ranges": null,
+                "ports": null,
+                "publish_not_ready_addresses": null,
+                "selector": {
+                    "training.kubeflow.org/job-name": "pi",
+                    "training.kubeflow.org/job-role": "worker",
+                    "training.kubeflow.org/operator-name": "mpi-operator"
+                },
+                "session_affinity": "None",
+                "session_affinity_config": null,
+                "type": "ClusterIP"
+            },
+            "status": {
+                "conditions": null,
+                "load_balancer": {
+                    "ingress": null
+                }
+            }
         }
     },
-    "service": {},
     "stateful_set": {},
     "storage_class": {
         "standard": {
@@ -13418,7 +13909,7 @@
                     "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"storage.k8s.io/v1\",\"kind\":\"StorageClass\",\"metadata\":{\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"},\"name\":\"standard\"},\"provisioner\":\"rancher.io/local-path\",\"reclaimPolicy\":\"Delete\",\"volumeBindingMode\":\"WaitForFirstConsumer\"}\n",
                     "storageclass.kubernetes.io/is-default-class": "true"
                 },
-                "creation_timestamp": "2024-02-07T19:16:11+00:00",
+                "creation_timestamp": "2024-02-12T22:18:55+00:00",
                 "deletion_grace_period_seconds": null,
                 "deletion_timestamp": null,
                 "finalizers": null,
@@ -13444,15 +13935,15 @@
                         "manager": "kubectl-client-side-apply",
                         "operation": "Update",
                         "subresource": null,
-                        "time": "2024-02-07T19:16:11+00:00"
+                        "time": "2024-02-12T22:18:55+00:00"
                     }
                 ],
                 "name": "standard",
                 "namespace": null,
                 "owner_references": null,
-                "resource_version": "284",
+                "resource_version": "330",
                 "self_link": null,
-                "uid": "6649df6c-e403-4eb3-9935-31dab783f7f2"
+                "uid": "43726bfa-9ea0-4615-bbf3-8926e18de792"
             },
             "mount_options": null,
             "parameters": null,

--- a/operators/mpi-operator/xp12-system-state.json
+++ b/operators/mpi-operator/xp12-system-state.json
@@ -1,0 +1,13464 @@
+{
+    "cluster_role_binding": {
+        "cluster-admin": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "cluster-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "135",
+                "self_link": null,
+                "uid": "be2dfc41-8ade-46ec-9a55-a369b4dbe171"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "cluster-admin"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:masters",
+                    "namespace": null
+                }
+            ]
+        },
+        "kindnet": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:10+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:10+00:00"
+                    }
+                ],
+                "name": "kindnet",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "269",
+                "self_link": null,
+                "uid": "a2fd7d69-68a1-4a8d-af14-495edc2a2fb4"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kindnet"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kindnet",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "kubeadm:get-nodes": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:07+00:00"
+                    }
+                ],
+                "name": "kubeadm:get-nodes",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "213",
+                "self_link": null,
+                "uid": "02fcc43c-f7bd-4d17-9e2e-d1f56c47ae44"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "kubeadm:get-nodes"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:kubelet-bootstrap": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:07+00:00"
+                    }
+                ],
+                "name": "kubeadm:kubelet-bootstrap",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "214",
+                "self_link": null,
+                "uid": "30260fee-2f7c-4f5a-8343-dc8f943f26bf"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-bootstrapper"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-autoapprove-bootstrap": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:07+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-autoapprove-bootstrap",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "216",
+                "self_link": null,
+                "uid": "613364cb-5dca-420e-ae63-65fb3bf57cbe"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:certificates.k8s.io:certificatesigningrequests:nodeclient"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:bootstrappers:kubeadm:default-node-token",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-autoapprove-certificate-rotation": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:07+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-autoapprove-certificate-rotation",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "217",
+                "self_link": null,
+                "uid": "507e3e30-9ee4-4040-96b6-f81a8c52b629"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:nodes",
+                    "namespace": null
+                }
+            ]
+        },
+        "kubeadm:node-proxier": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:08+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:08+00:00"
+                    }
+                ],
+                "name": "kubeadm:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "244",
+                "self_link": null,
+                "uid": "6adbc3b4-0655-4496-afb7-58a84b2d7744"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-proxier"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kube-proxy",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "local-path-provisioner-bind": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-bind\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"local-path-provisioner-role\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"local-path-provisioner-service-account\",\"namespace\":\"local-path-storage\"}]}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:16:11+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:11+00:00"
+                    }
+                ],
+                "name": "local-path-provisioner-bind",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "282",
+                "self_link": null,
+                "uid": "4444b608-5f3c-485b-9216-deb50e45f26c"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "local-path-provisioner-role"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "local-path-provisioner-service-account",
+                    "namespace": "local-path-storage"
+                }
+            ]
+        },
+        "mpi-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRoleBinding\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\"},\"roleRef\":{\"apiGroup\":\"rbac.authorization.k8s.io\",\"kind\":\"ClusterRole\",\"name\":\"mpi-operator\"},\"subjects\":[{\"kind\":\"ServiceAccount\",\"name\":\"mpi-operator\",\"namespace\":\"mpi-operator\"}]}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    }
+                ],
+                "name": "mpi-operator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "770",
+                "self_link": null,
+                "uid": "a8993f03-c51e-4a64-b1c0-15092f986f60"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "mpi-operator"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "mpi-operator",
+                    "namespace": "mpi-operator"
+                }
+            ]
+        },
+        "system:basic-user": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:basic-user",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "138",
+                "self_link": null,
+                "uid": "b665a296-c4e6-4e10-913f-f8623d6388ea"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:basic-user"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:controller:attachdetach-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:attachdetach-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "147",
+                "self_link": null,
+                "uid": "3323a5c4-3751-4775-a5b0-1003253b000d"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:attachdetach-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "attachdetach-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:certificate-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:certificate-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "174",
+                "self_link": null,
+                "uid": "f34b7082-e579-4cad-9501-acb82b7e1108"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:certificate-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "certificate-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:clusterrole-aggregation-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:clusterrole-aggregation-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "148",
+                "self_link": null,
+                "uid": "16a0160f-d4d9-4cb2-8bf2-9167588ffd75"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:clusterrole-aggregation-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "clusterrole-aggregation-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:cronjob-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:cronjob-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "149",
+                "self_link": null,
+                "uid": "863c672c-775c-4c4c-acda-a7d3dc2ed846"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:cronjob-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "cronjob-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:daemon-set-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:daemon-set-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "150",
+                "self_link": null,
+                "uid": "fc503a7c-5da7-4f91-91b9-07ca4e919743"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:daemon-set-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "daemon-set-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:deployment-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:deployment-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "151",
+                "self_link": null,
+                "uid": "2a73843c-e8a1-4aa5-963a-6fb9792cabdc"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:deployment-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "deployment-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:disruption-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:disruption-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "152",
+                "self_link": null,
+                "uid": "0a697f6a-450e-433b-a1af-10f2c464c76a"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:disruption-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "disruption-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpoint-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:endpoint-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "154",
+                "self_link": null,
+                "uid": "d4c84b33-28d4-42fa-87c0-339eddb809f7"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpoint-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpoint-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpointslice-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslice-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "155",
+                "self_link": null,
+                "uid": "d202e038-4a97-4e4a-9c6b-7854c3383ba0"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpointslice-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpointslice-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:endpointslicemirroring-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslicemirroring-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "156",
+                "self_link": null,
+                "uid": "75c4e5ee-762c-471c-aa0c-51f15cd0f247"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:endpointslicemirroring-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "endpointslicemirroring-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ephemeral-volume-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:ephemeral-volume-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "158",
+                "self_link": null,
+                "uid": "56eeb686-e9c2-489b-9b16-afb6e3008730"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ephemeral-volume-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ephemeral-volume-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:expand-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:expand-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "157",
+                "self_link": null,
+                "uid": "23a2d19b-b034-4b5a-a712-4510e9a4e657"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:expand-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "expand-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:generic-garbage-collector": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:generic-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "159",
+                "self_link": null,
+                "uid": "dfc4553a-60d2-4fc7-8b58-3891153538a1"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:generic-garbage-collector"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "generic-garbage-collector",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:horizontal-pod-autoscaler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:horizontal-pod-autoscaler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "160",
+                "self_link": null,
+                "uid": "18f42914-9082-4cf0-95e9-2368adb7e69f"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:horizontal-pod-autoscaler"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "horizontal-pod-autoscaler",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:job-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:job-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "161",
+                "self_link": null,
+                "uid": "707ed406-7616-46a8-ae88-e6529b336d43"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:job-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "job-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:namespace-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:namespace-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "162",
+                "self_link": null,
+                "uid": "a3efec8a-e1d1-46dc-96d7-74b2ee27efa2"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:namespace-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "namespace-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:node-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:node-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "163",
+                "self_link": null,
+                "uid": "87c96c3f-a588-4f3d-9e64-2d8ef2f8fc36"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:node-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "node-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:persistent-volume-binder": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:persistent-volume-binder",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "164",
+                "self_link": null,
+                "uid": "17bfe0e5-d6b9-4b9e-b49b-1742fc85336e"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:persistent-volume-binder"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "persistent-volume-binder",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pod-garbage-collector": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:pod-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "165",
+                "self_link": null,
+                "uid": "c4d84fe8-9b01-4cb0-9d85-9282844ef1a8"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pod-garbage-collector"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pod-garbage-collector",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pv-protection-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:pv-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "176",
+                "self_link": null,
+                "uid": "b143ad34-d8ba-4977-94b5-bbac6a7bc3c0"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pv-protection-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pv-protection-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:pvc-protection-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:pvc-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "175",
+                "self_link": null,
+                "uid": "c5e7a62a-e021-4fc4-b902-56e062d656ed"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:pvc-protection-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "pvc-protection-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:replicaset-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:replicaset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "166",
+                "self_link": null,
+                "uid": "56206277-a409-4e3f-8a11-aaaf541a0223"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:replicaset-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "replicaset-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:replication-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:replication-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "167",
+                "self_link": null,
+                "uid": "0e2737af-4399-4c7e-b3d8-189324847eac"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:replication-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "replication-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:resourcequota-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:resourcequota-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "168",
+                "self_link": null,
+                "uid": "278460b0-b8e1-47c3-ba8e-de6457583c37"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:resourcequota-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "resourcequota-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:root-ca-cert-publisher": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:root-ca-cert-publisher",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "178",
+                "self_link": null,
+                "uid": "804844c6-1121-4f05-852e-a8a99e876492"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:root-ca-cert-publisher"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "root-ca-cert-publisher",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:route-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:route-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "169",
+                "self_link": null,
+                "uid": "6b6634e8-425c-44f8-9f38-6f86f7b796ef"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:route-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "route-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:service-account-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:service-account-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "170",
+                "self_link": null,
+                "uid": "fa6b5bac-b2e3-4b93-9908-063c4f304d11"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:service-account-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "service-account-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:service-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:service-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "171",
+                "self_link": null,
+                "uid": "8ea8367a-807b-43ac-ba93-9c176efea59b"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:service-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "service-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:statefulset-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:statefulset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "172",
+                "self_link": null,
+                "uid": "0d8c3732-4fbf-44ca-833d-860bf6e4ef09"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:statefulset-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "statefulset-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ttl-after-finished-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-after-finished-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "177",
+                "self_link": null,
+                "uid": "39543532-2b38-4364-91ee-bc4ef98b1046"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ttl-after-finished-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ttl-after-finished-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:controller:ttl-controller": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "173",
+                "self_link": null,
+                "uid": "5eed15d4-951e-4e9b-989c-a7bf4003ef80"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:controller:ttl-controller"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "ttl-controller",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:coredns": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:08+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:08+00:00"
+                    }
+                ],
+                "name": "system:coredns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "232",
+                "self_link": null,
+                "uid": "26d6112e-7bbb-4946-a97d-6688c7c160dc"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:coredns"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "coredns",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:discovery": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "137",
+                "self_link": null,
+                "uid": "c64f36a7-abc0-4fe8-83c1-0df4d430581c"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:discovery"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:kube-controller-manager": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:kube-controller-manager",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "141",
+                "self_link": null,
+                "uid": "26cdada5-8b6f-46dd-9049-df3bdbf88801"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-controller-manager"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-controller-manager",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:kube-dns": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:kube-dns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "142",
+                "self_link": null,
+                "uid": "067090ab-aa91-4078-8322-8f98e9d192c2"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-dns"
+            },
+            "subjects": [
+                {
+                    "api_group": null,
+                    "kind": "ServiceAccount",
+                    "name": "kube-dns",
+                    "namespace": "kube-system"
+                }
+            ]
+        },
+        "system:kube-scheduler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:kube-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "143",
+                "self_link": null,
+                "uid": "5766d388-c005-49e6-bcfd-d6d2d03d0780"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:kube-scheduler"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-scheduler",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:monitoring": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:monitoring",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "136",
+                "self_link": null,
+                "uid": "5b0ca3e6-4c8c-4f30-9a0a-403b222326be"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:monitoring"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:monitoring",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:node": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:node",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "145",
+                "self_link": null,
+                "uid": "7aec7017-0bb5-4efd-b259-b3381d2b6812"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node"
+            },
+            "subjects": null
+        },
+        "system:node-proxier": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "140",
+                "self_link": null,
+                "uid": "b7b1ccfb-53c8-44df-9147-e459f9402aef"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:node-proxier"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-proxy",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:public-info-viewer": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:public-info-viewer",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "139",
+                "self_link": null,
+                "uid": "aa6dd882-60a7-4412-987e-d5bd3a4fa9bc"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:public-info-viewer"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:authenticated",
+                    "namespace": null
+                },
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:unauthenticated",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:service-account-issuer-discovery": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:service-account-issuer-discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "146",
+                "self_link": null,
+                "uid": "5040fe78-79ea-41d6-aac5-a8fb77d1afc5"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:service-account-issuer-discovery"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "Group",
+                    "name": "system:serviceaccounts",
+                    "namespace": null
+                }
+            ]
+        },
+        "system:volume-scheduler": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:05+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:roleRef": {},
+                            "f:subjects": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:05+00:00"
+                    }
+                ],
+                "name": "system:volume-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "144",
+                "self_link": null,
+                "uid": "23456e43-2733-4a39-ab19-14bc9fe09a6b"
+            },
+            "role_ref": {
+                "api_group": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "system:volume-scheduler"
+            },
+            "subjects": [
+                {
+                    "api_group": "rbac.authorization.k8s.io",
+                    "kind": "User",
+                    "name": "system:kube-scheduler",
+                    "namespace": null
+                }
+            ]
+        }
+    },
+    "cluster_role": {
+        "admin": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:21+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "348",
+                "self_link": null,
+                "uid": "1838e67e-1fe3-4c4d-b998-9a3ec29853af"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "cluster-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "cluster-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "70",
+                "self_link": null,
+                "uid": "17d9528d-9568-4d8f-b851-e7d087b7b0a7"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "*"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "edit": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:21+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "336",
+                "self_link": null,
+                "uid": "9cf796c8-e779-4834-85ad-01c404c23397"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kindnet": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:10+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-create",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:10+00:00"
+                    }
+                ],
+                "name": "kindnet",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "268",
+                "self_link": null,
+                "uid": "4d12914e-4031-44b6-b7b3-b01575fd5cfe"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kindnet"
+                    ],
+                    "resources": [
+                        "podsecuritypolicies"
+                    ],
+                    "verbs": [
+                        "use"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "kubeadm:get-nodes": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:07+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:07+00:00"
+                    }
+                ],
+                "name": "kubeadm:get-nodes",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "211",
+                "self_link": null,
+                "uid": "e3c47cb4-25be-4bdd-89e4-165ede758034"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "kubeflow-mpijobs-admin": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"aggregationRule\":{\"clusterRoleSelectors\":[{\"matchLabels\":{\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin\":\"true\"}}]},\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin\":\"true\"},\"name\":\"kubeflow-mpijobs-admin\"},\"rules\":[]}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator",
+                    "rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {},
+                                    "f:rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin": {}
+                                }
+                            }
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    }
+                ],
+                "name": "kubeflow-mpijobs-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "766",
+                "self_link": null,
+                "uid": "657335f2-9615-4b3e-bbd1-06a430b51a24"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "kubeflow.org"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "mpijobs",
+                        "mpijobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch",
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "kubeflow-mpijobs-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit\":\"true\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin\":\"true\"},\"name\":\"kubeflow-mpijobs-edit\"},\"rules\":[{\"apiGroups\":[\"kubeflow.org\"],\"resources\":[\"mpijobs\",\"mpijobs/status\"],\"verbs\":[\"get\",\"list\",\"watch\",\"create\",\"delete\",\"deletecollection\",\"patch\",\"update\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator",
+                    "rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit": "true",
+                    "rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {},
+                                    "f:rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit": {},
+                                    "f:rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    }
+                ],
+                "name": "kubeflow-mpijobs-edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "765",
+                "self_link": null,
+                "uid": "516a2843-f2c5-424a-b16f-4c82ba15ab36"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "kubeflow.org"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "mpijobs",
+                        "mpijobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch",
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "kubeflow-mpijobs-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\",\"rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view\":\"true\"},\"name\":\"kubeflow-mpijobs-view\"},\"rules\":[{\"apiGroups\":[\"kubeflow.org\"],\"resources\":[\"mpijobs\",\"mpijobs/status\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator",
+                    "rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {},
+                                    "f:rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    }
+                ],
+                "name": "kubeflow-mpijobs-view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "767",
+                "self_link": null,
+                "uid": "5c5c3a00-5f44-4d80-9e32-66b24f39565b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "kubeflow.org"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "mpijobs",
+                        "mpijobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "local-path-provisioner-role": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"name\":\"local-path-provisioner-role\"},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"nodes\",\"persistentvolumeclaims\",\"configmaps\"],\"verbs\":[\"get\",\"list\",\"watch\"]},{\"apiGroups\":[\"\"],\"resources\":[\"endpoints\",\"persistentvolumes\",\"pods\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"\"],\"resources\":[\"events\"],\"verbs\":[\"create\",\"patch\"]},{\"apiGroups\":[\"storage.k8s.io\"],\"resources\":[\"storageclasses\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:16:11+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:11+00:00"
+                    }
+                ],
+                "name": "local-path-provisioner-role",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "281",
+                "self_link": null,
+                "uid": "3abc43a6-f46e-48ba-aa49-fdc69450f161"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "persistentvolumeclaims",
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "persistentvolumes",
+                        "pods"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "mpi-operator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"rbac.authorization.k8s.io/v1\",\"kind\":\"ClusterRole\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\"},\"rules\":[{\"apiGroups\":[\"\"],\"resources\":[\"configmaps\",\"secrets\",\"services\"],\"verbs\":[\"create\",\"list\",\"watch\",\"update\"]},{\"apiGroups\":[\"\"],\"resources\":[\"pods\"],\"verbs\":[\"create\",\"get\",\"list\",\"watch\",\"delete\",\"update\",\"patch\"]},{\"apiGroups\":[\"\"],\"resources\":[\"pods/exec\"],\"verbs\":[\"create\"]},{\"apiGroups\":[\"\"],\"resources\":[\"endpoints\"],\"verbs\":[\"create\",\"get\",\"update\"]},{\"apiGroups\":[\"\"],\"resources\":[\"events\"],\"verbs\":[\"create\",\"patch\"]},{\"apiGroups\":[\"batch\"],\"resources\":[\"jobs\"],\"verbs\":[\"create\",\"list\",\"update\",\"watch\"]},{\"apiGroups\":[\"apiextensions.k8s.io\"],\"resources\":[\"customresourcedefinitions\"],\"verbs\":[\"create\",\"get\"]},{\"apiGroups\":[\"kubeflow.org\"],\"resources\":[\"mpijobs\",\"mpijobs/finalizers\",\"mpijobs/status\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"coordination.k8s.io\"],\"resources\":[\"leases\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"scheduling.incubator.k8s.io\",\"scheduling.sigs.dev\",\"scheduling.volcano.sh\"],\"resources\":[\"queues\",\"podgroups\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"scheduling.x-k8s.io\"],\"resources\":[\"podgroups\"],\"verbs\":[\"*\"]},{\"apiGroups\":[\"scheduling.k8s.io\"],\"resources\":[\"priorityclasses\"],\"verbs\":[\"get\",\"list\",\"watch\"]}]}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    }
+                ],
+                "name": "mpi-operator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "769",
+                "self_link": null,
+                "uid": "1376499c-e6e9-4e85-8bff-037418597d41"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "secrets",
+                        "services"
+                    ],
+                    "verbs": [
+                        "create",
+                        "list",
+                        "watch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch",
+                        "delete",
+                        "update",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/exec"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apiextensions.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "customresourcedefinitions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "kubeflow.org"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "mpijobs",
+                        "mpijobs/finalizers",
+                        "mpijobs/status"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "scheduling.incubator.k8s.io",
+                        "scheduling.sigs.dev",
+                        "scheduling.volcano.sh"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "queues",
+                        "podgroups"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "scheduling.x-k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "podgroups"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "scheduling.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "priorityclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-admin": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "78",
+                "self_link": null,
+                "uid": "5a291a5d-42e0-4e69-8933-97dd16586f64"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "rolebindings",
+                        "roles"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-edit": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-edit",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "79",
+                "self_link": null,
+                "uid": "c743cbb5-e3d4-4b29-adcb-f9231d1470a0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy",
+                        "secrets",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "impersonate"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "pods/attach",
+                        "pods/exec",
+                        "pods/portforward",
+                        "pods/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "events",
+                        "persistentvolumeclaims",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "secrets",
+                        "serviceaccounts",
+                        "services",
+                        "services/proxy"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "replicasets",
+                        "replicasets/scale",
+                        "statefulsets",
+                        "statefulsets/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "deployments",
+                        "deployments/rollback",
+                        "deployments/scale",
+                        "ingresses",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:aggregate-to-view": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-view": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:aggregate-to-view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "80",
+                "self_link": null,
+                "uid": "182be56b-6d7a-4b92-9e8e-3f2b119c20cd"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:auth-delegator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:auth-delegator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "86",
+                "self_link": null,
+                "uid": "35d1b84a-11f2-40e7-b608-b31746edb8e1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:basic-user": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:basic-user",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "73",
+                "self_link": null,
+                "uid": "8df32434-e247-413e-9c58-573e2233f145"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "selfsubjectaccessreviews",
+                        "selfsubjectrulesreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "selfsubjectreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:certificatesigningrequests:nodeclient": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:certificatesigningrequests:nodeclient",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "92",
+                "self_link": null,
+                "uid": "a1be3fbb-2f76-4f52-9c6c-e13dedbe4bd1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/nodeclient"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "93",
+                "self_link": null,
+                "uid": "d05f4c88-cd31-4342-9774-36f5f17727b2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/selfnodeclient"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kube-apiserver-client-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kube-apiserver-client-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "97",
+                "self_link": null,
+                "uid": "ba9cfb30-84e9-4034-991d-fc6cf3ef938c"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kube-apiserver-client-kubelet-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kube-apiserver-client-kubelet-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "98",
+                "self_link": null,
+                "uid": "bec72241-a69b-4e8c-907a-6a209692df43"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client-kubelet"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:kubelet-serving-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:kubelet-serving-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "96",
+                "self_link": null,
+                "uid": "9e94ae7d-e10e-4e0e-ba54-78788f051cb3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kubelet-serving"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:certificates.k8s.io:legacy-unknown-approver": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:certificates.k8s.io:legacy-unknown-approver",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "95",
+                "self_link": null,
+                "uid": "c44b59c0-2261-4f9b-bb1b-128f2a4a3a68"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/legacy-unknown"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                }
+            ]
+        },
+        "system:controller:attachdetach-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:attachdetach-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "102",
+                "self_link": null,
+                "uid": "06d8e9d9-49cc-4cfb-93b9-f2d6644750d4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumeattachments"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:certificate-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:certificate-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "130",
+                "self_link": null,
+                "uid": "ecb26171-533a-49eb-9d31-1e84fdeccd3a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests/approval",
+                        "certificatesigningrequests/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client-kubelet"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "approve"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kubernetes.io/kube-apiserver-client",
+                        "kubernetes.io/kube-apiserver-client-kubelet",
+                        "kubernetes.io/kubelet-serving",
+                        "kubernetes.io/legacy-unknown"
+                    ],
+                    "resources": [
+                        "signers"
+                    ],
+                    "verbs": [
+                        "sign"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:clusterrole-aggregation-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:clusterrole-aggregation-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "103",
+                "self_link": null,
+                "uid": "e83c7609-9697-4f29-8f54-dc47d5c7a32a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "rbac.authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clusterroles"
+                    ],
+                    "verbs": [
+                        "escalate",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:cronjob-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:cronjob-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "104",
+                "self_link": null,
+                "uid": "022050d6-03be-48d2-bc76-3af9a2f3fdc0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:daemon-set-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:daemon-set-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "105",
+                "self_link": null,
+                "uid": "7adf6a30-8f9c-4b31-b8fc-0001519840a0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/binding"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:deployment-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:deployment-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "106",
+                "self_link": null,
+                "uid": "6d30972c-63d2-4db4-9334-bb1d028102b3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:disruption-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:disruption-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "107",
+                "self_link": null,
+                "uid": "1303cc5b-83e4-4865-9e30-d73366c3558b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*/scale"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpoint-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:endpoint-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "109",
+                "self_link": null,
+                "uid": "a8e40bed-bd74-42d9-95e6-300361cd5ca4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints/restricted"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpointslice-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslice-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "110",
+                "self_link": null,
+                "uid": "83b81e89-b468-4f6f-be92-37b75fab5718"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes",
+                        "pods",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:endpointslicemirroring-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:endpointslicemirroring-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "111",
+                "self_link": null,
+                "uid": "c5cb5a2c-4f1e-47d3-8fea-d970e7f4cb3a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ephemeral-volume-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:ephemeral-volume-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "113",
+                "self_link": null,
+                "uid": "62c73a7e-d22a-4e72-b116-b7213672add3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:expand-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:expand-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "112",
+                "self_link": null,
+                "uid": "095bc024-1861-4720-8730-8f2ab70593bb"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:generic-garbage-collector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:generic-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "114",
+                "self_link": null,
+                "uid": "50e667e1-51d7-45cf-ae62-826c85175523"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:horizontal-pod-autoscaler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:horizontal-pod-autoscaler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "115",
+                "self_link": null,
+                "uid": "a5295d21-c44c-4a37-bdb1-3af96b7f34f4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "custom.metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "external.metrics.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:job-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:job-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "117",
+                "self_link": null,
+                "uid": "76f76d4b-db61-4dae-bb0f-d7ab630a65f1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:namespace-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:namespace-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "118",
+                "self_link": null,
+                "uid": "fe59af5a-cabf-4859-9ebf-7fdbb725ada3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces/finalize",
+                        "namespaces/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "deletecollection",
+                        "get",
+                        "list"
+                    ]
+                }
+            ]
+        },
+        "system:controller:node-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:node-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "119",
+                "self_link": null,
+                "uid": "a41e02c7-0456-4792-adcd-b9fc28b2b937"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "clustercidrs"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:controller:persistent-volume-binder": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:persistent-volume-binder",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "120",
+                "self_link": null,
+                "uid": "a48a9335-152f-46a7-8dff-f4edc412ab07"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pod-garbage-collector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:pod-garbage-collector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "121",
+                "self_link": null,
+                "uid": "fbbed0dc-8d50-4875-a1ba-869b9664f58b"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pv-protection-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:pv-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "132",
+                "self_link": null,
+                "uid": "edf9ec55-041d-417e-8070-48dd3fdc2c63"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:pvc-protection-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:pvc-protection-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "131",
+                "self_link": null,
+                "uid": "cb0d434a-b9ba-4b2e-8eb4-ae7be7bbbb7a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:replicaset-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:replicaset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "122",
+                "self_link": null,
+                "uid": "e535f2a4-9963-4790-bb94-3cc126edf8e2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:replication-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:replication-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "123",
+                "self_link": null,
+                "uid": "2ffdf41b-b74a-441e-aa06-47aa38d979bd"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "list",
+                        "patch",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:resourcequota-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:resourcequota-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "124",
+                "self_link": null,
+                "uid": "a4d97374-c78f-4ed5-8061-703e06c87158"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:root-ca-cert-publisher": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:root-ca-cert-publisher",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "134",
+                "self_link": null,
+                "uid": "fd90e012-1600-4477-a1a7-66376e256a1a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps"
+                    ],
+                    "verbs": [
+                        "create",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:route-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:route-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "125",
+                "self_link": null,
+                "uid": "6b2040f4-f8cb-4ec3-9f68-ba23f9bcbd37"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:service-account-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:service-account-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "126",
+                "self_link": null,
+                "uid": "2748e468-92f8-441c-b65a-a7d602e8dae0"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:service-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:service-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "127",
+                "self_link": null,
+                "uid": "be8787f6-ccdf-4630-ad08-bb5c90f863c1"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:statefulset-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:statefulset-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "128",
+                "self_link": null,
+                "uid": "13720dd3-63af-4034-8a37-a1df55d3f7d2"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets/finalizers"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ttl-after-finished-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-after-finished-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "133",
+                "self_link": null,
+                "uid": "3a30f497-9f8c-4e73-8f5b-8de85c6f0614"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "jobs"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:controller:ttl-controller": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:controller:ttl-controller",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "129",
+                "self_link": null,
+                "uid": "eda02675-2c0e-4009-b0cb-a87b70d44814"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:coredns": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:16:08+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "kubeadm",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:08+00:00"
+                    }
+                ],
+                "name": "system:coredns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "231",
+                "self_link": null,
+                "uid": "e12d41c0-c802-45ff-b172-03ec81752535"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services",
+                        "pods",
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:discovery": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "71",
+                "self_link": null,
+                "uid": "c210a05d-2193-4cd4-8867-77c48dc03aa4"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/api",
+                        "/api/*",
+                        "/apis",
+                        "/apis/*",
+                        "/healthz",
+                        "/livez",
+                        "/openapi",
+                        "/openapi/*",
+                        "/readyz",
+                        "/version",
+                        "/version/"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:heapster": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:heapster",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "81",
+                "self_link": null,
+                "uid": "d7709e7e-2864-442c-96f3-ff87ec1210e4"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events",
+                        "namespaces",
+                        "nodes",
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "deployments"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-aggregator": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:kube-aggregator",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "87",
+                "self_link": null,
+                "uid": "3def03f7-ac6e-4eff-b102-7b545f84df76"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-controller-manager": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:kube-controller-manager",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "88",
+                "self_link": null,
+                "uid": "4ff54c49-f16b-4ec2-b355-612bcaf913bd"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-controller-manager"
+                    ],
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-controller-manager"
+                    ],
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "namespaces",
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "secrets",
+                        "serviceaccounts"
+                    ],
+                    "verbs": [
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "*"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "*"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                }
+            ]
+        },
+        "system:kube-dns": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:kube-dns",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "89",
+                "self_link": null,
+                "uid": "04f1ee43-51cb-4c33-9820-b8f5c5489cec"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kube-scheduler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:kube-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "101",
+                "self_link": null,
+                "uid": "3e7c2489-1a53-44bc-9b47-02c2aa1b48a9"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-scheduler"
+                    ],
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": [
+                        "kube-scheduler"
+                    ],
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "pods/binding"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicationcontrollers",
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps",
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "replicasets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "statefulsets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csistoragecapacities"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:kubelet-api-admin": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:kubelet-api-admin",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "84",
+                "self_link": null,
+                "uid": "e26a8d83-e44a-4d7e-b3cc-8c089dd3ee85"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "proxy"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/log",
+                        "nodes/metrics",
+                        "nodes/proxy",
+                        "nodes/stats"
+                    ],
+                    "verbs": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "system:monitoring": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:monitoring",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "72",
+                "self_link": null,
+                "uid": "835b5d80-13d2-40e9-9303-57a5d194434f"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/healthz",
+                        "/healthz/*",
+                        "/livez",
+                        "/livez/*",
+                        "/metrics",
+                        "/metrics/slis",
+                        "/readyz",
+                        "/readyz/*"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:node": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:node",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "82",
+                "self_link": null,
+                "uid": "720fbcd1-39be-4d6f-9aab-08d2769fc7ea"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "authentication.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "tokenreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "authorization.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "localsubjectaccessreviews",
+                        "subjectaccessreviews"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "services"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/status"
+                    ],
+                    "verbs": [
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "pods/eviction"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "secrets"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims",
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "coordination.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "leases"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "volumeattachments"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "serviceaccounts/token"
+                    ],
+                    "verbs": [
+                        "create"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csidrivers"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "csinodes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "node.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "runtimeclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:node-bootstrapper": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:node-bootstrapper",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "85",
+                "self_link": null,
+                "uid": "81ab62eb-fd12-4009-a492-f69c02b0438f"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        "certificates.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "certificatesigningrequests"
+                    ],
+                    "verbs": [
+                        "create",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:node-problem-detector": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:node-problem-detector",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "83",
+                "self_link": null,
+                "uid": "b02adb4d-55a5-47cb-8645-525ecd5b7df3"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes/status"
+                    ],
+                    "verbs": [
+                        "patch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:node-proxier": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:node-proxier",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "100",
+                "self_link": null,
+                "uid": "94fa67ad-41f1-4290-a123-1aa9a8ba7b74"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpoints",
+                        "services"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "nodes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "system:persistent-volume-provisioner": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:persistent-volume-provisioner",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "91",
+                "self_link": null,
+                "uid": "9d4be23f-c4ab-4205-8ec1-526ec1a40723"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "create",
+                        "delete",
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "",
+                        "events.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "events"
+                    ],
+                    "verbs": [
+                        "create",
+                        "patch",
+                        "update"
+                    ]
+                }
+            ]
+        },
+        "system:public-info-viewer": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "system:public-info-viewer",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "74",
+                "self_link": null,
+                "uid": "e39fb456-b079-4f7f-92e1-84907bccfd0b"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/healthz",
+                        "/livez",
+                        "/readyz",
+                        "/version",
+                        "/version/"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:service-account-issuer-discovery": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:service-account-issuer-discovery",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "99",
+                "self_link": null,
+                "uid": "851facb8-7cb8-4ae5-92af-aba176bfba5e"
+            },
+            "rules": [
+                {
+                    "api_groups": null,
+                    "non_resource_ur_ls": [
+                        "/.well-known/openid-configuration",
+                        "/openid/v1/jwks"
+                    ],
+                    "resource_names": null,
+                    "resources": null,
+                    "verbs": [
+                        "get"
+                    ]
+                }
+            ]
+        },
+        "system:volume-scheduler": {
+            "aggregation_rule": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:04+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {}
+                                }
+                            },
+                            "f:rules": {}
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:04+00:00"
+                    }
+                ],
+                "name": "system:volume-scheduler",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "94",
+                "self_link": null,
+                "uid": "b9bf2685-5983-4cc4-be0d-96f4a7b000ad"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumes"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "storage.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "storageclasses"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "persistentvolumeclaims"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "patch",
+                        "update",
+                        "watch"
+                    ]
+                }
+            ]
+        },
+        "view": {
+            "aggregation_rule": {
+                "cluster_role_selectors": [
+                    {
+                        "match_expressions": null,
+                        "match_labels": {
+                            "rbac.authorization.k8s.io/aggregate-to-view": "true"
+                        }
+                    }
+                ]
+            },
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "rbac.authorization.kubernetes.io/autoupdate": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:03+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "kubernetes.io/bootstrapping": "rbac-defaults",
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:rules": {}
+                        },
+                        "manager": "clusterrole-aggregation-controller",
+                        "operation": "Apply",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:21+00:00"
+                    },
+                    {
+                        "api_version": "rbac.authorization.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:aggregationRule": {
+                                ".": {},
+                                "f:clusterRoleSelectors": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:rbac.authorization.kubernetes.io/autoupdate": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:kubernetes.io/bootstrapping": {},
+                                    "f:rbac.authorization.k8s.io/aggregate-to-edit": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-apiserver",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:03+00:00"
+                    }
+                ],
+                "name": "view",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "331",
+                "self_link": null,
+                "uid": "70c65ff8-f81e-4337-baa2-9e3c294b9e1a"
+            },
+            "rules": [
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "configmaps",
+                        "endpoints",
+                        "persistentvolumeclaims",
+                        "persistentvolumeclaims/status",
+                        "pods",
+                        "replicationcontrollers",
+                        "replicationcontrollers/scale",
+                        "serviceaccounts",
+                        "services",
+                        "services/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "bindings",
+                        "events",
+                        "limitranges",
+                        "namespaces/status",
+                        "pods/log",
+                        "pods/status",
+                        "replicationcontrollers/status",
+                        "resourcequotas",
+                        "resourcequotas/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        ""
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "namespaces"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "discovery.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "endpointslices"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "apps"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "controllerrevisions",
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "statefulsets",
+                        "statefulsets/scale",
+                        "statefulsets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "autoscaling"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "horizontalpodautoscalers",
+                        "horizontalpodautoscalers/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "batch"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "cronjobs",
+                        "cronjobs/status",
+                        "jobs",
+                        "jobs/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "extensions"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "daemonsets",
+                        "daemonsets/status",
+                        "deployments",
+                        "deployments/scale",
+                        "deployments/status",
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies",
+                        "replicasets",
+                        "replicasets/scale",
+                        "replicasets/status",
+                        "replicationcontrollers/scale"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "policy"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "poddisruptionbudgets",
+                        "poddisruptionbudgets/status"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                },
+                {
+                    "api_groups": [
+                        "networking.k8s.io"
+                    ],
+                    "non_resource_ur_ls": null,
+                    "resource_names": null,
+                    "resources": [
+                        "ingresses",
+                        "ingresses/status",
+                        "networkpolicies"
+                    ],
+                    "verbs": [
+                        "get",
+                        "list",
+                        "watch"
+                    ]
+                }
+            ]
+        }
+    },
+    "config_map": {
+        "kube-root-ca.crt": {
+            "api_version": null,
+            "binary_data": null,
+            "data": {
+                "ca.crt": "-----BEGIN CERTIFICATE-----\nMIIC/jCCAeagAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl\ncm5ldGVzMB4XDTI0MDIwNzE5MTUzOFoXDTM0MDIwNDE5MTUzOFowFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKg7\nm3u5q7aUkeEMyhNSiBgBmhvEebCwvwHHb5rubENxrt9e5iIIuUixACv7rqXRYqGy\nipSnDm5xK5UR22r889BoCAPZV1lvGSlMDKMsFVC9kADplnFmiB14/D+JO11aXXSp\nGgIromR9ZKqUQvC3boENclnrphd6/c7FJttBHA+wp9EGnEP9xs9aqSmczSCcnPRt\n76Sw4+HJnF6BC60Dtk3ht1rxGXZ0U9HB8IwKidqYEIYw5rw7SENyY6LXBiHV+jX9\ny5ujQKtq/ZtU7HzUBufZNxWIxmdJlQ1bs3HsQQq7mqr1Q4XlD4p4omO4m8uxrp5u\ntDL+sFCNM6gZBj91RCUCAwEAAaNZMFcwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB\n/wQFMAMBAf8wHQYDVR0OBBYEFLD/EjgMVAaNhEcbTDJ0ntQqxp1lMBUGA1UdEQQO\nMAyCCmt1YmVybmV0ZXMwDQYJKoZIhvcNAQELBQADggEBAFAizAWZc7TklddmPqnw\nvpxaPgFQfqYcUkNjFCEf5vkSxVs8cTw4VvDBZCXhI1L5JOa4XBTzww2PYmrydpm7\n/av2pqFfGteqifVEibRky9RoSgJku1gGpnqI+F8FqwTC9JjHWhAvHAn5+7+PFj1k\n2i2KAlnBajk30mn1DD9+LyG9pAHFzHT5u4mle+rwgqbIN0YrlhkPqe5ZRsdaQjlS\nxN9jduOiNGWfERneGS1Yo7uyjO4bz6nex3FXffch/GyxbW00fMrijqU6CwJCKSAF\n7YTjhaYIKyd4VbV3aooqpqoQQ1FIPmLLiRe5tXanwW1is1Enae1tLFiJuHvi+mKB\nixQ=\n-----END CERTIFICATE-----\n"
+            },
+            "immutable": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubernetes.io/description": "Contains a CA bundle that can be used to verify the kube-apiserver when using internal endpoints such as the internal service IP or kubernetes.default.svc. No other usage is guaranteed across distributions of Kubernetes clusters."
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:data": {
+                                ".": {},
+                                "f:ca.crt": {}
+                            },
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubernetes.io/description": {}
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    }
+                ],
+                "name": "kube-root-ca.crt",
+                "namespace": "mpi-operator",
+                "owner_references": null,
+                "resource_version": "760",
+                "self_link": null,
+                "uid": "f33ecdb3-9e3a-403e-9d20-aa76761bf28d"
+            }
+        }
+    },
+    "cron_job": {},
+    "daemon_set": {},
+    "deployment": {
+        "mpi-operator": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1",
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\",\"namespace\":\"mpi-operator\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"}},\"template\":{\"metadata\":{\"annotations\":{\"sidecar.istio.io/inject\":\"false\"},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"}},\"spec\":{\"containers\":[{\"args\":[\"-alsologtostderr\",\"--lock-namespace=mpi-operator\"],\"image\":\"mpioperator/mpi-operator:master\",\"name\":\"mpi-operator\"}],\"serviceAccountName\":\"mpi-operator\"}}}}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:progressDeadlineSeconds": {},
+                                "f:replicas": {},
+                                "f:revisionHistoryLimit": {},
+                                "f:selector": {},
+                                "f:strategy": {
+                                    "f:rollingUpdate": {
+                                        ".": {},
+                                        "f:maxSurge": {},
+                                        "f:maxUnavailable": {}
+                                    },
+                                    "f:type": {}
+                                },
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:annotations": {
+                                            ".": {},
+                                            "f:sidecar.istio.io/inject": {}
+                                        },
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:kustomize.component": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"mpi-operator\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    "f:deployment.kubernetes.io/revision": {}
+                                }
+                            },
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:conditions": {
+                                    ".": {},
+                                    "k:{\"type\":\"Available\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Progressing\"}": {
+                                        ".": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:lastUpdateTime": {},
+                                        "f:message": {},
+                                        "f:reason": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {},
+                                "f:updatedReplicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-07T19:21:32+00:00"
+                    }
+                ],
+                "name": "mpi-operator",
+                "namespace": "mpi-operator",
+                "owner_references": null,
+                "resource_version": "1147",
+                "self_link": null,
+                "uid": "7a910c00-7d78-4054-a271-91aadea59e1a"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "paused": null,
+                "progress_deadline_seconds": 600,
+                "replicas": 1,
+                "revision_history_limit": 10,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "mpi-operator",
+                        "app.kubernetes.io/component": "mpijob",
+                        "app.kubernetes.io/name": "mpi-operator",
+                        "kustomize.component": "mpi-operator"
+                    }
+                },
+                "strategy": {
+                    "rolling_update": {
+                        "max_surge": "25%",
+                        "max_unavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "sidecar.istio.io/inject": "false"
+                        },
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "mpi-operator",
+                            "app.kubernetes.io/component": "mpijob",
+                            "app.kubernetes.io/name": "mpi-operator",
+                            "kustomize.component": "mpi-operator"
+                        },
+                        "managed_fields": null,
+                        "name": null,
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "-alsologtostderr",
+                                    "--lock-namespace=mpi-operator"
+                                ],
+                                "command": null,
+                                "env": null,
+                                "env_from": null,
+                                "image": "mpioperator/mpi-operator:master",
+                                "image_pull_policy": "IfNotPresent",
+                                "lifecycle": null,
+                                "liveness_probe": null,
+                                "name": "mpi-operator",
+                                "ports": null,
+                                "readiness_probe": null,
+                                "resources": {
+                                    "claims": null,
+                                    "limits": null,
+                                    "requests": null
+                                },
+                                "security_context": null,
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": null,
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": null,
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "mpi-operator",
+                        "service_account_name": "mpi-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 30,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": null
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "collision_count": null,
+                "conditions": [
+                    {
+                        "last_transition_time": "2024-02-07T19:18:34+00:00",
+                        "last_update_time": "2024-02-07T19:18:49+00:00",
+                        "message": "ReplicaSet \"mpi-operator-6b8447f5cd\" has successfully progressed.",
+                        "reason": "NewReplicaSetAvailable",
+                        "status": "True",
+                        "type": "Progressing"
+                    },
+                    {
+                        "last_transition_time": "2024-02-07T19:21:32+00:00",
+                        "last_update_time": "2024-02-07T19:21:32+00:00",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1,
+                "unavailable_replicas": null,
+                "updated_replicas": 1
+            }
+        }
+    },
+    "endpoint": {},
+    "ingress": {},
+    "job": {},
+    "network_policy": {},
+    "persistent_volume_claim": {},
+    "persistent_volume": {},
+    "pod": {
+        "mpi-operator-6b8447f5cd-xcptc": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "sidecar.istio.io/inject": "false"
+                },
+                "creation_timestamp": "2024-02-07T19:18:35+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": "mpi-operator-6b8447f5cd-",
+                "generation": null,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator",
+                    "pod-template-hash": "6b8447f5cd"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:sidecar.istio.io/inject": {}
+                                },
+                                "f:generateName": {},
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"72d94527-ebb3-430f-8b51-48092f88db4b\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"mpi-operator\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {},
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {}
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {},
+                                "f:serviceAccount": {},
+                                "f:serviceAccountName": {},
+                                "f:terminationGracePeriodSeconds": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    },
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:conditions": {
+                                    "k:{\"type\":\"ContainersReady\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Initialized\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    },
+                                    "k:{\"type\":\"Ready\"}": {
+                                        ".": {},
+                                        "f:lastProbeTime": {},
+                                        "f:lastTransitionTime": {},
+                                        "f:status": {},
+                                        "f:type": {}
+                                    }
+                                },
+                                "f:containerStatuses": {},
+                                "f:hostIP": {},
+                                "f:phase": {},
+                                "f:podIP": {},
+                                "f:podIPs": {
+                                    ".": {},
+                                    "k:{\"ip\":\"10.244.1.2\"}": {
+                                        ".": {},
+                                        "f:ip": {}
+                                    }
+                                },
+                                "f:startTime": {}
+                            }
+                        },
+                        "manager": "kubelet",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-07T19:21:29+00:00"
+                    }
+                ],
+                "name": "mpi-operator-6b8447f5cd-xcptc",
+                "namespace": "mpi-operator",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "mpi-operator-6b8447f5cd",
+                        "uid": "72d94527-ebb3-430f-8b51-48092f88db4b"
+                    }
+                ],
+                "resource_version": "1142",
+                "self_link": null,
+                "uid": "93c4e218-e327-4be1-b306-1bd669218017"
+            },
+            "spec": {
+                "active_deadline_seconds": null,
+                "affinity": null,
+                "automount_service_account_token": null,
+                "containers": [
+                    {
+                        "args": [
+                            "-alsologtostderr",
+                            "--lock-namespace=mpi-operator"
+                        ],
+                        "command": null,
+                        "env": null,
+                        "env_from": null,
+                        "image": "mpioperator/mpi-operator:master",
+                        "image_pull_policy": "IfNotPresent",
+                        "lifecycle": null,
+                        "liveness_probe": null,
+                        "name": "mpi-operator",
+                        "ports": null,
+                        "readiness_probe": null,
+                        "resources": {
+                            "claims": null,
+                            "limits": null,
+                            "requests": null
+                        },
+                        "security_context": null,
+                        "startup_probe": null,
+                        "stdin": null,
+                        "stdin_once": null,
+                        "termination_message_path": "/dev/termination-log",
+                        "termination_message_policy": "File",
+                        "tty": null,
+                        "volume_devices": null,
+                        "volume_mounts": [
+                            {
+                                "mount_path": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "mount_propagation": null,
+                                "name": "kube-api-access-2qsz5",
+                                "read_only": true,
+                                "sub_path": null,
+                                "sub_path_expr": null
+                            }
+                        ],
+                        "working_dir": null
+                    }
+                ],
+                "dns_config": null,
+                "dns_policy": "ClusterFirst",
+                "enable_service_links": true,
+                "ephemeral_containers": null,
+                "host_aliases": null,
+                "host_ipc": null,
+                "host_network": null,
+                "host_pid": null,
+                "host_users": null,
+                "hostname": null,
+                "image_pull_secrets": null,
+                "init_containers": null,
+                "node_name": "kind-worker2",
+                "node_selector": null,
+                "os": null,
+                "overhead": null,
+                "preemption_policy": "PreemptLowerPriority",
+                "priority": 0,
+                "priority_class_name": null,
+                "readiness_gates": null,
+                "resource_claims": null,
+                "restart_policy": "Always",
+                "runtime_class_name": null,
+                "scheduler_name": "default-scheduler",
+                "scheduling_gates": null,
+                "security_context": {
+                    "fs_group": null,
+                    "fs_group_change_policy": null,
+                    "run_as_group": null,
+                    "run_as_non_root": null,
+                    "run_as_user": null,
+                    "se_linux_options": null,
+                    "seccomp_profile": null,
+                    "supplemental_groups": null,
+                    "sysctls": null,
+                    "windows_options": null
+                },
+                "service_account": "mpi-operator",
+                "service_account_name": "mpi-operator",
+                "set_hostname_as_fqdn": null,
+                "share_process_namespace": null,
+                "subdomain": null,
+                "termination_grace_period_seconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "toleration_seconds": 300,
+                        "value": null
+                    }
+                ],
+                "topology_spread_constraints": null,
+                "volumes": [
+                    {
+                        "aws_elastic_block_store": null,
+                        "azure_disk": null,
+                        "azure_file": null,
+                        "cephfs": null,
+                        "cinder": null,
+                        "config_map": null,
+                        "csi": null,
+                        "downward_api": null,
+                        "empty_dir": null,
+                        "ephemeral": null,
+                        "fc": null,
+                        "flex_volume": null,
+                        "flocker": null,
+                        "gce_persistent_disk": null,
+                        "git_repo": null,
+                        "glusterfs": null,
+                        "host_path": null,
+                        "iscsi": null,
+                        "name": "kube-api-access-2qsz5",
+                        "nfs": null,
+                        "persistent_volume_claim": null,
+                        "photon_persistent_disk": null,
+                        "portworx_volume": null,
+                        "projected": {
+                            "default_mode": 420,
+                            "sources": [
+                                {
+                                    "config_map": null,
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": {
+                                        "audience": null,
+                                        "expiration_seconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "config_map": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "mode": null,
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt",
+                                        "optional": null
+                                    },
+                                    "downward_api": null,
+                                    "secret": null,
+                                    "service_account_token": null
+                                },
+                                {
+                                    "config_map": null,
+                                    "downward_api": {
+                                        "items": [
+                                            {
+                                                "field_ref": {
+                                                    "api_version": "v1",
+                                                    "field_path": "metadata.namespace"
+                                                },
+                                                "mode": null,
+                                                "path": "namespace",
+                                                "resource_field_ref": null
+                                            }
+                                        ]
+                                    },
+                                    "secret": null,
+                                    "service_account_token": null
+                                }
+                            ]
+                        },
+                        "quobyte": null,
+                        "rbd": null,
+                        "scale_io": null,
+                        "secret": null,
+                        "storageos": null,
+                        "vsphere_volume": null
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-07T19:18:35+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-07T19:21:27+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-07T19:21:27+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "last_probe_time": null,
+                        "last_transition_time": "2024-02-07T19:18:35+00:00",
+                        "message": null,
+                        "reason": null,
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "container_statuses": [
+                    {
+                        "container_id": "containerd://08e85bc6e7f36f28e7b739bc2c8e54c113b19ded589327662de5fb5361692209",
+                        "image": "docker.io/mpioperator/mpi-operator:master",
+                        "image_id": "docker.io/mpioperator/mpi-operator@sha256:57e02cd03a5281e0c3eb0712f8a66db3cee83867ef0433169d5f6dd00963d3d2",
+                        "last_state": {
+                            "running": null,
+                            "terminated": {
+                                "container_id": "containerd://0bd28afbf354047025f8b9198f513c29252904445d3e63824c38e99568bba2a3",
+                                "exit_code": 255,
+                                "finished_at": "2024-02-07T19:21:21+00:00",
+                                "message": null,
+                                "reason": "Error",
+                                "signal": null,
+                                "started_at": "2024-02-07T19:18:48+00:00"
+                            },
+                            "waiting": null
+                        },
+                        "name": "mpi-operator",
+                        "ready": true,
+                        "restart_count": 1,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "started_at": "2024-02-07T19:21:26+00:00"
+                            },
+                            "terminated": null,
+                            "waiting": null
+                        }
+                    }
+                ],
+                "ephemeral_container_statuses": null,
+                "host_ip": "172.18.0.4",
+                "init_container_statuses": null,
+                "message": null,
+                "nominated_node_name": null,
+                "phase": "Running",
+                "pod_ip": "10.244.1.2",
+                "pod_i_ps": [
+                    {
+                        "ip": "10.244.1.2"
+                    }
+                ],
+                "qos_class": "BestEffort",
+                "reason": null,
+                "start_time": "2024-02-07T19:18:35+00:00"
+            }
+        }
+    },
+    "replica_set": {
+        "mpi-operator-6b8447f5cd": {
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/desired-replicas": "1",
+                    "deployment.kubernetes.io/max-replicas": "2",
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": 1,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator",
+                    "pod-template-hash": "6b8447f5cd"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:deployment.kubernetes.io/desired-replicas": {},
+                                    "f:deployment.kubernetes.io/max-replicas": {},
+                                    "f:deployment.kubernetes.io/revision": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {},
+                                    "f:pod-template-hash": {}
+                                },
+                                "f:ownerReferences": {
+                                    ".": {},
+                                    "k:{\"uid\":\"7a910c00-7d78-4054-a271-91aadea59e1a\"}": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:replicas": {},
+                                "f:selector": {},
+                                "f:template": {
+                                    "f:metadata": {
+                                        "f:annotations": {
+                                            ".": {},
+                                            "f:sidecar.istio.io/inject": {}
+                                        },
+                                        "f:labels": {
+                                            ".": {},
+                                            "f:app": {},
+                                            "f:app.kubernetes.io/component": {},
+                                            "f:app.kubernetes.io/name": {},
+                                            "f:kustomize.component": {},
+                                            "f:pod-template-hash": {}
+                                        }
+                                    },
+                                    "f:spec": {
+                                        "f:containers": {
+                                            "k:{\"name\":\"mpi-operator\"}": {
+                                                ".": {},
+                                                "f:args": {},
+                                                "f:image": {},
+                                                "f:imagePullPolicy": {},
+                                                "f:name": {},
+                                                "f:resources": {},
+                                                "f:terminationMessagePath": {},
+                                                "f:terminationMessagePolicy": {}
+                                            }
+                                        },
+                                        "f:dnsPolicy": {},
+                                        "f:restartPolicy": {},
+                                        "f:schedulerName": {},
+                                        "f:securityContext": {},
+                                        "f:serviceAccount": {},
+                                        "f:serviceAccountName": {},
+                                        "f:terminationGracePeriodSeconds": {}
+                                    }
+                                }
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    },
+                    {
+                        "api_version": "apps/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:status": {
+                                "f:availableReplicas": {},
+                                "f:fullyLabeledReplicas": {},
+                                "f:observedGeneration": {},
+                                "f:readyReplicas": {},
+                                "f:replicas": {}
+                            }
+                        },
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "subresource": "status",
+                        "time": "2024-02-07T19:21:29+00:00"
+                    }
+                ],
+                "name": "mpi-operator-6b8447f5cd",
+                "namespace": "mpi-operator",
+                "owner_references": [
+                    {
+                        "api_version": "apps/v1",
+                        "block_owner_deletion": true,
+                        "controller": true,
+                        "kind": "Deployment",
+                        "name": "mpi-operator",
+                        "uid": "7a910c00-7d78-4054-a271-91aadea59e1a"
+                    }
+                ],
+                "resource_version": "1143",
+                "self_link": null,
+                "uid": "72d94527-ebb3-430f-8b51-48092f88db4b"
+            },
+            "spec": {
+                "min_ready_seconds": null,
+                "replicas": 1,
+                "selector": {
+                    "match_expressions": null,
+                    "match_labels": {
+                        "app": "mpi-operator",
+                        "app.kubernetes.io/component": "mpijob",
+                        "app.kubernetes.io/name": "mpi-operator",
+                        "kustomize.component": "mpi-operator",
+                        "pod-template-hash": "6b8447f5cd"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "sidecar.istio.io/inject": "false"
+                        },
+                        "creation_timestamp": null,
+                        "deletion_grace_period_seconds": null,
+                        "deletion_timestamp": null,
+                        "finalizers": null,
+                        "generate_name": null,
+                        "generation": null,
+                        "labels": {
+                            "app": "mpi-operator",
+                            "app.kubernetes.io/component": "mpijob",
+                            "app.kubernetes.io/name": "mpi-operator",
+                            "kustomize.component": "mpi-operator",
+                            "pod-template-hash": "6b8447f5cd"
+                        },
+                        "managed_fields": null,
+                        "name": null,
+                        "namespace": null,
+                        "owner_references": null,
+                        "resource_version": null,
+                        "self_link": null,
+                        "uid": null
+                    },
+                    "spec": {
+                        "active_deadline_seconds": null,
+                        "affinity": null,
+                        "automount_service_account_token": null,
+                        "containers": [
+                            {
+                                "args": [
+                                    "-alsologtostderr",
+                                    "--lock-namespace=mpi-operator"
+                                ],
+                                "command": null,
+                                "env": null,
+                                "env_from": null,
+                                "image": "mpioperator/mpi-operator:master",
+                                "image_pull_policy": "IfNotPresent",
+                                "lifecycle": null,
+                                "liveness_probe": null,
+                                "name": "mpi-operator",
+                                "ports": null,
+                                "readiness_probe": null,
+                                "resources": {
+                                    "claims": null,
+                                    "limits": null,
+                                    "requests": null
+                                },
+                                "security_context": null,
+                                "startup_probe": null,
+                                "stdin": null,
+                                "stdin_once": null,
+                                "termination_message_path": "/dev/termination-log",
+                                "termination_message_policy": "File",
+                                "tty": null,
+                                "volume_devices": null,
+                                "volume_mounts": null,
+                                "working_dir": null
+                            }
+                        ],
+                        "dns_config": null,
+                        "dns_policy": "ClusterFirst",
+                        "enable_service_links": null,
+                        "ephemeral_containers": null,
+                        "host_aliases": null,
+                        "host_ipc": null,
+                        "host_network": null,
+                        "host_pid": null,
+                        "host_users": null,
+                        "hostname": null,
+                        "image_pull_secrets": null,
+                        "init_containers": null,
+                        "node_name": null,
+                        "node_selector": null,
+                        "os": null,
+                        "overhead": null,
+                        "preemption_policy": null,
+                        "priority": null,
+                        "priority_class_name": null,
+                        "readiness_gates": null,
+                        "resource_claims": null,
+                        "restart_policy": "Always",
+                        "runtime_class_name": null,
+                        "scheduler_name": "default-scheduler",
+                        "scheduling_gates": null,
+                        "security_context": {
+                            "fs_group": null,
+                            "fs_group_change_policy": null,
+                            "run_as_group": null,
+                            "run_as_non_root": null,
+                            "run_as_user": null,
+                            "se_linux_options": null,
+                            "seccomp_profile": null,
+                            "supplemental_groups": null,
+                            "sysctls": null,
+                            "windows_options": null
+                        },
+                        "service_account": "mpi-operator",
+                        "service_account_name": "mpi-operator",
+                        "set_hostname_as_fqdn": null,
+                        "share_process_namespace": null,
+                        "subdomain": null,
+                        "termination_grace_period_seconds": 30,
+                        "tolerations": null,
+                        "topology_spread_constraints": null,
+                        "volumes": null
+                    }
+                }
+            },
+            "status": {
+                "available_replicas": 1,
+                "conditions": null,
+                "fully_labeled_replicas": 1,
+                "observed_generation": 1,
+                "ready_replicas": 1,
+                "replicas": 1
+            }
+        }
+    },
+    "role_binding": {},
+    "role": {},
+    "secret": {},
+    "service_account": {
+        "default": {
+            "api_version": null,
+            "automount_service_account_token": null,
+            "image_pull_secrets": null,
+            "kind": null,
+            "metadata": {
+                "annotations": null,
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": null,
+                "name": "default",
+                "namespace": "mpi-operator",
+                "owner_references": null,
+                "resource_version": "759",
+                "self_link": null,
+                "uid": "0fef7cde-58ca-4911-88eb-a17c73d7cc6d"
+            },
+            "secrets": null
+        },
+        "mpi-operator": {
+            "api_version": null,
+            "automount_service_account_token": null,
+            "image_pull_secrets": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"ServiceAccount\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"mpi-operator\",\"app.kubernetes.io/component\":\"mpijob\",\"app.kubernetes.io/name\":\"mpi-operator\",\"kustomize.component\":\"mpi-operator\"},\"name\":\"mpi-operator\",\"namespace\":\"mpi-operator\"}}\n"
+                },
+                "creation_timestamp": "2024-02-07T19:18:34+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": {
+                    "app": "mpi-operator",
+                    "app.kubernetes.io/component": "mpijob",
+                    "app.kubernetes.io/name": "mpi-operator",
+                    "kustomize.component": "mpi-operator"
+                },
+                "managed_fields": [
+                    {
+                        "api_version": "v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                },
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:app.kubernetes.io/component": {},
+                                    "f:app.kubernetes.io/name": {},
+                                    "f:kustomize.component": {}
+                                }
+                            }
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:18:34+00:00"
+                    }
+                ],
+                "name": "mpi-operator",
+                "namespace": "mpi-operator",
+                "owner_references": null,
+                "resource_version": "763",
+                "self_link": null,
+                "uid": "df35796b-a3d3-4771-b22d-5452a08862d7"
+            },
+            "secrets": null
+        }
+    },
+    "service": {},
+    "stateful_set": {},
+    "storage_class": {
+        "standard": {
+            "allow_volume_expansion": null,
+            "allowed_topologies": null,
+            "api_version": null,
+            "kind": null,
+            "metadata": {
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"storage.k8s.io/v1\",\"kind\":\"StorageClass\",\"metadata\":{\"annotations\":{\"storageclass.kubernetes.io/is-default-class\":\"true\"},\"name\":\"standard\"},\"provisioner\":\"rancher.io/local-path\",\"reclaimPolicy\":\"Delete\",\"volumeBindingMode\":\"WaitForFirstConsumer\"}\n",
+                    "storageclass.kubernetes.io/is-default-class": "true"
+                },
+                "creation_timestamp": "2024-02-07T19:16:11+00:00",
+                "deletion_grace_period_seconds": null,
+                "deletion_timestamp": null,
+                "finalizers": null,
+                "generate_name": null,
+                "generation": null,
+                "labels": null,
+                "managed_fields": [
+                    {
+                        "api_version": "storage.k8s.io/v1",
+                        "fields_type": "FieldsV1",
+                        "fields_v1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {},
+                                    "f:storageclass.kubernetes.io/is-default-class": {}
+                                }
+                            },
+                            "f:provisioner": {},
+                            "f:reclaimPolicy": {},
+                            "f:volumeBindingMode": {}
+                        },
+                        "manager": "kubectl-client-side-apply",
+                        "operation": "Update",
+                        "subresource": null,
+                        "time": "2024-02-07T19:16:11+00:00"
+                    }
+                ],
+                "name": "standard",
+                "namespace": null,
+                "owner_references": null,
+                "resource_version": "284",
+                "self_link": null,
+                "uid": "6649df6c-e403-4eb3-9935-31dab783f7f2"
+            },
+            "mount_options": null,
+            "parameters": null,
+            "provisioner": "rancher.io/local-path",
+            "reclaim_policy": "Delete",
+            "volume_binding_mode": "WaitForFirstConsumer"
+        }
+    }
+}


### PR DESCRIPTION
## CRD Analyze

The CRD of the mpi-operator contains the following properties:
- launcherCreationPolicy : Define how the launcher is created.
- mpiImplementation : Specify the mpi implementation.
- mpiReplicaSpecs : Define the behavior of replicas.
- runPolicy : Define the bahavior of the pod to run mpi job.
- slotsPerWorker : Specifies the number of slots per worker used in hostfile.
- sshAuthMountPath : Specify where to mount the ssh key.

### Categorize

mpi-operator operates simple computing jobs. Therefore, the system is simple. Roughly the properties can be categorized into the following categories.

#### Run Policy
- launcherCreationPolicy
- runPolicy
- mpiReplicaSpecs

#### Worker Spec
- mpiImplementation
- slotsPerWorker
- sshAuthMountPath

---

## CRD Complexity
We can measure the complexity of CRD file by the maximum depth of the specification, which is **34**.